### PR TITLE
Fix s3 find

### DIFF
--- a/apps/cloud/odc/apps/cloud/s3_find.py
+++ b/apps/cloud/odc/apps/cloud/s3_find.py
@@ -91,8 +91,12 @@ def cli(uri, skip_check):
         else:
             stream = do_dir_query(qq)
 
-    for i, o in enumerate(stream):
-        print(o.url, flush=(i % flush_freq == 0))
+    try:
+        for i, o in enumerate(stream):
+            print(o.url, flush=(i % flush_freq == 0))
+    except Exception as e:
+        print(f"ERROR: {str(e)}")
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/libs/aio/odc/aio/__init__.py
+++ b/libs/aio/odc/aio/__init__.py
@@ -36,7 +36,7 @@ async def s3_fetch_object(url, s3, range=None):
     if range is not None:
         try:
             extra_args['Range'] = s3_fmt_range(range)
-        except Exception as e:
+        except Exception:
             return result(error='Bad range passed in: ' + str(range))
 
     try:

--- a/libs/aio/odc/aio/__init__.py
+++ b/libs/aio/odc/aio/__init__.py
@@ -194,6 +194,10 @@ async def s3_dir_dir(url, depth, dst_q, s3):
     if not url.endswith('/'):
         url = url + '/'
 
+    if depth == 0:
+        await dst_q.put(url)
+        return
+
     pp = s3.get_paginator('list_objects_v2')
 
     async def step(bucket, prefix, depth, work_q, dst_q):


### PR DESCRIPTION
Address `s3-find` problems.
- IO errors leading to hanged process
- Not listing files for queries with `0` depth: `s3://bucket/some/path/*tif`

Closes #27 
Closes #26 