### PR TITLE
Add run-pq cli tool 

### DIFF
--- a/libs/dscache/odc/dscache/__init__.py
+++ b/libs/dscache/odc/dscache/__init__.py
@@ -1,4 +1,5 @@
 from ._dscache import (
+    TileIdx,
     DatasetCache,
     train_dictionary,
     create_cache,
@@ -16,6 +17,7 @@ __all__ = (
     'open_ro',
     'open_rw',
     'db_exists',
+    'TileIdx',
     'DatasetCache',
     'train_dictionary',
     'JsonBlobCache',

--- a/libs/dscache/odc/dscache/_dscache.py
+++ b/libs/dscache/odc/dscache/_dscache.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, List, Union, Iterator, Optional, Any, Iterable, Collection
+from typing import Tuple, Dict, List, Union, Iterator, Optional, Iterable, Collection, cast
 from uuid import UUID
 
 import toolz
@@ -97,7 +97,7 @@ def mk_group_name(idx: TileIdx, name: str = "unnamed_grid") -> str:
     elif len(idx) == 3:
         t = idx[0]
         return f"{name}/{t}/{x:+05d}/{y:+05d}"
-    raise ValueError(f"Expect index in (x, y) or (t, x, y) format")
+    raise ValueError("Expect index in (x, y) or (t, x, y) format")
 
 
 def parse_group_name(group_name: str) -> Tuple[TileIdx, str]:
@@ -118,11 +118,13 @@ def parse_group_name(group_name: str) -> Tuple[TileIdx, str]:
     try:
         prefix, *tidx = split_and_check(group_name, '/', (3, 4))
         x, y = map(int, tidx[-2:])
-        temporal = tuple(tidx[:-2])
     except ValueError:
         raise ValueError('Bad group name: ' + group_name)
 
-    return temporal + (x, y), prefix
+    if len(tidx) == 2:
+        return (x, y), prefix
+
+    return (cast(str, tidx[0]), x, y), prefix
 
 
 class DatasetCache:

--- a/libs/io/odc/io/text.py
+++ b/libs/io/odc/io/text.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union, Dict, Any, Iterator, List
+from typing import Tuple, Union, Dict, Any, Iterator, List, Optional
 from pathlib import Path
 
 PathLike = Union[str, Path]
@@ -166,5 +166,36 @@ def click_range2d(ctx, param, value):
     if value is not None:
         try:
             return parse_range2d_int(value)
+        except ValueError as e:
+            raise click.ClickException(str(e)) from None
+
+
+def parse_slice(s: str) -> slice:
+    """
+    Parse slice syntax in the form start:stop[:step]
+    Examples "::4", "2:5", "2::10", "3:100:5"
+    """
+    def parse(part: str) -> Optional[int]:
+        if part == '':
+            return None
+        return int(part)
+
+    try:
+        parts = [parse(p) for p in split_and_check(s, ':', (2, 3))]
+    except ValueError:
+        raise ValueError(f'Expect <start>:<stop>[:<step>] syntax, got "{s}"') from None
+
+    return slice(*parts)
+
+
+def click_slice(ctx, param, value):
+    """
+    @click.option('--slice', callback=click_slice)
+    Examples "::4", "2:5", "2::10", "3:100:5"
+    """
+    import click
+    if value is not None:
+        try:
+            return parse_slice(value)
         except ValueError as e:
             raise click.ClickException(str(e)) from None

--- a/libs/io/tests/test_text.py
+++ b/libs/io/tests/test_text.py
@@ -1,5 +1,5 @@
 import pytest
-from odc.io.text import parse_mtl, parse_yaml, split_and_check
+from odc.io.text import parse_mtl, parse_yaml, split_and_check, parse_slice
 
 
 def test_mtl():
@@ -82,3 +82,12 @@ def test_split_check():
 
     with pytest.raises(ValueError):
         split_and_check("a:b", ":", 3)
+
+
+def test_parse_slice():
+    from numpy import s_
+    assert parse_slice("::2") == s_[::2]
+    assert parse_slice("1:") == s_[1:]
+    assert parse_slice("1:4") == s_[1:4]
+    assert parse_slice("1:4:2") == s_[1:4:2]
+    assert parse_slice("1::2") == s_[1::2]

--- a/libs/stats/odc/stats/_cli_common.py
+++ b/libs/stats/odc/stats/_cli_common.py
@@ -1,0 +1,16 @@
+from typing import Tuple
+import click
+
+
+def parse_task(s: str) -> Tuple[str, int, int]:
+    from odc.io.text import split_and_check
+    sep = '/' if '/' in s else ','
+    t, x, y = split_and_check(s, sep, 3)
+    if t.startswith('x'):
+        t, x, y = y, t, x
+    return (t, int(x.lstrip('x')), int(y.lstrip('y')))
+
+
+@click.group(help="Stats command line interface")
+def main():
+    pass

--- a/libs/stats/odc/stats/_cli_common.py
+++ b/libs/stats/odc/stats/_cli_common.py
@@ -1,14 +1,56 @@
-from typing import Tuple
+from typing import Tuple, List
 import click
 
+TileIdx = Tuple[str, int, int]
 
-def parse_task(s: str) -> Tuple[str, int, int]:
+
+def parse_task(s: str) -> TileIdx:
     from odc.io.text import split_and_check
     sep = '/' if '/' in s else ','
     t, x, y = split_and_check(s, sep, 3)
     if t.startswith('x'):
         t, x, y = y, t, x
     return (t, int(x.lstrip('x')), int(y.lstrip('y')))
+
+
+def parse_all_tasks(inputs: List[str], all_possible_tasks: List[TileIdx]) -> List[TileIdx]:
+    """
+    Select a subset of all possible tasks given user input on cli.
+
+    Every input task can be one of:
+     <int>                   -- 0 based index into all_possible_tasks list
+
+     <start>:<stop>[:<step>] -- slice of all_possible_tasks, 1:100, ::10, 1::100, -10:
+
+     t,x,y or x,y,t triplet  -- Task index as a triplet of period,x,y
+       2019--P1Y/10/-3
+       2019--P1Y,10,-3
+       x+10/y-3/2019--P1Y
+    """
+    from odc.io.text import parse_slice
+    out: List[TileIdx] = []
+    full_set = set(all_possible_tasks)
+
+    for s in inputs:
+        if ',' in s or '/' in s:
+            task = parse_task(s)
+            if task not in full_set:
+                raise ValueError(f"No task matches '{s}'")
+            out.append(task)
+        elif ':' in s:
+            ii = parse_slice(s)
+            out.extend(all_possible_tasks[ii])
+        else:
+            try:
+                idx = int(s)
+            except ValueError:
+                raise ValueError(f"Failed to parse '{s}'") from None
+
+            if idx < 0 or idx >= len(all_possible_tasks):
+                raise ValueError(f"Task index is out of range: {idx}")
+            out.append(all_possible_tasks[idx])
+
+    return out
 
 
 @click.group(help="Stats command line interface")

--- a/libs/stats/odc/stats/_pq.py
+++ b/libs/stats/odc/stats/_pq.py
@@ -1,0 +1,50 @@
+"""
+Sentinel 2 pixel quality stats
+"""
+import xarray as xr
+
+from odc.stats.model import Task
+from odc.algo.io import load_with_native_transform
+from odc.algo import enum_to_bool
+
+bad_pixel_classes = (0, 'saturated or defective')
+cloud_classes = ('cloud shadows',
+                 'cloud medium probability',
+                 'cloud high probability',
+                 'thin cirrus')
+
+
+def _pq_native_transform(xx):
+    """
+    config:
+    bad_pixel_classes
+    cloud_classes
+    """
+
+    valid = enum_to_bool(xx.SCL, bad_pixel_classes, invert=True, value_true=255, dtype='uint8')
+    clear = enum_to_bool(xx.SCL, bad_pixel_classes+cloud_classes, invert=True, value_true=255, dtype='uint8')
+    return xr.Dataset(dict(valid=valid, clear=clear))
+
+
+def pq_input_data(task: Task, resampling: str) -> xr.Dataset:
+    """
+    .valid  Bool
+    .clear  Bool
+    """
+    xx = load_with_native_transform(task.datasets,
+                                    ['SCL'],
+                                    task.geobox,
+                                    _pq_native_transform,
+                                    groupby='solar_day',
+                                    resampling=resampling,
+                                    chunks={'x': 4800, 'y': 4800})
+    return xx > 127
+
+
+def pq_reduce(xx: xr.Dataset) -> xr.Dataset:
+    """
+    """
+    pq = xr.Dataset(dict(clear=xx.clear.sum(axis=0, dtype='uint16'),
+                         total=xx.valid.sum(axis=0, dtype='uint16')))
+
+    return pq

--- a/libs/stats/odc/stats/_pq_cli.py
+++ b/libs/stats/odc/stats/_pq_cli.py
@@ -1,0 +1,141 @@
+import sys
+import click
+from ._cli_common import main, parse_task
+
+
+@main.command('run-pq')
+@click.option('--verbose', '-v', is_flag=True, help='Be verbose')
+@click.option('--threads', type=int, help='Number of worker threads', default=0)
+@click.option('--dryrun', is_flag=True, help='Do not run computation just print what work will be done')
+@click.option('--overwrite', is_flag=True, help='Do not check if output already exists')
+@click.argument('cache_file', type=str, nargs=1)
+@click.argument('tasks', type=str, nargs=-1)
+def run_pq(cache_file, tasks, dryrun, verbose, threads, overwrite):
+    """
+    Run Pixel Quality stats
+
+    \b
+    Each task is a comma-separated triplet: period,x,y
+       2019--P1Y,+003,-004
+       2019--P1Y/3/-4          `/` is also accepted
+       x+003/y-004/2019--P1Y   is accepted as well
+    """
+    from tqdm.auto import tqdm
+    from functools import partial
+    from odc.dscache import open_ro
+    from .io import S3COGSink
+    from ._pq import pq_input_data, pq_reduce
+    from .metadata import load_task, clear_pixel_count_product
+    from .proc import process_tasks
+    from datacube.utils.dask import start_local_dask
+    from datacube.utils.rio import configure_s3_access
+
+    # config
+    resampling = 'nearest'
+    COG_OPTS = dict(compress='deflate',
+                    predict=2,
+                    zlevel=6,
+                    blocksize=512)
+    # ..
+
+    cache = open_ro(cache_file)
+    cfg = cache.get_info_dict('stats/config')
+    if verbose:
+        print(cfg)
+
+    grid = cfg['grid']
+    gs = cache.grids[grid]
+    pq_product = clear_pixel_count_product(gs)
+
+    def get_task(tidx):
+        return load_task(cache, tidx, pq_product, grid)
+
+    def pq_proc(task):
+        ds_in = pq_input_data(task, resampling=resampling)
+        ds = pq_reduce(ds_in)
+        return ds
+
+    def dry_run_proc(task, sink, check_s3=False):
+        uri = sink.uri(task)
+        exists = None
+        if check_s3:
+            exists = sink.exists(task)
+
+        nds = len(task.datasets)
+        ndays = len(set(ds.center_time.date() for ds in task.datasets))
+
+        if overwrite:
+            flag = {None: '',
+                    True: ' (recompute)',
+                    False: ' (new)'}[exists]
+        else:
+            flag = {None: '',
+                    True: ' (skip)',
+                    False: ' (new)'}[exists]
+
+        task_id = f"{task.short_time}/{task.tile_index[0]:+05d}/{task.tile_index[1]:+05d}"
+        print(f"{task_id} days={ndays:03} ds={nds:04} {uri}{flag}")
+
+        return uri
+
+    all_tasks = sorted(idx for idx, _ in cache.tiles(grid))
+
+    if len(tasks) == 0:
+        tasks = all_tasks
+        if verbose:
+            print(f"Found {len(tasks):,d} tasks in the file")
+    else:
+        try:
+            tasks = [parse_task(t) for t in tasks]
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
+
+        all_tasks_set = set(all_tasks)
+        for t in tasks:
+            if t not in all_tasks_set:
+                print(f"No such task: {t}")
+                sys.exit(2)
+        del all_tasks_set
+
+    sink = S3COGSink(cog_opts=COG_OPTS)
+    if verbose:
+        creds_rw = sink._creds
+        print(f'creds: ..{creds_rw.access_key[-5:]} ..{creds_rw.secret_key[-5:]}')
+
+    _tasks = map(get_task, tasks)
+
+    client = None
+    if not dryrun:
+        if verbose:
+            print("Starting local Dask cluster")
+
+        client = start_local_dask(threads_per_worker=threads,
+                                  mem_safety_margin='1G')
+
+        # TODO: aws_unsigned is not always desirable
+        configure_s3_access(aws_unsigned=True,
+                            cloud_defaults=True,
+                            client=client)
+        if verbose:
+            print(client)
+
+    if dryrun:
+        results = map(partial(dry_run_proc, sink=sink, check_s3=not overwrite),
+                      _tasks)
+    else:
+        results = process_tasks(_tasks, pq_proc, client, sink,
+                                check_exists=not overwrite,
+                                verbose=verbose)
+    if not dryrun and verbose:
+        results = tqdm(results, total=len(tasks))
+
+    for p in results:
+        if verbose and not dryrun:
+            print(p)
+
+    if verbose:
+        print("Exiting")
+
+    if client is not None:
+        client.close()

--- a/libs/stats/odc/stats/cli.py
+++ b/libs/stats/odc/stats/cli.py
@@ -6,6 +6,8 @@ import pickle
 from datetime import datetime
 from collections import namedtuple
 from odc.io.text import click_range2d
+from ._cli_common import main
+from . import _pq_cli
 
 CompressedDataset = namedtuple("CompressedDataset", ['id', 'time'])
 
@@ -14,11 +16,6 @@ def is_tile_in(tidx, tiles):
     (x0, x1), (y0, y1) = tiles
     x, y = tidx
     return (x0 <= x < x1) and (y0 <= y < y1)
-
-
-@click.group(help="Stats command line interface")
-def main():
-    pass
 
 
 @main.command('save-tasks')

--- a/libs/stats/odc/stats/cli.py
+++ b/libs/stats/odc/stats/cli.py
@@ -109,7 +109,9 @@ def save_tasks(grid, year, period,
         return CompressedDataset(ds.id, ds.center_time)
 
     def out_path(suffix, base=output):
-        return base.rstrip(".db") + suffix
+        if base.endswith(".db"):
+            base = base[:-3]
+        return base + suffix
 
     def sanitize_query(query):
         def sanitize(v):

--- a/libs/stats/odc/stats/cli.py
+++ b/libs/stats/odc/stats/cli.py
@@ -225,7 +225,7 @@ def save_tasks(grid, year, period,
     csv_path = out_path(".csv")
     print(f"Writing summary to {csv_path}")
     with open(csv_path, 'wt') as f:
-        f.write('"Period", "X", "Y", "datasets", "days"\n')
+        f.write('"Period","X","Y","datasets","days"\n')
 
         for p, x, y in sorted(tasks):
             dss = tasks[(p, x, y)]

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -69,8 +69,11 @@ class S3COGSink:
         self._meta_contentype = 'application/json'
         self._band_ext = 'tiff'
 
+    def uri(self, task: Task) -> str:
+        return task.metadata_path('absolute', ext=self._meta_ext)
+
     def exists(self, task: Task) -> bool:
-        uri = task.metadata_path('absolute', ext=self._meta_ext)
+        uri = self.uri(task)
         s3 = s3_client(creds=self._creds, cache=True)
         meta = s3_head_object(uri, s3=s3)
         return meta is not None

--- a/libs/stats/odc/stats/metadata.py
+++ b/libs/stats/odc/stats/metadata.py
@@ -36,34 +36,6 @@ def gs_bounds(gs: GridSpec, tiles: Tuple[Tuple[int, int],
     return polygon_from_transform(nx, ny, gb.affine, gb.crs)
 
 
-def clear_pixel_count_product(gridspec: GridSpec, location=None) -> OutputProduct:
-    name = 'ga_s2_clear_pixel_count'
-    short_name = 'ga_s2_cpc'
-    version = '0.0.0'
-
-    if location is None:
-        bucket = 'deafrica-stats-processing'
-        location = f's3://{bucket}/{name}/v{version}'
-
-    measurements = ('clear', 'total')
-
-    properties = {
-        'odc:file_format': 'GeoTIFF',
-        'odc:producer': 'ga.gov.au',
-        'odc:product_family': 'pixel_quality_statistics'
-    }
-
-    return OutputProduct(name=name,
-                         version=version,
-                         short_name=short_name,
-                         location=location,
-                         properties=properties,
-                         measurements=measurements,
-                         gridspec=gridspec,
-                         href=f'https://collections.digitalearth.africa/product/{name}',
-                         freq='1Y')
-
-
 def load_task(cache: dscache.DatasetCache,
               tile_index: TileIdx_txy,
               product: OutputProduct,

--- a/libs/stats/odc/stats/metadata.py
+++ b/libs/stats/odc/stats/metadata.py
@@ -1,14 +1,15 @@
 import math
 from copy import deepcopy
 import toolz
-from typing import Tuple, Dict, Any, Union
-from datetime import datetime, timedelta
+from typing import Tuple, Dict, Any
+from datetime import timedelta
 
 from datacube.model import GridSpec
 from datacube.utils.geometry import polygon_from_transform, Geometry
 from odc import dscache
 from odc.index import solar_offset
 from .model import OutputProduct, Task, DateTimeRange, TileIdx, TileIdx_xy, TileIdx_txy
+
 
 def _xy(tidx: TileIdx) -> TileIdx_xy:
     return tidx[-2:]
@@ -35,13 +36,15 @@ def gs_bounds(gs: GridSpec, tiles: Tuple[Tuple[int, int],
     return polygon_from_transform(nx, ny, gb.affine, gb.crs)
 
 
-def clear_pixel_count_product(gridspec: GridSpec) -> OutputProduct:
+def clear_pixel_count_product(gridspec: GridSpec, location=None) -> OutputProduct:
     name = 'ga_s2_clear_pixel_count'
-    short_name = 'deafrica_s2_cpc'
+    short_name = 'ga_s2_cpc'
     version = '0.0.0'
 
-    bucket_name = 'deafrica-stats-processing'
-    location = f's3://{bucket_name}/{name}/v{version}'
+    if location is None:
+        bucket = 'deafrica-stats-processing'
+        location = f's3://{bucket}/{name}/v{version}'
+
     measurements = ('clear', 'total')
 
     properties = {

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -1,0 +1,91 @@
+from typing import Iterable, Iterator, Callable, Optional, List, Set, Any, Tuple
+import dask.distributed
+from dask.distributed import Client, wait as dask_wait
+import xarray as xr
+
+from .model import Task
+from .io import S3COGSink
+
+Future = Any
+
+
+def drain(futures: Set[Future],
+          timeout: Optional[float] = None) -> Tuple[List[str], Set[Future]]:
+    return_when = 'FIRST_COMPLETED'
+    if timeout is None:
+        return_when = 'ALL_COMPLETED'
+
+    try:
+        rr = dask_wait(futures, timeout=timeout, return_when=return_when)
+    except dask.distributed.TimeoutError:
+        return [], futures
+
+    done: List[str] = []
+    for f in rr.done:
+        try:
+            path, ok = f.result()
+            if ok:
+                done.append(path)
+            else:
+                print(f"Failed to write: {path}")
+        except Exception as e:
+            print(e)
+
+    return done, rr.not_done
+
+
+def _with_lookahead1(it: Iterable[Any]) -> Iterator[Any]:
+    NOT_SET = object()
+    prev = NOT_SET
+    for x in it:
+        if prev is not NOT_SET:
+            yield prev
+        prev = x
+    if prev is not NOT_SET:
+        yield prev
+
+
+def process_tasks(tasks: Iterable[Task],
+                  proc: Callable[[Task], xr.Dataset],
+                  client: Client,
+                  sink: S3COGSink,
+                  check_exists: bool = True,
+                  verbose: bool = True) -> Iterator[str]:
+
+    def prep_stage(tasks: Iterable[Task],
+                   proc: Callable[[Task], xr.Dataset]) -> Iterator[Tuple[Optional[xr.Dataset], Task, str]]:
+        for task in tasks:
+            path = sink.uri(task)
+            if check_exists:
+                if sink.exists(task):
+                    yield (None, task, path)
+                    continue
+
+            ds = proc(task)
+            yield (ds, task, path)
+
+    in_flight_cogs: Set[Future] = set()
+    for ds, task, path in _with_lookahead1(prep_stage(tasks, proc)):
+        if ds is None:
+            if verbose:
+                print(f"..skipping: {path} (exists already)")
+            yield path
+            continue
+
+        ds = client.persist(ds, fifo_timeout='1ms')
+
+        if len(in_flight_cogs):
+            done, in_flight_cogs = drain(in_flight_cogs, 1.0)
+            for r in done:
+                yield r
+
+        cog = client.compute(sink.dump(task, ds),
+                             fifo_timeout='1ms')
+        rr = dask_wait(ds)
+        assert len(rr.not_done) == 0
+        del ds, rr
+        in_flight_cogs.add(cog)
+
+    done, _ = drain(in_flight_cogs)
+    for r in done:
+        yield r

--- a/libs/stats/tests/test_stats_model.py
+++ b/libs/stats/tests/test_stats_model.py
@@ -1,4 +1,5 @@
 from odc.stats.model import DateTimeRange
+from odc.stats._cli_common import parse_task
 from datetime import datetime, timedelta
 
 
@@ -41,3 +42,10 @@ def test_dt_range():
 
     assert DateTimeRange.year(2000) + 1 == DateTimeRange.year(2001)
     assert DateTimeRange.year(2000) - 1 == DateTimeRange.year(1999)
+
+
+def test_parse_task():
+    assert parse_task("2017--P1Y/3/4") == ('2017--P1Y', 3, 4)
+    assert parse_task("2017--P1Y,+3,+004") == ('2017--P1Y', 3, 4)
+    assert parse_task("2017--P1Y,x+3,y+004") == ('2017--P1Y', 3, 4)
+    assert parse_task("x+003/y-004/2018--P3Y") == ('2018--P3Y', 3, -4)


### PR DESCRIPTION
```
Usage: odc-stats run-pq [OPTIONS] CACHE_FILE [TASKS]...

  Run Pixel Quality stats

  Task could be one of the 3 things

  1. Comma-separated triplet: period,x,y or 'x[+-]<int>/y[+-]<int>/period
     2019--P1Y,+003,-004
     2019--P1Y/3/-4          `/` is also accepted
     x+003/y-004/2019--P1Y   is accepted as well
  2. A zero based index
  3. A slice following python convention <start>:<stop>[:<step]
      ::10 -- every tenth task: 0,10,20,..
     1::10 -- every tenth but skip first one 1, 11, 21 ..
      :100 -- first 100 tasks

  If no tasks are supplied whole file be processed.

Options:
  -v, --verbose      Be verbose
  --threads INTEGER  Number of worker threads
  --dryrun           Do not run computation just print what work will be done
  --overwrite        Do not check if output already exists
  --location TEXT    Output location prefix as a uri: s3://bucket/path/
  --help             Show this message and exit.
```