### PR TITLE
Address overview block size issue

### DIFF
--- a/libs/algo/setup.py
+++ b/libs/algo/setup.py
@@ -24,6 +24,7 @@ setup(
         'xarray',
         'numpy',
         'toolz',
+        'hdstats',
         'odc-index',
         'datacube',
         'scikit-image',

--- a/libs/stats/k8s/runme.sh
+++ b/libs/stats/k8s/runme.sh
@@ -4,5 +4,5 @@ exec odc-stats run-gm tasks.db \
   --verbose \
   --public \
   --threads 40 \
-  --location s3://deafrica-stats-processing/kk/gm-0910/ \
+  --location s3://deafrica-stats-processing/kk/gm-1210/ \
   $@

--- a/libs/stats/k8s/stats-scratch.yaml
+++ b/libs/stats/k8s/stats-scratch.yaml
@@ -31,7 +31,7 @@ spec:
                 - memory-optimised-r5-8xl
       containers:
       - name: sandbox
-        image: 565417506782.dkr.ecr.us-west-2.amazonaws.com/statistician:0.0.10-24-gd703139
+        image: 565417506782.dkr.ecr.us-west-2.amazonaws.com/statistician:0.0.10-25-gba266b9
         imagePullPolicy: IfNotPresent
 
         resources:

--- a/libs/stats/odc/stats/_cli_run_gm.py
+++ b/libs/stats/odc/stats/_cli_run_gm.py
@@ -55,7 +55,9 @@ def run_gm(cache_file, tasks, dryrun, verbose, threads, x_chunks, y_chunks, over
     COG_OPTS = dict(compress='deflate',
                     predict=2,
                     zlevel=6,
-                    blocksize=800)
+                    blocksize=800,
+                    ovr_blocksize=256,  # ovr_blocksize must be powers of 2 for some reason in GDAL
+                    overview_resampling='bilinear')
     ncpus = psutil.cpu_count()
     # ..
 


### PR DESCRIPTION
Turns out that GDAL only likes powers of 2 for tile sizes within overview images, even though TIFF allows for any multiple of 16...
So configuring ovr_blocksize to be 256.
Adding `hdstats` as a dependency of `odc-algo`
Tweaking deployment also
