### PR TITLE
Fix fmask_to_bool for enumerations with values >=8

### DIFF
--- a/libs/algo/odc/algo/_masking.py
+++ b/libs/algo/odc/algo/_masking.py
@@ -196,23 +196,23 @@ def from_float(x, dtype, nodata, scale=1, offset=0):
                         attrs=attrs)
 
 
-def _impl_to_bool(x, m):
-    return ((1 << x) & m) > 0
+def _impl_to_bool(x, m, dtype):
+    return ((1 << x.astype(dtype)) & m) > 0
 
 
-def _impl_to_bool_inverted(x, m):
-    return ((1 << x) & m) == 0
+def _impl_to_bool_inverted(x, m, dtype):
+    return ((1 << x.astype(dtype)) & m) == 0
 
 
 def fmask_to_bool(mask, categories, invert=False, flag_name=None):
     """This method works for fmask and other "enumerated" masks, so long as
-    largest label for a category is <= 32.
+    largest label for a category is <= 63.
 
     For non-fmask masks you might have to specify `flag_name: str`:
     To see what name should be check this: `list(xx.your_mask.flags_definition)`
 
     It is equivalent to `np.isin(mask, categories)`, but uses bit shifts to
-    speed things up, hence the limit <=32
+    speed things up, hence the limit <= 63
 
     example:
         xx = dc.load(.., measurements=['fmask', ...])
@@ -222,19 +222,31 @@ def fmask_to_bool(mask, categories, invert=False, flag_name=None):
 
     """
 
+    def _pick_dtype(max_v, candidates):
+        for dtype in candidates:
+            if np.iinfo(dtype).max > max_v:
+                return dtype
+
+        raise ValueError("Largest enumeration value is too big")
+
     def _get_mask(names, flags):
         enum_to_value = {n: int(v)
                          for v, n in flags['values'].items()}
-        if max(enum_to_value.values()) > 32:
-            raise ValueError('This method only works on enumerations with values <= 32')
 
         m = 0
+        dtype = mask.dtype
         for n in names:
             v = enum_to_value.get(n, None)
             if v is None:
                 raise ValueError(f'`{n}` is not a valid class name')
+            if v >= 64:
+                raise ValueError(f'{n} = {v} is too large, supported value range is [0, 63]')
             m |= (1 << v)
-        return m
+
+        if m > np.iinfo(dtype).max:
+            dtype = _pick_dtype(m, ('uint16', 'uint32', 'uint64'))
+
+        return m, dtype
 
     flags = getattr(mask, 'flags_definition', None)
     if flags is None:
@@ -248,11 +260,12 @@ def fmask_to_bool(mask, categories, invert=False, flag_name=None):
         if flags is None:
             raise ValueError(f"Expect `{flag_name}` key in `flags_defition` attribute")
 
-    m = _get_mask(categories, flags)
+    m, dtype = _get_mask(categories, flags)
+
     func = {False: _impl_to_bool,
             True: _impl_to_bool_inverted}.get(invert)
 
-    bmask = xr.apply_ufunc(func, mask, m,
+    bmask = xr.apply_ufunc(func, mask, m, dtype,
                            keep_attrs=True,
                            dask='parallelized',
                            output_dtypes=['bool'])
@@ -384,3 +397,36 @@ def test_gap_fill():
     assert xab.name == xa.name
     assert xab.attrs == xa.attrs
     assert xab.compute().values.tolist() == [0, 33, 33, 33, 33]
+
+
+def test_fmask_to_bool():
+    import pytest
+
+    fake_flags = dict(bits=list(range(8)),
+                      values={str(i): f'cat_{i}' for i in range(0, 65)})
+    flags_definition = dict(fmask=fake_flags)
+
+    fmask = xr.DataArray(np.arange(0, 65, dtype='uint8'),
+                         attrs=dict(flags_definition=flags_definition))
+
+    mm = fmask_to_bool(fmask, ("cat_1", "cat_3"))
+    ii, = np.where(mm)
+    assert tuple(ii) == (1, 3)
+
+    # upcast to uint16 internally
+    mm = fmask_to_bool(fmask, ("cat_0", "cat_15"))
+    ii, = np.where(mm)
+    assert tuple(ii) == (0, 15)
+
+    # upcast to uint32 internally
+    mm = fmask_to_bool(fmask, ("cat_1", "cat_3", "cat_31"))
+    ii, = np.where(mm)
+    assert tuple(ii) == (1, 3, 31)
+
+    # upcast to uint64 internally
+    mm = fmask_to_bool(fmask, ("cat_0", "cat_32", "cat_37", "cat_63"))
+    ii, = np.where(mm)
+    assert tuple(ii) == (0, 32, 37, 63)
+
+    with pytest.raises(ValueError):
+        fmask_to_bool(fmask, ('cat_64'))


### PR DESCRIPTION
`fmask_to_bool` didn't work for categories with value `8` and above. With these changes, values up to and including `63` should work.

Fix: make sure to use appropriately sized `dtype` when computing `1 << fmask`