### PR TITLE
Migrate to newer `aiobotocore` and add support for unsigned and requestor pays

### DIFF
--- a/apps/cloud/odc/apps/cloud/s3_find.py
+++ b/apps/cloud/odc/apps/cloud/s3_find.py
@@ -1,13 +1,15 @@
 import click
 import sys
-from odc.aio import s3_find_glob
+from odc.aio import s3_find_glob, S3Fetcher
 
 
 @click.command('s3-find')
 @click.option('--skip-check', is_flag=True,
               help='Assume file exists when listing exact file rather than wildcard.')
+@click.option('--aws-unsigned', is_flag=True,
+              help='Do not sign AWS S3 requests')
 @click.argument('uri', type=str, nargs=1)
-def cli(uri, skip_check):
+def cli(uri, skip_check, aws_unsigned=None):
     """ List files on S3 bucket.
 
     Example:
@@ -34,8 +36,10 @@ def cli(uri, skip_check):
     """
     flush_freq = 100
 
+    s3 = S3Fetcher(aws_unsigned=aws_unsigned)
+
     try:
-        stream = s3_find_glob(uri, skip_check)
+        stream = s3_find_glob(uri, skip_check=skip_check, s3=s3)
         for i, o in enumerate(stream):
             print(o.url, flush=(i % flush_freq == 0))
     except ValueError as ve:
@@ -44,7 +48,6 @@ def cli(uri, skip_check):
     except Exception as e:
         click.echo(str(e), err=True)
         sys.exit(1)
-    
 
 
 if __name__ == '__main__':

--- a/apps/cloud/odc/apps/cloud/s3_inventory.py
+++ b/apps/cloud/odc/apps/cloud/s3_inventory.py
@@ -2,7 +2,7 @@ import re
 from fnmatch import fnmatch
 import sys
 import click
-from odc.aws import make_s3_client
+from odc.aws import s3_client
 from odc.aws.inventory import list_inventory
 
 
@@ -62,7 +62,7 @@ def cli(inventory, prefix, regex, glob, aws_profile):
         return 's3://{e.Bucket}/{e.Key}'.format(e=entry)
 
     flush_freq = 100
-    s3 = make_s3_client(profile=aws_profile)
+    s3 = s3_client(profile=aws_profile)
 
     if glob == '':
         glob = None

--- a/apps/cloud/odc/apps/cloud/s3_to_tar.py
+++ b/apps/cloud/odc/apps/cloud/s3_to_tar.py
@@ -17,8 +17,10 @@ from odc.io.timer import RateEstimator
 @click.option('--verbose', '-v', is_flag=True, help='Be verbose')
 @click.option('--gzip', is_flag=True, help='Compress with gzip')
 @click.option('--xz', is_flag=True, help='Compress with xz')
+@click.option('--aws-unsigned', is_flag=True,
+              help='Do not sign AWS S3 requests')
 @click.argument("outfile", type=str, nargs=1, default='-')
-def cli(n, verbose, gzip, xz, outfile):
+def cli(n, verbose, gzip, xz, outfile, aws_unsigned=None):
     """ Fetch a bunch of s3 files into a tar archive.
 
     \b
@@ -58,7 +60,7 @@ def cli(n, verbose, gzip, xz, outfile):
         if verbose:
             print(' {}'.format(str(fps)), file=stderr)
 
-    fetcher = S3Fetcher(nconcurrent=nconnections)
+    fetcher = S3Fetcher(nconcurrent=nconnections, aws_unsigned=aws_unsigned)
     is_pipe = outfile == '-'
     tar_opts = dict(mode='w'+tar_mode(gzip=gzip, xz=xz, is_pipe=is_pipe))
     if is_pipe:

--- a/libs/aio/setup.py
+++ b/libs/aio/setup.py
@@ -18,7 +18,7 @@ setup(
 
     tests_require=['pytest'],
     install_requires=[
-        'aiobotocore',
+        'aiobotocore >= 1.0',
         'botocore',
         'odc_aws',
         'odc_ppt',

--- a/libs/aws/odc/aws/__init__.py
+++ b/libs/aws/odc/aws/__init__.py
@@ -1,16 +1,27 @@
-from urllib.parse import urlparse
+"""
+Helper methods for working with AWS
+"""
+import os
 import botocore
 import botocore.session
-import logging
+from botocore.credentials import Credentials, ReadOnlyCredentials
+from botocore.session import Session
 import time
+from urllib.request import urlopen
+from urllib.parse import urlparse
+from typing import Optional, Dict, Tuple, Any, Union, IO
+import logging
+import threading
+
+_LCL = threading.local()
+ByteRange = Union[slice, Tuple[int, int]]       # pylint: disable=invalid-name
+MaybeS3 = Optional[botocore.client.BaseClient]  # pylint: disable=invalid-name
+
 
 log = logging.getLogger(__name__)
 
 
-def _fetch_text(url, timeout=0.1):
-    """ Turn url into text this url points to.
-    """
-    from urllib.request import urlopen
+def _fetch_text(url: str, timeout: float = 0.1) -> Optional[str]:
     try:
         with urlopen(url, timeout=timeout) as resp:
             if 200 <= resp.getcode() < 300:
@@ -21,8 +32,42 @@ def _fetch_text(url, timeout=0.1):
         return None
 
 
-def ec2_metadata(timeout=0.1):
-    """ Read and parse EC metadata.
+def s3_url_parse(url: str) -> Tuple[str, str]:
+    """ Return Bucket, Key tuple
+    """
+    uu = urlparse(url)
+    if uu.scheme != "s3":
+        raise ValueError("Not a valid s3 url")
+    return uu.netloc, uu.path.lstrip('/')
+
+
+def s3_fmt_range(r: Optional[ByteRange]):
+    """ None -> None
+        (in, out) -> "bytes={in}-{out-1}"
+    """
+    if r is None:
+        return None
+
+    if isinstance(r, slice):
+        if r.step not in [1, None]:
+            raise ValueError("Can not process decimated slices")
+        if r.stop is None:
+            raise ValueError("Can not process open ended slices")
+
+        _in = 0 if r.start is None else r.start
+        _out = r.stop
+    else:
+        _in, _out = r
+
+    if _in < 0 or _out < 0:
+        raise ValueError("Slice has to be positive")
+
+    return 'bytes={:d}-{:d}'.format(_in, _out-1)
+
+
+def ec2_metadata(timeout: float = 0.1) -> Optional[Dict[str, Any]]:
+    """ When running inside AWS returns dictionary describing instance identity.
+        Returns None when not inside AWS
     """
     import json
     txt = _fetch_text('http://169.254.169.254/latest/dynamic/instance-identity/document', timeout)
@@ -36,8 +81,8 @@ def ec2_metadata(timeout=0.1):
         return None
 
 
-def ec2_current_region():
-    """ Query EC2 metadata for region name this instance is running in.
+def ec2_current_region() -> Optional[str]:
+    """ Returns name of the region  this EC2 instance is running in.
     """
     cfg = ec2_metadata()
     if cfg is None:
@@ -45,82 +90,278 @@ def ec2_current_region():
     return cfg.get('region', None)
 
 
-def botocore_default_region(session=None):
-    """Return region configured for AWS.
-
-    With no arguments or with session=None return region configured in the default session.
-
-    Otherwise return region configured in the supplied session.
+def botocore_default_region(session: Optional[Session] = None) -> Optional[str]:
+    """ Returns default region name as configured on the system.
     """
     if session is None:
         session = botocore.session.get_session()
     return session.get_config_variable('region')
 
 
-def auto_find_region(session=None):
-    """ Find region to use
-    1. Use session settings if session is supplied and has region configured
-    2. Use default session region settings if session not supplied but default one has region configured
-    3. Use region EC2 instance is running in (if running on EC2)
-    4. raise ValueError if none of the steps above worked
+def auto_find_region(session: Optional[Session] = None, default: Optional[str] = None) -> str:
+    """
+    Try to figure out which region name to use
+
+    1. Region as configured for this/default session
+    2. Region this EC2 instance is running in
+    3. Value supplied in `default`
+    4. raise exception
     """
     region_name = botocore_default_region(session)
 
     if region_name is None:
         region_name = ec2_current_region()
 
-    if region_name is None:
+    if region_name is not None:
+        return region_name
+
+    if default is None:
         raise ValueError('Region name is not supplied and default can not be found')
 
-    return region_name
+    return default
 
 
-def make_s3_client(region_name=None,
-                   max_pool_connections=32,
-                   session=None,
-                   profile=None,
-                   creds=None,
-                   use_ssl=True):
-    """ Create s3 client with correct region and configured max_pool_connections.
+def get_creds_with_retry(session: Session,
+                         max_tries: int = 10,
+                         sleep: float = 0.1) -> Optional[Credentials]:
+    """ Attempt to obtain credentials upto `max_tries` times with back off
+    :param session: botocore session, see mk_boto_session
+    :param max_tries: number of attempt before failing and returing None
+    :param sleep: number of seconds to sleep after first failure (doubles on every consecutive failure)
+    """
+    for i in range(max_tries):
+        if i > 0:
+            time.sleep(sleep)
+            sleep = min(sleep*2, 10)
+
+        creds = session.get_credentials()
+        if creds is not None:
+            return creds
+
+    return None
+
+
+def mk_boto_session(profile: Optional[str] = None,
+                    creds: Optional[ReadOnlyCredentials] = None,
+                    region_name: Optional[str] = None) -> Session:
+    """ Get botocore session with correct `region` configured
+
+    :param profile: profile name to lookup
+    :param creds: Override credentials with supplied data
+    :param region_name: default region_name to use if not configured for a given profile
+    """
+    session = botocore.session.Session(profile=profile)
+
+    if creds is not None:
+        session.set_credentials(creds.access_key,
+                                creds.secret_key,
+                                creds.token)
+
+    _region = session.get_config_variable("region")
+    if _region is None:
+        if region_name is None or region_name == "auto":
+            _region = auto_find_region(session, default='us-west-2')
+        else:
+            _region = region_name
+        session.set_config_variable("region", _region)
+
+    return session
+
+
+def _s3_cache_key(profile: Optional[str] = None,
+                  creds: Optional[ReadOnlyCredentials] = None,
+                  region_name: Optional[str] = None,
+                  aws_unsigned: bool = False,
+                  prefix: str = "s3") -> str:
+    parts = [prefix,
+             "" if creds is None else creds.access_key,
+             "T" if aws_unsigned else "F",
+             profile or "",
+             region_name or ""]
+    return ":".join(parts)
+
+
+def _mk_s3_client(profile: Optional[str] = None,
+                  creds: Optional[ReadOnlyCredentials] = None,
+                  region_name: Optional[str] = None,
+                  session: Optional[Session] = None,
+                  use_ssl: bool = True,
+                  **cfg) -> botocore.client.BaseClient:
+    """ Construct s3 client with configured region_name.
+
+    :param profile    : profile name to lookup (only used if session is not supplied)
+    :param creds      : Override credentials with supplied data
+    :param region_name: region_name to use, overrides session setting
+    :param session    : botocore session to use
+    :param use_ssl    : Whether to connect via http or https
+    :param cfg        : passed on to ``botocore.client.Config(..)``
+                        max_pool_connections
+                        connect_timeout
+                        read_timeout
+                        parameter_validation
+                        ...
     """
     if session is None:
-        session = get_boto_session(region_name=region_name,
-                                   profile=profile,
-                                   creds=creds)
+        session = mk_boto_session(profile=profile,
+                                  creds=creds,
+                                  region_name=region_name)
 
-    region_name = session.get_config_variable("region")
+    extras = {}  # type: Dict[str, Any]
+    if creds is not None:
+        extras.update(aws_access_key_id=creds.access_key,
+                      aws_secret_access_key=creds.secret_key,
+                      aws_session_token=creds.token)
+    if region_name is not None:
+        extras['region_name'] = region_name
 
-    protocol = 'https' if use_ssl else 'http'
+    return session.create_client('s3',
+                                 use_ssl=use_ssl,
+                                 **extras,
+                                 config=botocore.client.Config(**cfg))
 
-    s3 = session.create_client('s3',
-                               region_name=region_name,
-                               endpoint_url='{}://s3.{}.amazonaws.com'.format(protocol, region_name),
-                               config=botocore.client.Config(max_pool_connections=max_pool_connections))
+
+def _aws_unsigned_check_env() -> bool:
+    def parse_bool(v: str) -> bool:
+        return v.upper() in ('YES', 'Y', 'TRUE', 'T', '1')
+
+    for evar in ('AWS_UNSIGNED', 'AWS_NO_SIGN_REQUEST'):
+        v = os.environ.get(evar, None)
+        if v is not None:
+            return parse_bool(v)
+
+    return False
+
+
+def s3_client(profile: Optional[str] = None,
+              creds: Optional[ReadOnlyCredentials] = None,
+              region_name: Optional[str] = None,
+              session: Optional[Session] = None,
+              aws_unsigned: Optional[bool] = None,
+              use_ssl: bool = True,
+              cache: Union[bool, str] = False,
+              **cfg) -> botocore.client.BaseClient:
+    """ Construct s3 client with configured region_name.
+
+    :param profile: profile name to lookup (only used if session is not supplied)
+    :param creds: Override credentials with supplied data
+    :param region_name: region_name to use, overrides session setting
+    :param aws_unsigned: Do not use any credentials when accessing S3 resources
+    :param session: botocore session to use
+    :param use_ssl: Whether to connect via http or https
+    :param cache: ``True`` - store/lookup s3 client in thread local cache.
+                  ``"purge"`` - delete from cache and return what was there to begin with
+
+    :param cfg: passed on to ``botocore.client.Config(..)``
+
+    """
+    if aws_unsigned is None:
+        aws_unsigned = _aws_unsigned_check_env()
+
+    if aws_unsigned:
+        cfg.update(signature_version=botocore.UNSIGNED)
+
+    if not cache:
+        return _mk_s3_client(profile,
+                             creds=creds,
+                             region_name=region_name,
+                             session=session,
+                             use_ssl=use_ssl,
+                             **cfg)
+
+    _cache = thread_local_cache("__aws_s3_cache", {})
+
+    key = _s3_cache_key(profile=profile,
+                        region_name=region_name,
+                        creds=creds,
+                        aws_unsigned=aws_unsigned)
+
+    if cache == "purge":
+        return _cache.pop(key, None)
+
+    s3 = _cache.get(key, None)
+
+    if s3 is None:
+        s3 = _mk_s3_client(profile,
+                           creds=creds,
+                           region_name=region_name,
+                           session=session,
+                           use_ssl=use_ssl,
+                           **cfg)
+        _cache[key] = s3
+
     return s3
 
 
-def s3_url_parse(url):
-    """ Return Bucket, Key tuple
+def s3_open(url: str,
+            s3: MaybeS3 = None,
+            range: Optional[ByteRange] = None,  # pylint: disable=redefined-builtin
+            **kwargs):
+    """ Open whole or part of S3 object
+
+    :param url: s3://bucket/path/to/object
+    :param s3: pre-configured s3 client, see make_s3_client()
+    :param range: Byte range to read (first_byte, one_past_last_byte), default is whole object
+    :param kwargs: are passed on to ``s3.get_object(..)``
     """
-    uu = urlparse(url)
-    return uu.netloc, uu.path.lstrip('/')
+    if range is not None:
+        try:
+            kwargs['Range'] = s3_fmt_range(range)
+        except Exception:
+            raise ValueError('Bad range passed in: ' + str(range))
+
+    s3 = s3 or s3_client()
+    bucket, key = s3_url_parse(url)
+    oo = s3.get_object(Bucket=bucket, Key=key, **kwargs)
+    return oo['Body']
 
 
-def s3_fmt_range(range):
-    """ None -> None
-        (in, out) -> "bytes={in}-{out-1}"
+def s3_fetch(url: str,
+             s3: MaybeS3 = None,
+             range: Optional[ByteRange] = None,  # pylint: disable=redefined-builtin
+             **kwargs) -> bytes:
+    """ Read entire or part of object into memory and return as bytes
+
+    :param url: s3://bucket/path/to/object
+    :param s3: pre-configured s3 client, see make_s3_client()
+    :param range: Byte range to read (first_byte, one_past_last_byte), default is whole object
     """
-    if range is None:
-        return None
+    return s3_open(url, s3=s3, range=range, **kwargs).read()
 
-    _in, _out = range
-    return 'bytes={:d}-{:d}'.format(_in, _out-1)
 
+def s3_dump(data: Union[bytes, str, IO],
+            url: str,
+            s3: MaybeS3 = None,
+            **kwargs):
+    """ Write data to s3 object.
+
+    :param data: bytes to write
+    :param url: s3://bucket/path/to/object
+    :param s3: pre-configured s3 client, see s3_client()
+    :param kwargs: Are passed on to ``s3.put_object(..)``
+
+    ContentType
+    ACL
+    """
+
+    s3 = s3 or s3_client()
+    bucket, key = s3_url_parse(url)
+
+    r = s3.put_object(Bucket=bucket,
+                      Key=key,
+                      Body=data,
+                      **kwargs)
+    code = r['ResponseMetadata']['HTTPStatusCode']
+    return 200 <= code < 300
+
+
+###########################################################################
+# Code above is also in datacube, code below not yet
+###########################################################################
 
 def s3_ls(url, s3=None):
     bucket, prefix = s3_url_parse(url)
 
-    s3 = s3 or make_s3_client()
+    s3 = s3 or s3_client()
     paginator = s3.get_paginator('list_objects_v2')
 
     n_skip = len(prefix)
@@ -135,7 +376,7 @@ def s3_ls_dir(uri, s3=None):
     if len(prefix) > 0 and not prefix.endswith('/'):
         prefix = prefix + '/'
 
-    s3 = s3 or make_s3_client()
+    s3 = s3 or s3_client()
     paginator = s3.get_paginator('list_objects_v2')
 
     for page in paginator.paginate(Bucket=bucket,
@@ -172,7 +413,7 @@ def s3_find(url, pred=None, glob=None, s3=None):
 
     bucket, prefix = s3_url_parse(url)
 
-    s3 = s3 or make_s3_client()
+    s3 = s3 or s3_client()
     paginator = s3.get_paginator('list_objects_v2')
 
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
@@ -180,104 +421,6 @@ def s3_find(url, pred=None, glob=None, s3=None):
             o = s3_file_info(o, bucket)
             if pred is not None and pred(o):
                 yield o
-
-
-def get_boto_session(region_name=None,
-                     profile=None,
-                     creds=None,
-                     cache=None):
-    """ Get botocore.session with correct region_name configured
-    """
-    if cache is not None:
-        sessions = getattr(cache, 'sessions', None)
-        if sessions is None:
-            sessions = {}
-            setattr(cache, 'sessions', sessions)
-
-        session = sessions.get(region_name)
-    else:
-        sessions, session = {}, None
-
-    if session is not None:
-        return session
-
-    session = botocore.session.Session(profile=profile)
-    _region = session.get_config_variable("region")
-
-    if creds is not None:
-        session.set_credentials(creds.access_key,
-                                creds.secret_key,
-                                creds.token)
-
-    if _region is None:
-        if region_name is None or region_name == "auto":
-            _region = auto_find_region(session)
-        else:
-            _region = region_name
-        session.set_config_variable("region", _region)
-
-    sessions[_region] = session
-
-    return session
-
-
-def get_creds_with_retry(session, max_tries=10, sleep=0.1):
-    """ Attempt to obtain credentials upto `max_tries` times with back off
-    :param session: botocore session, see get_boto_session
-    :param max_tries: number of attempt before failing and returing None
-    """
-    for i in range(max_tries):
-        if i > 0:
-            time.sleep(sleep)
-            sleep = min(sleep*2, 10)
-
-        creds = session.get_credentials()
-        if creds is not None:
-            return creds
-
-    return None
-
-
-def s3_fetch(url, s3=None, range=None, **kwargs):
-    """ Read entire or part of object into memory and return as bytes
-
-    :param url: s3://bucket/path/to/object
-    :param s3: pre-configured s3 client, see make_s3_client()
-    :param range: Byte range to read (first_byte, one_past_last_byte), default is whole object
-    """
-    if range is not None:
-        try:
-            kwargs['Range'] = s3_fmt_range(range)
-        except Exception:
-            raise ValueError('Bad range passed in: ' + str(range))
-
-    s3 = s3 or make_s3_client()
-    bucket, key = s3_url_parse(url)
-    oo = s3.get_object(Bucket=bucket, Key=key, **kwargs)
-    return oo['Body'].read()
-
-
-def s3_dump(data, url, s3=None, **kwargs):
-    """ Write data to s3 object.
-
-    :param data: bytes to write
-    :param url: s3://bucket/path/to/object
-    :param s3: pre-configured s3 client, see make_s3_client()
-    **kwargs -- Are passed on to `s3.put_object(..)`
-
-    ContentType
-    ACL
-    """
-
-    s3 = s3 or make_s3_client()
-    bucket, key = s3_url_parse(url)
-
-    r = s3.put_object(Bucket=bucket,
-                      Key=key,
-                      Body=data,
-                      **kwargs)
-    code = r['ResponseMetadata']['HTTPStatusCode']
-    return 200 <= code < 300
 
 
 def this_instance(ec2=None):
@@ -293,7 +436,7 @@ def this_instance(ec2=None):
         return None
 
     if ec2 is None:
-        session = get_boto_session()
+        session = mk_boto_session()
         if session is None:
             return None
         ec2 = session.create_client('ec2')
@@ -319,7 +462,7 @@ def read_ssm_params(params, ssm=None):
     """Build dictionary from SSM keys to values in the paramater store.
     """
     if ssm is None:
-        ssm = get_boto_session().create_client('ssm')
+        ssm = mk_boto_session().create_client('ssm')
 
     result = ssm.get_parameters(Names=[s for s in params],
                                 WithDecryption=True)
@@ -328,3 +471,33 @@ def read_ssm_params(params, ssm=None):
         raise ValueError('Failed to lookup some keys: ' + ','.join(failed))
     return {x['Name']: x['Value']
             for x in result['Parameters']}
+
+
+def thread_local_cache(name: str,
+                       initial_value: Any = None,
+                       purge: bool = False) -> Any:
+    """ Define/get thread local object with a given name.
+
+    :param name:          name for this cache
+    :param initial_value: Initial value if not set for this thread
+    :param purge:         If True delete from cache (returning what was there previously)
+
+    Returns
+    -------
+    value previously set in the thread or `initial_value`
+    """
+    absent = object()
+    cc = getattr(_LCL, name, absent)
+    absent = cc is absent
+
+    if absent:
+        cc = initial_value
+
+    if purge:
+        if not absent:
+            delattr(_LCL, name)
+    else:
+        if absent:
+            setattr(_LCL, name, cc)
+
+    return cc

--- a/libs/aws/odc/aws/__init__.py
+++ b/libs/aws/odc/aws/__init__.py
@@ -358,19 +358,19 @@ def s3_dump(data: Union[bytes, str, IO],
 # Code above is also in datacube, code below not yet
 ###########################################################################
 
-def s3_ls(url, s3=None):
+def s3_ls(url, s3=None, **kw):
     bucket, prefix = s3_url_parse(url)
 
     s3 = s3 or s3_client()
     paginator = s3.get_paginator('list_objects_v2')
 
     n_skip = len(prefix)
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix, **kw):
         for o in page.get('Contents', []):
             yield o['Key'][n_skip:]
 
 
-def s3_ls_dir(uri, s3=None):
+def s3_ls_dir(uri, s3=None, **kw):
     bucket, prefix = s3_url_parse(uri)
 
     if len(prefix) > 0 and not prefix.endswith('/'):
@@ -381,7 +381,8 @@ def s3_ls_dir(uri, s3=None):
 
     for page in paginator.paginate(Bucket=bucket,
                                    Prefix=prefix,
-                                   Delimiter='/'):
+                                   Delimiter='/',
+                                   **kw):
         sub_dirs = page.get('CommonPrefixes', [])
         files = page.get('Contents', [])
 
@@ -392,7 +393,7 @@ def s3_ls_dir(uri, s3=None):
             yield 's3://{bucket}/{path}'.format(bucket=bucket, path=o['Key'])
 
 
-def s3_find(url, pred=None, glob=None, s3=None):
+def s3_find(url, pred=None, glob=None, s3=None, **kw):
     """ List all objects under certain path
 
         each s3 object is represented by a SimpleNamespace with attributes:
@@ -416,7 +417,7 @@ def s3_find(url, pred=None, glob=None, s3=None):
     s3 = s3 or s3_client()
     paginator = s3.get_paginator('list_objects_v2')
 
-    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix, **kw):
         for o in page.get('Contents', []):
             o = s3_file_info(o, bucket)
             if pred is not None and pred(o):

--- a/libs/aws/odc/aws/dns.py
+++ b/libs/aws/odc/aws/dns.py
@@ -1,6 +1,6 @@
 """ Tools for interacting with route53
 """
-from . import get_boto_session, _fetch_text
+from . import mk_boto_session, _fetch_text
 
 
 def public_ip():
@@ -20,7 +20,7 @@ def _find_zone_id(domain, route53):
 
 def dns_update(domain, ip=None, route53=None, ttl=300):
     if route53 is None:
-        route53 = get_boto_session().create_client('route53')
+        route53 = mk_boto_session().create_client('route53')
 
     domain = domain.rstrip('.') + '.'
     zone_id = _find_zone_id(domain, route53)
@@ -48,7 +48,7 @@ def dns_update(domain, ip=None, route53=None, ttl=300):
 
 def dns_delete(domain, route53=None):
     if route53 is None:
-        route53 = get_boto_session().create_client('route53')
+        route53 = mk_boto_session().create_client('route53')
 
     domain = domain.rstrip('.') + '.'
     zone_id = _find_zone_id(domain, route53)

--- a/libs/aws/odc/aws/inventory.py
+++ b/libs/aws/odc/aws/inventory.py
@@ -4,7 +4,7 @@ from gzip import GzipFile
 import csv
 import json
 
-from . import make_s3_client, s3_fetch, s3_ls_dir
+from . import s3_client, s3_fetch, s3_ls_dir
 
 
 def find_latest_manifest(prefix, s3):
@@ -22,7 +22,7 @@ def list_inventory(manifest, s3=None, **kw):
 
     manifest -- s3:// url to manifest.json or a folder in which case latest one is chosen.
     """
-    s3 = s3 or make_s3_client(**kw)
+    s3 = s3 or s3_client(**kw)
 
     if manifest.endswith('/'):
         manifest = find_latest_manifest(manifest, s3)

--- a/notebooks/s3-inventory-example.ipynb
+++ b/notebooks/s3-inventory-example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from odc.aws import make_s3_client\n",
+    "from odc.aws import s3_client\n",
     "from odc.aws.inventory import list_inventory"
    ]
   },
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3 = make_s3_client()\n",
+    "s3 = s3_client()\n",
     "\n",
     "full_inventory = list_inventory(manifest, s3=s3)"
    ]


### PR DESCRIPTION
1. Bring code changes from `datacube-core` back into `odc-tools` (this includes support for unsigned listing)
2. Support newer `aibotocore` lib
3. Add support for unsigned requests to `odc.aio`
4. Add options to pass through arbitrary boto keywords into various s3 helper methods (needed for Request Payer)
5. Add CLI options `--no-sign-request` and `--request-payer` to `s3-find`, `s3-to-tar` and `s3-inventory-dump` tools, option names are copied from `aws` cli app.

- [x] Closes #38
