### PR TITLE
Optimise stac transform

### DIFF
--- a/apps/cloud/odc/apps/cloud/s3_to_tar.py
+++ b/apps/cloud/odc/apps/cloud/s3_to_tar.py
@@ -74,7 +74,7 @@ def cli(n, verbose, gzip, xz, outfile):
 
     def on_ctrlc(sig, frame):
         nonlocal exit_early
-        print('Shuttting down', file=sys.stderr)
+        print('Shutting down...', file=sys.stderr)
         exit_early = True
 
     signal.signal(signal.SIGINT, on_ctrlc)

--- a/libs/index/odc/index/__init__.py
+++ b/libs/index/odc/index/__init__.py
@@ -1,9 +1,10 @@
 """ Indexing related helper methods.
 """
 
-from . _index import (
+from ._index import (
     from_metadata_stream,
     from_yaml_doc_stream,
+    parse_doc_stream,
     bin_dataset_stream,
     dataset_count,
     count_by_year,
@@ -33,6 +34,7 @@ from ._yaml import (
 __all__ = (
     "from_yaml_doc_stream",
     "from_metadata_stream",
+    "parse_doc_stream",
     "bin_dataset_stream",
     "dataset_count",
     "count_by_year",

--- a/libs/index/odc/index/_index.py
+++ b/libs/index/odc/index/_index.py
@@ -1,11 +1,12 @@
 import datetime
-from typing import Iterator, Tuple
+import json
 from types import SimpleNamespace
+from typing import Iterator, Tuple
 
-from datacube.index.hl import Doc2Dataset
-from datacube.api.query import Query
-from datacube.model import Range
 from datacube import Datacube
+from datacube.api.query import Query
+from datacube.index.hl import Doc2Dataset
+from datacube.model import Range
 from odc.io.text import parse_yaml
 
 
@@ -50,7 +51,10 @@ def parse_doc_stream(doc_stream, on_error=None):
     """
     for uri, doc in doc_stream:
         try:
-            metadata = parse_yaml(doc)
+            if 'json' in uri:
+                metadata = json.loads(doc)
+            else:
+                metadata = parse_yaml(doc)
         except Exception as e:
             if on_error is not None:
                 on_error(uri, doc, e)

--- a/libs/index/odc/index/_index.py
+++ b/libs/index/odc/index/_index.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from warnings import warn
 from types import SimpleNamespace
 from typing import Iterator, Tuple
 
@@ -80,8 +81,7 @@ def from_yaml_doc_stream(doc_stream, index, logger=None,
 
     if transform is not None:
         try:
-            metadata_stream = map(lambda d: (d[0], transform(d[1])),
-                                metadata_stream)
+            metadata_stream = map(lambda d: (d[0], transform(d[1])), metadata_stream)
         except Exception as e:
             on_parse_error()
 
@@ -215,7 +215,6 @@ def bin_dataset_stream(gridspec, dss, persist=None):
      .geobox  - tile geobox
      .dss     - list of UUIDs, or results of `persist(dataset)` if custom `persist` is supplied
     """
-    from warnings import warn
 
     cells = {}
     geobox_cache = {}

--- a/libs/index/odc/index/_index.py
+++ b/libs/index/odc/index/_index.py
@@ -69,12 +69,17 @@ def from_yaml_doc_stream(doc_stream, index, logger=None,
     def on_parse_error(uri, doc, err):
         if logger is not None:
             logger.error("Failed to parse: %s", uri)
+        else:
+            print(f"Failed to handle {uri}")
 
     metadata_stream = parse_doc_stream(doc_stream, on_error=on_parse_error)
 
     if transform is not None:
-        metadata_stream = map(lambda d: (d[0], transform(d[1])),
-                              metadata_stream)
+        try:
+            metadata_stream = map(lambda d: (d[0], transform(d[1])),
+                                metadata_stream)
+        except Exception as e:
+            on_parse_error()
 
     return from_metadata_stream(metadata_stream, index, **kwargs)
 

--- a/libs/index/odc/index/_index.py
+++ b/libs/index/odc/index/_index.py
@@ -51,7 +51,7 @@ def parse_doc_stream(doc_stream, on_error=None):
     """
     for uri, doc in doc_stream:
         try:
-            if 'json' in uri:
+            if uri.endswith('.json'):
                 metadata = json.loads(doc)
             else:
                 metadata = parse_yaml(doc)

--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -1,5 +1,6 @@
-from pyproj import Transformer
 from pathlib import Path
+
+from datacube.utils.geometry import _make_crs_transform
 from odc.index import odc_uuid
 
 KNOWN_CONSTELLATIONS = [
@@ -69,7 +70,7 @@ def _get_stac_bands(item, default_grid='g10.0m'):
 def _geographic_to_projected(geometry, target_srs):
     """ Transform from WGS84 to the target projection, assuming Lon, Lat order
     """
-    transformer = Transformer.from_crs(4326, target_srs, always_xy=True)
+    transformer = _make_crs_transform(4326, target_srs, always_xy=True)
     geometry['coordinates'][0] = list(transformer.itransform(
         geometry['coordinates'][0]))
 


### PR DESCRIPTION
- Add try-except to handle errors in json files
- Use cached pyproj transformer
- Switch to json parsing instead of yaml if `json` is in the path