### PR TITLE
Fix grid naming for STAC grids

### DIFF
--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -115,6 +115,6 @@ def stac_transform(input_stac):
     }
 
     if region_code:
-        stac_odc['properties']['odc:region_code']: region_code
+        stac_odc['properties']['odc:region_code'] = region_code
 
     return stac_odc

--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -32,7 +32,7 @@ def _stac_product_lookup(item):
     return product_label, product_name, region_code
 
 
-def _get_stac_bands(item, default_grid='g10.0m'):
+def _get_stac_bands(item, default_grid='g10m'):
     bands = {}
 
     grids = {}
@@ -45,7 +45,7 @@ def _get_stac_bands(item, default_grid='g10.0m'):
             continue
 
         transform = asset['proj:transform']
-        grid = f'g{transform[0]}m'
+        grid = f'res:g{transform[0]}m'
 
         if grid not in grids:
             grids[grid] = {
@@ -85,7 +85,7 @@ def stac_transform(input_stac):
 
     deterministic_uuid = str(odc_uuid("sentinel-2_stac_process", "1.0.0", [product_label]))
 
-    bands, grids = _get_stac_bands(input_stac)
+    bands, grids = _get_stac_bands(input_stac, default_grid='g10m')
 
     properties = input_stac['properties']
     epsg = properties['proj:epsg']

--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -45,7 +45,7 @@ def _get_stac_bands(item, default_grid='g10m'):
             continue
 
         transform = asset['proj:transform']
-        grid = f'res:g{transform[0]}m'
+        grid = f'g{transform[0]:g}m'
 
         if grid not in grids:
             grids[grid] = {


### PR DESCRIPTION
Removes the .0 from grid names, chancing them from things like g10.0m to g10m.