### PR TITLE
Move eo3 related code from app to lib

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/index_from_tar.py
+++ b/apps/dc_tools/odc/apps/dc_tools/index_from_tar.py
@@ -5,43 +5,11 @@ from datacube.utils.changes import allow_any
 from odc.io.tar import tar_doc_stream, tar_mode
 from odc.io.timer import RateEstimator
 from odc.index import from_yaml_doc_stream
-from odc.index import eo3_grid_spatial
-
-# TODO: Move to library
-def add_eo3_parts(doc, tol=None):
-    return dict(**doc,
-                **eo3_grid_spatial(doc, tol=tol))
-
-# TODO: Move to library
-def prep_eo3(doc, tol=None):
-    if doc is None:
-        return None
-
-    doc = add_eo3_parts(doc, tol=tol)
-    lineage = doc.pop('lineage', {})
-
-    def remap_lineage(uuids):
-        """ Turn [uuid] -> {id: uuid}
-        """
-        uuid, *_ = uuids
-        return dict(id=uuid)
-
-    doc['lineage'] = dict(source_datasets={
-        n: remap_lineage(v) for n, v in lineage.items()})
-
-    return doc
-
-# TODO: Detect eo3
-def detect_eo3(doc : dict) -> bool:
-    """Heuristics to auto-detect and apply eo3 transforms
-    
-    Arguments:
-        doc {dict} -- ODC Metadata (typically from YAML)
-    
-    Returns:
-        bool -- is this metadata eo3 ?
-    """
-    return False
+from odc.index import (
+    add_eo3_parts,
+    prep_eo3,
+    detect_eo3
+)
 
 
 def from_tar_file(tarfname, index, mk_uri, mode, doc_transform=None, **kwargs):

--- a/apps/dc_tools/odc/apps/dc_tools/index_from_tar.py
+++ b/apps/dc_tools/odc/apps/dc_tools/index_from_tar.py
@@ -7,12 +7,12 @@ from odc.io.timer import RateEstimator
 from odc.index import from_yaml_doc_stream
 from odc.index import eo3_grid_spatial
 
-
+# TODO: Move to library
 def add_eo3_parts(doc, tol=None):
     return dict(**doc,
                 **eo3_grid_spatial(doc, tol=tol))
 
-
+# TODO: Move to library
 def prep_eo3(doc, tol=None):
     if doc is None:
         return None
@@ -30,6 +30,18 @@ def prep_eo3(doc, tol=None):
         n: remap_lineage(v) for n, v in lineage.items()})
 
     return doc
+
+# TODO: Detect eo3
+def detect_eo3(doc : dict) -> bool:
+    """Heuristics to auto-detect and apply eo3 transforms
+    
+    Arguments:
+        doc {dict} -- ODC Metadata (typically from YAML)
+    
+    Returns:
+        bool -- is this metadata eo3 ?
+    """
+    return False
 
 
 def from_tar_file(tarfname, index, mk_uri, mode, doc_transform=None, **kwargs):
@@ -143,6 +155,7 @@ def cli(input_fname,
 
         return n_failed
 
+    # TODO: Release SQLAlchemy with context manager
     dc = datacube.Datacube(env=env)
 
     if len(input_fname) == 0:

--- a/apps/dc_tools/odc/apps/dc_tools/index_from_tar.py
+++ b/apps/dc_tools/odc/apps/dc_tools/index_from_tar.py
@@ -123,7 +123,6 @@ def cli(input_fname,
 
         return n_failed
 
-    # TODO: Release SQLAlchemy with context manager
     dc = datacube.Datacube(env=env)
 
     if len(input_fname) == 0:

--- a/libs/index/odc/index/__init__.py
+++ b/libs/index/odc/index/__init__.py
@@ -18,6 +18,9 @@ from . _index import (
 from ._eo3 import (
     eo3_lonlat_bbox,
     eo3_grid_spatial,
+    add_eo3_parts,
+    prep_eo3,
+    detect_eo3
 )
 
 from ._uuid import (

--- a/libs/index/odc/index/_eo3.py
+++ b/libs/index/odc/index/_eo3.py
@@ -102,3 +102,36 @@ def eo3_grid_spatial(doc, tol=None):
         lon=dict(begin=bb.left, end=bb.right))
 
     return oo
+
+def add_eo3_parts(doc, tol=None):
+    return dict(**doc,
+                **eo3_grid_spatial(doc, tol=tol))
+
+def prep_eo3(doc, tol=None):
+    if doc is None:
+        return None
+
+    doc = add_eo3_parts(doc, tol=tol)
+    lineage = doc.pop('lineage', {})
+
+    def remap_lineage(uuids):
+        """ Turn [uuid] -> {id: uuid}
+        """
+        uuid, *_ = uuids
+        return dict(id=uuid)
+
+    doc['lineage'] = dict(source_datasets={
+        n: remap_lineage(v) for n, v in lineage.items()})
+
+    return doc
+
+def detect_eo3(doc : dict) -> bool:
+    """Heuristics to auto-detect and apply eo3 transforms
+    
+    Arguments:
+        doc {dict} -- ODC Metadata (typically from YAML)
+    
+    Returns:
+        bool -- is this metadata eo3 ?
+    """
+    return False

--- a/libs/index/odc/index/_eo3.py
+++ b/libs/index/odc/index/_eo3.py
@@ -104,10 +104,14 @@ def eo3_grid_spatial(doc, tol=None):
     return oo
 
 def add_eo3_parts(doc, tol=None):
+    """Add spatial keys the DB requires to eo3 metadata
+    """
     return dict(**doc,
                 **eo3_grid_spatial(doc, tol=tol))
 
 def prep_eo3(doc, tol=None):
+    """Modify spatial and lineage sections of eo3 metadata
+    """
     if doc is None:
         return None
 


### PR DESCRIPTION
Enable better re-use of YAML post-processing code form eo3 metadata by moving it to library. Also add a proposed eo3 auto-detect block to be implemented and addressed in separate PR, with relevant change management for deprecation of `--eo3` CLI flag.