### PR TITLE
Improvements to stac-to-eo3 conversion

### DIFF
--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -37,7 +37,7 @@ def _stac_product_lookup(item: Document) -> Tuple[Optional[str], str, Optional[s
     properties = item['properties']
 
     product_label = None
-    product_name = properties['platform']
+    product_name = properties.pop('odc:product', None) or properties['platform']
     region_code = None
     default_grid = None
 
@@ -57,7 +57,6 @@ def _stac_product_lookup(item: Document) -> Tuple[Optional[str], str, Optional[s
     elif properties.get('platform') in LANDSAT_PLATFORMS:
         self_href = _find_self_href(item)
         product_label = Path(self_href).stem.replace(".stac-item", "")
-        product_name = properties.get('odc:product')
         region_code = properties.get('odc:region_code')
         default_grid = "g30m"
 

--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -167,7 +167,12 @@ def _get_stac_properties_lineage(input_stac: Document) -> Tuple[Document, Any]:
     prop = {MAPPING_STAC_TO_EO3.get(key, key): _convert_value_to_eo3_type(key, val)
             for key, val in properties.items()}
     if prop.get('odc:processing_datetime') is None:
-        prop['odc:processing_datetime'] = properties['datetime'].replace("000+00:00", "Z")
+        prop['odc:processing_datetime'] = (
+            # Stac's 'created' property.
+            prop.pop('created', None) or
+            # TODO: This is not ideal. Perhaps the file ctime?
+            properties['datetime'].replace("000+00:00", "Z")
+        )
     if prop.get('odc:file_format') is None:
         prop['odc:file_format'] = 'GeoTIFF'
 


### PR DESCRIPTION
See this PR on eodatasets3 eo3-to-stac converter for some context: https://github.com/GeoscienceAustralia/eo-datasets/pull/98

- Use stac 'created' field as the odc:prodocessed_datetime if available instead of duplicating the dataset datetime.
- Support the stac 'title' field as the output dataset label (but don't use it for the stable uuid generation)
- Avoid putting raw UUIDs in the dataset label (the field is optional and shouldn't be set if just a uuid)
- Fix landsat 8 OLI_TIRS datasets being recorded as only OLI (it was always throwing away all but the first instrument in the list)

(the 'created' and 'title' fields were requested by DEA Access.)

I've tested this on our Landsat products by doing a round trip conversion:

```bash
$ eo3-to-stac ga_ls5t_ard_3-1-20200605_113081_1988-03-30_final.odc-metadata.yaml
$ python stac_to_eo3.py ga_ls5t*.stac-item.json
$ eo3-to-stac ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml
$ python stac_to_eo3.py ga_ls8c*.stac-item.json
```

Further test cases are welcome -- I'm not sure what some of it is doing.

---

# Known Issues

The round-trip-diff shows a few outstanding things that aren't converted by this tool, but they're unrelated to getting the above PR merged so I haven't addressed them here.

Here's what the diff looks like on a Landsat 8 document after these changes:

(left is the original eo3, right is after conversion and back again)

![Screenshot_2020-10-09 Diff Checker](https://user-images.githubusercontent.com/25688/95534478-b7e75b00-0a31-11eb-901a-14196d667a5d.png)

- I'd like to look at those hard-coded product exceptions in this file at some point -- I deliberately avoided changing their behaviour in this PR.