### PR TITLE
Fix wrong resolution reads in geomedian + minor cleanups

### DIFF
--- a/libs/stats/k8s/stats-scratch.yaml
+++ b/libs/stats/k8s/stats-scratch.yaml
@@ -20,11 +20,6 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: nodetype
-                operator: In
-                values:
-                - spot
-            - matchExpressions:
               - key: nodegroup
                 operator: In
                 values:

--- a/libs/stats/k8s/stats-scratch.yaml
+++ b/libs/stats/k8s/stats-scratch.yaml
@@ -26,7 +26,7 @@ spec:
                 - memory-optimised-r5-8xl
       containers:
       - name: sandbox
-        image: 565417506782.dkr.ecr.us-west-2.amazonaws.com/statistician:0.0.10-25-gba266b9
+        image: 565417506782.dkr.ecr.us-west-2.amazonaws.com/statistician:0.0.10-26-ge5642c6
         imagePullPolicy: IfNotPresent
 
         resources:
@@ -84,6 +84,10 @@ spec:
                 [ -f /build.info ] && cat /build.info
 
                 aws s3 cp "${TASK_DB_S3}" tasks.db
+
+                (git clone https://github.com/opendatacube/odc-tools.git -b stats \
+                 && cd odc-tools \
+                 && ./scripts/dev-install.sh)
 
                 while true ; do
                    for i in {1..10}; do

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -71,19 +71,23 @@ def _gm_native_transform(xx: xr.Dataset) -> xr.Dataset:
     return xx
 
 
-def gm_input_data(task: Task, resampling: str, chunk: Union[int, Tuple[int, int]] = 1600) -> xr.Dataset:
+def gm_input_data(task: Task, resampling: str, chunk: Union[int, Tuple[int, int]] = 1600,
+                  basis: Optional[str] = None) -> xr.Dataset:
     """
     .valid  Bool
     .clear  Bool
     """
     if isinstance(chunk, int):
         chunk = (chunk, chunk)
+    if basis is None:
+        basis = task.product.measurements[0]
 
     xx = load_with_native_transform(task.datasets,
-                                    ['SCL', *task.product.measurements],
+                                    [*task.product.measurements, 'SCL'],
                                     task.geobox,
                                     _gm_native_transform,
                                     groupby='solar_day',
+                                    basis=basis,
                                     resampling=resampling,
                                     chunks={'y': chunk[0],
                                             'x': chunk[1]})

--- a/libs/stats/odc/stats/_pq.py
+++ b/libs/stats/odc/stats/_pq.py
@@ -4,7 +4,6 @@ Sentinel 2 pixel quality stats
 from typing import Optional
 import xarray as xr
 
-from datacube.model import GridSpec
 from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
 from odc.algo import enum_to_bool

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -123,7 +123,7 @@ class S3COGSink:
             uri = self.uri(task)
         _u = urlparse(uri)
         if _u.scheme == 's3':
-            s3 = s3_client(creds=self._creds, cache=True)
+            s3 = s3_client(creds=self._get_creds(), cache=True)
             meta = s3_head_object(uri, s3=s3)
             return meta is not None
         elif _u.scheme == 'file':

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -2,7 +2,7 @@
 Various I/O adaptors
 """
 
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Union
 import json
 from urllib.parse import urlparse
 from dask.delayed import Delayed
@@ -41,7 +41,7 @@ def dump_json(meta: Dict[str, Any]) -> str:
 
 class S3COGSink:
     def __init__(self,
-                 creds: Optional[ReadOnlyCredentials] = None,
+                 creds: Union[ReadOnlyCredentials, str, None] = None,
                  cog_opts: Optional[Dict[str, Any]] = None,
                  public: bool = False):
 
@@ -61,6 +61,8 @@ class S3COGSink:
     def _get_creds(self) -> ReadOnlyCredentials:
         if self._creds is None:
             self._creds = load_creds()
+        if isinstance(self._creds, str):
+            self._creds = load_creds(self._creds)
         return self._creds
 
     def verify_s3_credentials(self, test_uri: Optional[str] = None) -> bool:

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -116,8 +116,11 @@ class S3COGSink:
         cog_bytes = to_cog(da, **self._cog_opts)
         return self._write_blob(cog_bytes, url, ContentType='image/tiff')
 
-    def exists(self, task: Task) -> bool:
-        uri = self.uri(task)
+    def exists(self, task: Union[Task, str]) -> bool:
+        if isinstance(task, str):
+            uri = task
+        else:
+            uri = self.uri(task)
         _u = urlparse(uri)
         if _u.scheme == 's3':
             s3 = s3_client(creds=self._creds, cache=True)

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 from uuid import UUID
 
 import pandas as pd
-from datacube.model import Dataset, GridSpec
+from datacube.model import Dataset
 from datacube.utils.dates import normalise_dt
 from datacube.utils.geometry import GeoBox
 from odc.index import odc_uuid
@@ -245,7 +245,7 @@ class Task:
         region_code = product.region_code(self.tile_index)
         inputs = list(map(str, self._lineage()))
 
-        properties = deepcopy(product.properties)
+        properties: Dict[str, Any] = deepcopy(product.properties)
 
         properties.update(self.time_range.to_stac())
         properties['odc:processing_datetime'] = format_datetime(processing_dt, timespec='seconds')
@@ -263,8 +263,7 @@ class Task:
                 ],
                 'href': path,
                 'proj:shape': geobox.shape,
-                'proj:transform': geobox.transform
-                }
+                'proj:transform': geobox.transform}
             for band, path in self.paths(ext=ext).items()
         }
 


### PR DESCRIPTION
Turns out that Geomedian code produced Dask graph that read all the bands at the resolution of the SCL band (20m), resulting in a blurry output. Change: use first data band to determine "native load" input resolution.

Some interface improvements in S3COGSink: accept arbitrary url as well as Task for `.exists`, add `write_cog` function so that auxilary data, like RGBA previews can be written as a separate post-processing step.

