### PR TITLE
Dask reproject

### DIFF
--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -33,6 +33,10 @@ from ._rgba import (
     to_rgba_np,
 )
 
+from ._warp import (
+    dask_reproject
+)
+
 __all__ = (
     "keep_good_np",
     "keep_good_only",
@@ -53,4 +57,5 @@ __all__ = (
     "is_rgb",
     "to_rgba",
     "to_rgba_np",
+    "dask_reproject",
 )

--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -34,7 +34,8 @@ from ._rgba import (
 )
 
 from ._warp import (
-    dask_reproject
+    dask_reproject,
+    xr_reproject_array,
 )
 
 __all__ = (
@@ -58,4 +59,5 @@ __all__ = (
     "to_rgba",
     "to_rgba_np",
     "dask_reproject",
+    "xr_reproject_array",
 )

--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -34,8 +34,7 @@ from ._rgba import (
 )
 
 from ._warp import (
-    dask_reproject,
-    xr_reproject_array,
+    xr_reproject,
 )
 
 __all__ = (
@@ -58,6 +57,5 @@ __all__ = (
     "is_rgb",
     "to_rgba",
     "to_rgba_np",
-    "dask_reproject",
-    "xr_reproject_array",
+    "xr_reproject",
 )

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -1,8 +1,14 @@
-""" Generic dask helpers
 """
-from dask.distributed import wait as dask_wait
-from toolz import partition_all
+Generic dask helpers
+"""
+
+from typing import Tuple, Optional
 from random import randint
+import numpy as np
+from dask.distributed import wait as dask_wait
+import dask.array as da
+from dask.highlevelgraph import HighLevelGraph
+from toolz import partition_all
 
 
 def chunked_persist(data, n_concurrent, client, verbose=False):
@@ -41,3 +47,177 @@ def chunked_persist(data, n_concurrent, client, verbose=False):
 
 def randomize(prefix: str):
     return '{}-{:08x}'.format(prefix, randint(0, 0xFFFFFFFF))
+
+
+def _stack_2d_np(shape_in_blocks, *blocks, out=None):
+    """
+    Stack a bunch of blocks into one plane.
+
+    Takes a flat sequence of blocks in row major order an rearranges them onto a plane.
+
+    Example:
+      (2, 3) [a0, a1, a2, a3, a4, a5]
+      >>
+            [[a0, a1, a2],
+             [a3, a4, a5]]
+
+    Blocks should have y,x dimensions first, i.e. a[y,x] or a[y, x, band] or more generally a[y,x,...]
+    """
+    assert len(blocks) > 0
+    assert len(shape_in_blocks) == 2
+    assert shape_in_blocks[0]*shape_in_blocks[1] == len(blocks)
+
+    dtype = blocks[0].dtype
+    extra_dims = blocks[0].shape[2:]
+
+    h, w = shape_in_blocks
+
+    chunk_y = [b.shape[0] for b in blocks[0:h*w:w]]
+    chunk_x = [b.shape[1] for b in blocks[:w]]
+    offset = [np.cumsum(x) for x in ([0] + chunk_y, [0] + chunk_x)]
+    ny, nx = [x[-1] for x in offset]
+
+    if out is None:
+        out = np.empty((ny, nx, *extra_dims), dtype=dtype)
+    else:
+        pass  # TODO: verify out shape is ok
+
+    for block, idx in zip(blocks, np.ndindex(shape_in_blocks)):
+        _y, _x = (offset[i][j] for i, j in zip([0, 1], idx))
+
+        out[_y:_y+block.shape[0],
+            _x:_x+block.shape[1]] = block
+
+    return out
+
+
+def _extract_as_one_block(crop, shape_in_blocks, *blocks):
+    out = _stack_2d_np(shape_in_blocks, *blocks)
+    if crop is None:
+        return out
+    return out[crop]
+
+
+def _chunk_getter(xx):
+    """
+    _chunk_getter(xx)(np.s_[:3, 2:4]) -> (
+    (xx.name, 0, 2),
+    (xx.name, 0, 3),
+    (xx.name, 1, 2),
+    ...)
+    """
+    shape_in_chunks = tuple(map(len, xx.chunks))
+    name = xx.name
+    xx = np.asarray([{'v': tuple(idx)} for idx in np.ndindex(shape_in_chunks)]).reshape(shape_in_chunks)
+
+    def getter(roi):
+        return tuple((name, *x['v']) for x in xx[roi].ravel())
+
+    return getter
+
+
+def _rechunk_2x2(xx, name='2x2'):
+    """
+    this is for testing only, ignore it, it's not robust
+    """
+    assert xx.ndim == 2
+    name = randomize(name)
+    ny, nx = (len(ch)//2 for ch in xx.chunks[:2])
+
+    dsk = {}
+    chunks = _chunk_getter(xx)
+
+    for r, c in np.ndindex((ny, nx)):
+        r2 = r*2
+        c2 = c*2
+        ch_idx = np.s_[r2:r2+2, c2:c2+2]
+        _xx = chunks(ch_idx)
+        dsk[(name, r, c)] = (_stack_2d_np, (2, 2), *_xx)
+
+    chy = tuple(xx.chunks[0][i*2] + xx.chunks[0][i*2 + 1] for i in range(ny))
+    chx = tuple(xx.chunks[1][i*2] + xx.chunks[1][i*2 + 1] for i in range(nx))
+
+    chunks = (chy, chx)
+    dsk = HighLevelGraph.from_collections(name, dsk, dependencies=(xx,))
+
+    return da.Array(dsk, name, chunks=chunks, dtype=xx.dtype, shape=xx.shape)
+
+
+def slice_in_out(s: slice, n: int) -> Tuple[int, int]:
+    def fill_if_none(x: Optional[int], val_if_none: int) -> int:
+        return val_if_none if x is None else x
+
+    start = fill_if_none(s.start, 0)
+    stop = fill_if_none(s.stop, n)
+    start, stop = [x if x >= 0 else n+x for x in (start, stop)]
+    return (start, stop)
+
+
+def roi_shape(roi: Tuple[slice, ...], shape: Optional[Tuple[int, ...]] = None) -> Tuple[int, ...]:
+    if shape is None:
+        # Assume slices are normalised
+        return tuple(s.stop - (s.start or 0) for s in roi)
+
+    return tuple(_out - _in
+                 for _in, _out in (slice_in_out(s, n)
+                                   for s, n in zip(roi, shape)))
+
+
+def compute_chunk_range(span: slice,
+                        chunks: Tuple[int, ...],
+                        summed: bool = False) -> Tuple[slice, slice]:
+    """
+    Compute slice in chunk space and slice after taking just those chunks
+
+    :param span: example: `np.s_[:10]`
+    :param chunks: example: xx.chunks[0]
+
+    """
+    from bisect import bisect_right, bisect_left
+
+    cs = chunks if summed else tuple(np.cumsum(chunks))
+    n = cs[-1]
+
+    _in, _out = slice_in_out(span, n)
+
+    b_start = bisect_right(cs, _in)
+    b_end = bisect_left(cs, _out) + 1
+
+    offset = _in - (0 if b_start == 0 else cs[b_start-1])
+    sz = _out - _in
+
+    return slice(b_start, b_end), slice(offset, offset+sz)
+
+
+def extract_dense_2d(xx: da.Array, roi: Tuple[slice, ...], name: str = 'get_roi') -> da.Array:
+    """
+    xx[roi] -> Dask array with 1 single chunk
+    """
+    assert len(roi) == xx.ndim
+    assert xx.ndim == 2
+
+    broi = []
+    crop = []
+
+    for span, chunks in zip(roi, xx.chunks):
+        bspan, pspan = compute_chunk_range(span, chunks)
+        broi.append(bspan)
+        crop.append(pspan)
+
+    broi = tuple(broi)
+    crop = tuple(crop)
+
+    xx_chunks = _chunk_getter(xx)
+    bshape = roi_shape(broi)
+
+    name = randomize(name)
+    dsk = {}
+    dsk[(name, 0, 0)] = (_extract_as_one_block, crop, bshape, *xx_chunks(broi))
+    dsk = HighLevelGraph.from_collections(name, dsk, dependencies=(xx,))
+    shape = roi_shape(crop)
+    chunks = tuple((n,) for n in shape)
+
+    return da.Array(dsk, name,
+                    chunks=chunks,
+                    dtype=xx.dtype,
+                    shape=shape)

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -70,6 +70,23 @@ def unpack_chunksize(chunk: int, N: int) -> Tuple[int, ...]:
     return tuple(chunk for _ in range(nb)) + (last_chunk,)
 
 
+def empty_maker(fill_value, dtype, dsk, name='empty'):
+    cache = {}
+
+    def mk_empty(shape: Tuple[int, ...]) -> str:
+        x = cache.get(shape, None)
+        if x is not None:
+            return x
+
+        b_name = name + '_' + "x".join(str(i) for i in shape)
+        b_name = randomize(b_name)
+        cache[shape] = b_name
+        dsk[b_name] = (np.full, shape, fill_value, dtype)
+        return b_name
+
+    return mk_empty
+
+
 def _stack_2d_np(shape_in_blocks, *blocks, out=None, axis=0):
     """
     Stack a bunch of blocks into one plane.

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -59,7 +59,8 @@ def unpack_chunksize(chunk: int, N: int) -> Tuple[int, ...]:
     Compute chunk sizes
     Example: 4, 11 -> (4, 4, 3)
     """
-    assert chunk <= N
+    if chunk >= N:
+        return (N,)
 
     nb = N//chunk
     last_chunk = N - chunk*nb

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -48,8 +48,26 @@ def chunked_persist(data, n_concurrent, client, verbose=False):
     return client.persist(data)
 
 
-def randomize(prefix: str):
+def randomize(prefix: str) -> str:
+    """
+    Append random token to name
+    """
     return '{}-{:08x}'.format(prefix, randint(0, 0xFFFFFFFF))
+
+
+def unpack_chunksize(chunk: int, N: int) -> Tuple[int, ...]:
+    """
+    Compute chunk sizes
+    Example: 4, 11 -> (4, 4, 3)
+    """
+    assert chunk <= N
+
+    nb = N//chunk
+    last_chunk = N - chunk*nb
+    if last_chunk == 0:
+        return tuple(chunk for _ in range(nb))
+
+    return tuple(chunk for _ in range(nb)) + (last_chunk,)
 
 
 def _stack_2d_np(shape_in_blocks, *blocks, out=None, axis=0):

--- a/libs/algo/odc/algo/_tools.py
+++ b/libs/algo/odc/algo/_tools.py
@@ -1,0 +1,32 @@
+"""
+Various utilities
+"""
+from typing import Tuple, Union, Optional
+
+ROI = Union[slice, Tuple[slice, ...]]
+
+
+def slice_in_out(s: slice, n: int) -> Tuple[int, int]:
+    def fill_if_none(x: Optional[int], val_if_none: int) -> int:
+        return val_if_none if x is None else x
+
+    start = fill_if_none(s.start, 0)
+    stop = fill_if_none(s.stop, n)
+    start, stop = [x if x >= 0 else n+x for x in (start, stop)]
+    return (start, stop)
+
+
+def roi_shape(roi: ROI, shape: Optional[Union[int, Tuple[int, ...]]] = None) -> Tuple[int, ...]:
+    if isinstance(shape, int):
+        shape = (shape,)
+
+    if isinstance(roi, slice):
+        roi = (roi,)
+
+    if shape is None:
+        # Assume slices are normalised
+        return tuple(s.stop - (s.start or 0) for s in roi)
+
+    return tuple(_out - _in
+                 for _in, _out in (slice_in_out(s, n)
+                                   for s, n in zip(roi, shape)))

--- a/libs/algo/odc/algo/_warp.py
+++ b/libs/algo/odc/algo/_warp.py
@@ -1,0 +1,118 @@
+"""
+Dask aware reproject implementation
+"""
+from typing import Tuple, Optional, Union, Dict, Any
+import numpy as np
+# import xarray as xr
+import dask.array as da
+from dask.highlevelgraph import HighLevelGraph
+from ._dask import randomize, crop_2d_dense, unpack_chunksize, empty_maker
+from datacube.utils.geometry import GeoBox, rio_reproject, compute_reproject_roi
+from datacube.utils.geometry.gbox import GeoboxTiles
+
+NodataType = Union[int, float]
+
+
+def _reproject_block_impl(src: np.ndarray,
+                          src_geobox: GeoBox,
+                          dst_geobox: GeoBox,
+                          resampling: str = 'nearest',
+                          src_nodata: Optional[NodataType] = None,
+                          dst_nodata: Optional[NodataType] = None,
+                          axis: int = 0) -> np.ndarray:
+    dst = np.empty(dst_geobox.shape, dtype=src.dtype)
+
+    rio_reproject(src,
+                  dst,
+                  src_geobox,
+                  dst_geobox,
+                  resampling,
+                  src_nodata,
+                  dst_nodata)
+    return dst
+
+
+def dask_reproject(src: da.Array,
+                   src_geobox: GeoBox,
+                   dst_geobox: GeoBox,
+                   resampling: str = "nearest",
+                   chunks: Optional[Tuple[int, int]] = None,
+                   src_nodata: Optional[NodataType] = None,
+                   dst_nodata: Optional[NodataType] = None,
+                   axis: int = 0,
+                   name: str = "reproject") -> da.Array:
+    """
+    Reproject to GeoBox as dask operation
+
+    :param src       : Input src[(time,) y,x (, band)]
+    :param src_geobox: GeoBox of the source array
+    :param dst_geobox: GeoBox of the destination
+    :param resampling: Resampling strategy as a string: nearest, bilinear, average, mode ...
+    :param chunks    : In Y,X dimensions only, default is to use same input chunk size
+    :param axis      : Index of Y axis (default is 0)
+    :param src_nodata: nodata marker for source image
+    :param dst_nodata: nodata marker for dst image
+    :param name      : Dask graph name, "reproject" is the default
+    """
+    if chunks is None:
+        chunks = src.chunksize[axis:axis+2]
+
+    if dst_nodata is None:
+        dst_nodata = src_nodata
+
+    assert src.shape[axis:axis+2] == src_geobox.shape
+    yx_shape = dst_geobox.shape
+    yx_chunks = tuple(unpack_chunksize(ch, n)
+                      for ch, n in zip(chunks, yx_shape))
+
+    dst_chunks = src.chunks[:axis] + yx_chunks + src.chunks[axis+2:]
+    dst_shape = src.shape[:axis] + yx_shape + src.shape[axis+2:]
+
+    #  tuple(*dims1, y, x, *dims2) -- complete shape in blocks
+    # dims1 = tuple(map(len, dst_chunks[:axis]))
+    # dims2 = tuple(map(len, dst_chunks[axis+2:]))
+    deps = [src]
+
+    gbt = GeoboxTiles(dst_geobox, chunks)
+    xy_chunks_with_data = list(gbt.tiles(src_geobox.extent))
+
+    name = randomize(name)
+    dsk: Dict[Any, Any] = {}
+
+    for idx in xy_chunks_with_data:
+        _dst_geobox = gbt[idx]
+        rr = compute_reproject_roi(src_geobox, _dst_geobox)
+        _src = crop_2d_dense(src, rr.roi_src, axis=axis)
+        _src_geobox = src_geobox[rr.roi_src]
+
+        deps.append(_src)
+
+        # TODO: other dims
+        dsk[(name, *idx)] = (_reproject_block_impl,
+                             (_src.name, 0, 0),
+                             _src_geobox,
+                             _dst_geobox,
+                             resampling,
+                             src_nodata,
+                             dst_nodata,
+                             axis)
+
+    fill_value = 0 if dst_nodata is None else dst_nodata
+    yx_shape_in_blocks = tuple(map(len, yx_chunks))
+
+    mk_empty = empty_maker(fill_value, src.dtype, dsk)
+
+    for idx in np.ndindex(yx_shape_in_blocks):
+        # TODO: other dims
+        k = (name, *idx)
+        if k not in dsk:
+            bshape = gbt.chunk_shape(idx)
+            dsk[k] = mk_empty(bshape)
+
+    dsk = HighLevelGraph.from_collections(name, dsk, dependencies=deps)
+
+    return da.Array(dsk,
+                    name,
+                    chunks=dst_chunks,
+                    dtype=src.dtype,
+                    shape=dst_shape)

--- a/libs/algo/odc/algo/_warp.py
+++ b/libs/algo/odc/algo/_warp.py
@@ -150,9 +150,7 @@ def xr_reproject_array(src: xr.DataArray,
     if dst_nodata is None:
         dst_nodata = src.nodata
 
-    assert is_dask_collection(src)
     src_geobox = src.geobox
-
     assert src_geobox is not None
 
     yx_dims = spatial_dims(src)
@@ -170,14 +168,23 @@ def xr_reproject_array(src: xr.DataArray,
     if dst_nodata is not None:
         attrs['nodata'] = dst_nodata
 
-    data = dask_reproject(src.data,
-                          src_geobox,
-                          geobox,
-                          resampling=resampling,
-                          chunks=chunks,
-                          src_nodata=src.nodata,
-                          dst_nodata=dst_nodata,
-                          axis=axis)
+    if is_dask_collection(src):
+        data = dask_reproject(src.data,
+                              src_geobox,
+                              geobox,
+                              resampling=resampling,
+                              chunks=chunks,
+                              src_nodata=src.nodata,
+                              dst_nodata=dst_nodata,
+                              axis=axis)
+    else:
+        data = _reproject_block_impl(src.data,
+                                     src_geobox,
+                                     geobox,
+                                     resampling=resampling,
+                                     src_nodata=src.nodata,
+                                     dst_nodata=dst_nodata,
+                                     axis=axis)
 
     return xr.DataArray(data,
                         name=src.name,

--- a/libs/algo/odc/algo/_warp.py
+++ b/libs/algo/odc/algo/_warp.py
@@ -110,7 +110,7 @@ def dask_reproject(src: da.Array,
         # TODO: other dims
         k = (name, *idx)
         if k not in dsk:
-            bshape = tuple(dst_chunks[i] for i in idx)
+            bshape = tuple(ch[i] for ch, i in zip(dst_chunks, idx))
             dsk[k] = mk_empty(bshape)
 
     dsk = HighLevelGraph.from_collections(name, dsk, dependencies=deps)

--- a/libs/algo/odc/algo/_warp.py
+++ b/libs/algo/odc/algo/_warp.py
@@ -25,14 +25,23 @@ def _reproject_block_impl(src: np.ndarray,
     dst_shape = src.shape[:axis] + dst_geobox.shape + src.shape[axis+2:]
     dst = np.empty(dst_shape, dtype=src.dtype)
 
-    for prefix in np.ndindex(src.shape[:axis]):
-        rio_reproject(src[prefix],
-                      dst[prefix],
+    if dst.ndim == 2 or (dst.ndim == 3 and axis == 1):
+        rio_reproject(src,
+                      dst,
                       src_geobox,
                       dst_geobox,
                       resampling,
                       src_nodata,
                       dst_nodata)
+    else:
+        for prefix in np.ndindex(src.shape[:axis]):
+            rio_reproject(src[prefix],
+                          dst[prefix],
+                          src_geobox,
+                          dst_geobox,
+                          resampling,
+                          src_nodata,
+                          dst_nodata)
     return dst
 
 

--- a/libs/algo/odc/algo/test_dask.py
+++ b/libs/algo/odc/algo/test_dask.py
@@ -1,0 +1,85 @@
+import pytest
+import numpy as np
+import dask.array as da
+import toolz
+from ._dask import _rechunk_2x2, _stack_2d_np, compute_chunk_range, extract_dense_2d
+
+
+def test_1():
+    xx = da.random.uniform(0, 10, size=(16, 6),
+                           chunks=(4, 3)).astype('uint8')
+    yy = _rechunk_2x2(xx)
+    assert xx.dtype == yy.dtype
+    assert xx.shape == yy.shape
+    assert (xx.compute() == yy.compute()).all()
+
+
+@pytest.mark.parametrize("shape, block_shape", [
+    [(2, 3), (2, 2)],
+    [(3, 2), (1, 2)],
+    [(1, 2), (2, 3)],
+    [(1, 1), (2, 3)],
+    [(2, 3), (2, 3, 3)],
+    [(2, 3), (3, 2, 4)],
+    [(2, 3), (3, 2, 4, 1)],
+])
+def test_stack2d_np(shape, block_shape, verbose=False):
+    aa = np.zeros((block_shape), dtype='int8')
+
+    h, w = shape
+    seq = [aa+i for i in range(w*h)]
+
+    expect = np.vstack([np.hstack(row)
+                        for row in toolz.partition_all(w, seq)])
+
+    cc = _stack_2d_np(shape, *seq)
+
+    assert (cc == expect).all()
+
+    if verbose:
+        print()
+        if cc.ndim == 2:
+            print(cc)
+        elif cc.ndim == 3:
+            print(cc[:, :, 0], f"x{cc.shape[2:]}")
+        else:
+            print(f"x{cc.shape}")
+
+
+@pytest.mark.parametrize("span, chunks, summed, bspan, pspan", [
+    (np.s_[:], (4, 4), False, slice(0, 2), slice(0, 8)),
+    (np.s_[0:], (4, 4), False, slice(0, 2), slice(0, 8)),
+    (np.s_[0:-1], (4, 4), False, slice(0, 2), slice(0, 7)),
+    (np.s_[-1:], (4, 4), False, slice(1, 2), slice(3, 4)),
+    (np.s_[-4:], (4, 4), False, slice(1, 2), slice(0, 4)),
+    (np.s_[0:8], (4, 4), False, slice(0, 2), slice(0, 8)),
+    (np.s_[1:], (4, 4), False, slice(0, 2), slice(1, 8)),
+    (np.s_[1:4], (4, 4), False, slice(0, 1), slice(1, 4)),
+    (np.s_[:], (2, 4, 6, 11, 13), True, slice(0, 5), slice(0, 13)),
+    (np.s_[2:7], (2, 4, 6, 11, 13), True, slice(1, 4), slice(0, 5)),
+    (np.s_[3:7], (2, 4, 6, 11, 13), True, slice(1, 4), slice(1, 5)),
+    (np.s_[3:], (2, 4, 6, 11, 13), True, slice(1, 5), slice(1, 13 - 3 + 1)),
+])
+def test_chunk_range(span, chunks, summed, bspan, pspan):
+    _bspan, _pspan = compute_chunk_range(span, chunks, summed)
+    assert _bspan == bspan
+    assert _pspan == pspan
+
+
+@pytest.mark.parametrize("roi", [
+    np.s_[:, :],
+    np.s_[:1, :1],
+    np.s_[3:, 1:],
+    np.s_[3:-3, 1:-5],
+    np.s_[3:-3, -5:],
+])
+def test_extract_one_block(roi):
+    xx = da.random.uniform(0, 10, size=(16, 6),
+                           chunks=(4, 3)).astype('uint8')
+
+    yy = extract_dense_2d(xx, roi)
+    assert xx.dtype == yy.dtype
+    assert yy.shape == xx[roi].shape
+    assert yy.shape == yy.chunksize
+
+    assert (xx[roi].compute() == yy.compute()).all()

--- a/libs/algo/odc/algo/test_dask.py
+++ b/libs/algo/odc/algo/test_dask.py
@@ -19,6 +19,7 @@ def test_1():
     (3, 9, (3, 3, 3)),
     (8, 8, (8,)),
     (1, 3, (1, 1, 1)),
+    (10, 3, (3,)),
 ])
 def test_unpack_chunks(chunk, n, expect):
     assert unpack_chunksize(chunk, n) == expect

--- a/libs/algo/odc/algo/test_dask.py
+++ b/libs/algo/odc/algo/test_dask.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import dask.array as da
 import toolz
-from ._dask import _rechunk_2x2, _stack_2d_np, compute_chunk_range, crop_2d_dense
+from ._dask import _rechunk_2x2, _stack_2d_np, compute_chunk_range, crop_2d_dense, unpack_chunksize
 
 
 def test_1():
@@ -12,6 +12,16 @@ def test_1():
     assert xx.dtype == yy.dtype
     assert xx.shape == yy.shape
     assert (xx.compute() == yy.compute()).all()
+
+
+@pytest.mark.parametrize("chunk, n, expect", [
+    (4, 7, (4, 3)),
+    (3, 9, (3, 3, 3)),
+    (8, 8, (8,)),
+    (1, 3, (1, 1, 1)),
+])
+def test_unpack_chunks(chunk, n, expect):
+    assert unpack_chunksize(chunk, n) == expect
 
 
 @pytest.mark.parametrize("shape, block_shape", [


### PR DESCRIPTION
MEM -> MEM reproject that should work on bigger than available RAM Dask graphs.

Accepts `xr.Data{Array|Set}` and `GeoBox` on input and produces `xr.Data{Array|Set)` on output.
Time dimension is supported, but RGBA inputs are not yet supported for the `reproject` some of the lower-level components are fully N-dimensional `crop_2d_dense`.

When working with Dask inputs the dependency graph is computed to be "minimal", i.e. only those blocks that are needed to compute output block are declared as a dependency see (`crop_2d_dense`). 

Future Improvements not included here

- Support RGBA inputs
- Share GeoSpatial computation across bands (might be handy for really large, in the number of blocks, inputs)

The assumption is that reproject doesn't perform a huge reduction is scale, as this might require to fully realize (load into memory) too big of a window of the input for one single output block.

