### PR TITLE
Changing dstiler grid spec management

### DIFF
--- a/libs/dscache/odc/dscache/apps/dstiler.py
+++ b/libs/dscache/odc/dscache/apps/dstiler.py
@@ -1,58 +1,59 @@
 import click
 from odc import dscache
-from odc.dscache.tools.tiling import bin_by_native_tile, web_gs, extract_native_albers_tile
-from datacube.model import GridSpec
+from odc.dscache.tools.tiling import (
+    bin_by_native_tile,
+    web_gs,
+    extract_native_albers_tile,
+    parse_gridspec,
+    mk_group_name)
 from odc.index import bin_dataset_stream
-
-GS_ALBERS = GridSpec(crs='EPSG:3577',
-                     tile_size=(100000.0, 100000.0),
-                     resolution=(-25, 25))
 
 
 @click.command('dstiler')
 @click.option('--native', is_flag=True, help='Use Landsat Path/Row as grouping')
-@click.option('--native-albers', is_flag=True, help='When datasets are in Albers grid already')
+@click.option('--native-albers', is_flag=True, help='When datasets are in Albers (AU) grid already')
 @click.option('--web', type=int, help='Use web map tiling regime at supplied zoom level')
-@click.option('--crs', type=str, help="Custom gridspec: CRS code")
-@click.option('--resolution', type=str, help="Custom gridspec: resolution in CRS units per pixel in y,x order")
-@click.option('--shape', type=str, help="Custom gridspec: shape of tile in pixel in y,x order")
-@click.option('--bin-format', type=str, help="Custom gridspec: format of bin group key")
+@click.option('--grid', type=str,
+              help="Grid spec or name 'crs;pixel_resolution;shape_in_pixels'|albers_au_25",
+              default='albers_au_25')
 @click.argument('dbfile', type=str, nargs=1)
-def cli(native, native_albers, web, crs, resolution, shape, bin_format, dbfile):
+def cli(native, native_albers, web, grid, dbfile):
     """Add spatial grouping to file db.
 
     Default grid is Australian Albers (EPSG:3577) with 100k by 100k tiles. But
     you can also group by Landsat path/row (--native), or Google's map tiling
     regime (--web zoom_level)
 
+    \b
+    Example for custom --grid:
+      - rectangular: 'epsg:6933;-10x10;2000x3000'
+                      ^crs      ^y  ^x ^ny  ^nx
+      - square     : 'epsg:3857;10;10000'
+      - named      : albers_au_25
+                     albers_africa_10  (20,30,60 are also available)
     """
     cache = dscache.open_rw(dbfile)
     label = 'Processing {} ({:,d} datasets)'.format(dbfile, cache.count)
+    group_prefix = 'grid'
+    gs = None
 
     if native:
-        group_key_fmt = 'native/{:03d}_{:03d}'
+        group_prefix = 'native'
         binner = bin_by_native_tile
     elif native_albers:
-        group_key_fmt = 'albers/{:03d}_{:03d}'
+        group_prefix = 'albers'
         binner = lambda dss: bin_by_native_tile(dss, native_tile_id=extract_native_albers_tile)
     elif web is not None:
         gs = web_gs(web)
-        group_key_fmt = 'web_' + str(web) + '/{:03d}_{:03d}'
-        binner = lambda dss: bin_dataset_stream(gs, dss)
-    elif crs is not None or resolution is not None or shape is not None or bin_format is not None:
-        settings = dict(crs=crs, resolution=resolution, shape=shape, bin_format=bin_format)
-        missing = [key for key, value in settings.items() if value is None]
-        if missing:
-            raise ValueError('Missing options in custom grid spec: {}'.format(' '.join(missing)))
-        group_key_fmt = bin_format
-        resolution = [float(comp) for comp in resolution.split(',')]
-        shape = [float(comp) for comp in shape.split(',')]
-        tile_size = [abs(res * shp) for res, shp in zip(resolution, shape)]
-        gs = GridSpec(crs=crs, tile_size=tile_size, resolution=resolution)
+        group_prefix = 'web_' + str(web)
         binner = lambda dss: bin_dataset_stream(gs, dss)
     else:
-        group_key_fmt = 'albers/{:03d}_{:03d}'
-        binner = lambda dss: bin_dataset_stream(GS_ALBERS, dss)
+        gs = parse_gridspec(grid)
+        group_prefix = f"epsg{gs.crs.epsg:d}"
+        binner = lambda dss: bin_dataset_stream(gs, dss)
+
+    if gs is not None:
+        click.echo(f'Using gridspec: {gs}')
 
     with click.progressbar(cache.get_all(), length=cache.count, label=label) as dss:
         bins = binner(dss)
@@ -61,7 +62,7 @@ def cli(native, native_albers, web, crs, resolution, shape, bin_format, dbfile):
 
     with click.progressbar(bins.values(), length=len(bins), label='Saving') as groups:
         for group in groups:
-            k = group_key_fmt.format(*group.idx)
+            k = mk_group_name(group.idx, group_prefix)
             cache.put_group(k, group.dss)
 
 

--- a/libs/dscache/odc/dscache/tools/tiling.py
+++ b/libs/dscache/odc/dscache/tools/tiling.py
@@ -1,8 +1,35 @@
+from typing import Tuple, Optional
+from math import pi
 from types import SimpleNamespace
 import toolz
+from datacube.utils.geometry import CRS
+from datacube.model import GridSpec, Dataset
+from odc.io.text import split_and_check, parse_range_int
+
+epsg3577 = CRS('epsg:3577')
+epsg6933 = CRS('epsg:6933')
 
 
-def web_gs(zoom, tile_size=256):
+GRIDS = {
+    'albers_au_25': GridSpec(crs=epsg3577,
+                             tile_size=(100_000.0, 100_000.0),
+                             resolution=(-25, 25)),
+    'albers_africa_10': GridSpec(crs=epsg6933,
+                                 tile_size=(96_000.0, 96_000.0),
+                                 resolution=(-10, 10)),
+    'albers_africa_20': GridSpec(crs=epsg6933,
+                                 tile_size=(96_000.0, 96_000.0),
+                                 resolution=(-20, 20)),
+    'albers_africa_30': GridSpec(crs=epsg6933,
+                                 tile_size=(96_000.0, 96_000.0),
+                                 resolution=(-30, 30)),
+    'albers_africa_60': GridSpec(crs=epsg6933,
+                                 tile_size=(96_000.0, 96_000.0),
+                                 resolution=(-30, 30)),
+}
+
+
+def web_gs(zoom: int, tile_size: int = 256) -> GridSpec:
     """ Construct grid spec compatible with TerriaJS requests at a given level.
 
     Tile indexes should be the same as google maps, except that Y component is negative,
@@ -11,10 +38,6 @@ def web_gs(zoom, tile_size=256):
 
     http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
     """
-    from datacube.utils.geometry import CRS
-    from datacube.model import GridSpec
-    from math import pi
-
     R = 6378137
 
     origin = pi * R
@@ -28,13 +51,14 @@ def web_gs(zoom, tile_size=256):
                     origin=(origin-tsz, -origin))  # Y,X
 
 
-def extract_native_albers_tile(ds, tile_size=100_000):
+def extract_native_albers_tile(ds: Dataset, tile_size: float = 100_000.0) -> Tuple[int, int]:
     ll = toolz.get_in('grid_spatial.projection.geo_ref_points.ll'.split('.'),
                       ds.metadata_doc)
-    return tuple(int(ll[k]/tile_size) for k in ('x', 'y'))
+    return (int(ll['x']/tile_size),
+            int(ll['y']/tile_size))
 
 
-def extract_ls_path_row(ds):
+def extract_ls_path_row(ds: Dataset) -> Optional[Tuple[int, int]]:
     full_id = ds.metadata_doc.get('tile_id')
 
     if full_id is None:
@@ -42,7 +66,8 @@ def extract_ls_path_row(ds):
 
     if full_id is None:
         return None
-    return tuple(int(s) for s in (full_id[3:6], full_id[6:9]))
+    return (int(full_id[3:6]),
+            int(full_id[6:9]))
 
 
 def bin_by_native_tile(dss, persist=None, native_tile_id=None):
@@ -84,22 +109,56 @@ def bin_by_native_tile(dss, persist=None, native_tile_id=None):
     return cells
 
 
-def parse_group_name(group_name):
-    """ Return an ((int, int), prefix) tuple from group name.
+def parse_group_name(group_name: str) -> Tuple[Tuple[int, int], str]:
+    """ Return an ((int, int), prefix:str) tuple from group name.
 
-        Expects group to be in the form {prefix}/{x}_{y}
+        Expects group to be in the form {prefix}/{x}/{y}
 
         raises ValueError if group_name is not in the expected format.
     """
 
-    idx = group_name.rfind('/')
-    if idx < 0:
+    try:
+        prefix, x, y = split_and_check(group_name, '/', 3)
+        x, y = map(int, (x, y))
+    except ValueError:
         raise ValueError('Bad group name: ' + group_name)
 
-    prefix = group_name[:idx]
-    vv = group_name[idx+1:].split('_')
+    return (x, y), prefix
 
-    if len(vv) != 2:
-        raise ValueError('Bad group name: ' + group_name)
 
-    return tuple([int(v) for v in vv]), prefix
+def mk_group_name(idx: Tuple[int, int], name: str = "grid") -> str:
+    return f"{name}/{idx[0]:+05d}/{idx[1]:+05d}"
+
+
+def parse_gridspec(s: str) -> GridSpec:
+    """
+    "albers_africa_10"
+    "epsg:6936;10;9600"
+    "epsg:6936;-10x10;9600x9600"
+    """
+    named_gs = GRIDS.get(s)
+    if named_gs is not None:
+        return named_gs
+
+    crs, res, shape = split_and_check(s, ';', 3)
+    try:
+        if 'x' in res:
+            res = tuple(float(v) for v in split_and_check(res, 'x', 2))
+        else:
+            res = float(res)
+            res = (-res, res)
+
+        if 'x' in shape:
+            shape = parse_range_int(shape, separator='x')
+        else:
+            shape = int(shape)
+            shape = (shape, shape)
+    except ValueError:
+        raise ValueError(f"Failed to parse gridspec: {s}")
+
+    tsz = tuple(abs(n*res) for n, res in zip(res, shape))
+
+    return GridSpec(crs=CRS(crs),
+                    tile_size=tsz,
+                    resolution=res,
+                    origin=(0, 0))


### PR DESCRIPTION
1. Adding `--grid=<name|crs;resolution;shape>`
2. Removing ability to customize "group name format"
   It is now always 'name:str/x:int/y:int'