### PR TITLE
Chunked processing of Geomedian

### DIFF
--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -26,6 +26,8 @@ from ._geomedian import (
 
 from ._dask import (
     chunked_persist,
+    chunked_persist_ds,
+    chunked_persist_da,
     randomize,
 )
 
@@ -57,6 +59,8 @@ __all__ = (
     "int_geomedian_np",
     "reshape_for_geomedian",
     "chunked_persist",
+    "chunked_persist_da",
+    "chunked_persist_ds",
     "randomize",
     "is_rgb",
     "to_rgba",

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -48,6 +48,14 @@ def chunked_persist(data, n_concurrent, client, verbose=False):
     return client.persist(data)
 
 
+def chunked_persist_da(xx: xr.DataArray, n_concurrent, client, verbose=False) -> xr.DataArray:
+    data = chunked_persist(xx.data,
+                           n_concurrent,
+                           client=client,
+                           verbose=verbose)
+    return xr.DataArray(data, dims=xx.dims, coords=xx.coords, attrs=xx.attrs)
+
+
 def chunked_persist_ds(xx: xr.Dataset, client, verbose: bool = False) -> xr.Dataset:
     names = list(xx.data_vars)
     data = [xx[n].data for n in names]

--- a/libs/algo/odc/algo/_geomedian.py
+++ b/libs/algo/odc/algo/_geomedian.py
@@ -174,7 +174,12 @@ def int_geomedian_np(*bands,
     return gm_int
 
 
-def int_geomedian(ds, scale=1, offset=0, wk_rows=-1, **kw):
+def int_geomedian(ds,
+                  scale=1,
+                  offset=0,
+                  wk_rows=-1,
+                  as_array=False,
+                  **kw):
     """ ds -- xr.Dataset (possibly dask) with dims: (time, y, x) for each band
 
         on output time dimension is removed
@@ -183,6 +188,7 @@ def int_geomedian(ds, scale=1, offset=0, wk_rows=-1, **kw):
     :param scale: Normalize data for running computation (output is scaled back to original values)
     :param offset: ``(x*scale + offset)``
     :param wk_rows: reduce memory requirements by processing that many rows of a chunk at a time
+    :param as_array: If set to True return DataArray with band dimension instead of Dataset
     :param kw: Passed on to hdstats (eps=1e-4, num_threads=1, maxiters=10_000, nocheck=True)
 
     """
@@ -234,8 +240,12 @@ def int_geomedian(ds, scale=1, offset=0, wk_rows=-1, **kw):
     cc = {k: xx.coords[k] for k in dims[1:]}
     cc['band'] = band_names
 
-    ds_out = xr.DataArray(data, dims=dims, coords=cc).to_dataset(dim='band')
+    da_out = xr.DataArray(data, dims=dims, coords=cc)
 
+    if as_array:
+        return da_out
+
+    ds_out = da_out.to_dataset(dim='band')
     ds_out.attrs.update(ds.attrs)
     for b in ds.data_vars.keys():
         src, dst = ds[b], ds_out[b]

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -1,10 +1,9 @@
 """
 Sentinel-2 Geomedian
 """
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 import xarray as xr
 
-from datacube.model import GridSpec
 from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
 from odc.algo import enum_to_bool, int_geomedian, keep_good_only
@@ -86,12 +85,16 @@ def gm_input_data(task: Task, resampling: str, chunk: int = 1600) -> xr.Dataset:
     return xx
 
 
-def gm_reduce(xx: xr.Dataset, num_threads=4) -> xr.Dataset:
+def gm_reduce(xx: xr.Dataset,
+              num_threads: int = 4,
+              wk_rows: int = 64,
+              as_array: bool = False) -> Union[xr.Dataset, xr.DataArray]:
     """
     """
     return int_geomedian(xx,
                          scale=1/10_000,
-                         wk_rows=16*4,
+                         wk_rows=wk_rows,
+                         as_array=as_array,
                          eps=1e-4,
                          num_threads=num_threads,
                          maxiters=1_000)

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -70,18 +70,22 @@ def _gm_native_transform(xx: xr.Dataset) -> xr.Dataset:
     return xx
 
 
-def gm_input_data(task: Task, resampling: str, chunk: int = 1600) -> xr.Dataset:
+def gm_input_data(task: Task, resampling: str, chunk: Union[int, Tuple[int, int]] = 1600) -> xr.Dataset:
     """
     .valid  Bool
     .clear  Bool
     """
+    if isinstance(chunk, int):
+        chunk = (chunk, chunk)
+
     xx = load_with_native_transform(task.datasets,
                                     ['SCL', *task.product.measurements],
                                     task.geobox,
                                     _gm_native_transform,
                                     groupby='solar_day',
                                     resampling=resampling,
-                                    chunks={'x': chunk, 'y': chunk})
+                                    chunks={'y': chunk[0],
+                                            'x': chunk[1]})
     return xx
 
 


### PR DESCRIPTION
Force Dask to process 1/6 of an image at a time when computing Geomedian.

Settings as hard-coded in the CLI are for 9600x9600 Sentinel2 with 10 bands running on 256G instance with 32 cores.

Run with `--threads=40` to increase compute density (it's mostly waiting for IO)