### PR TITLE
Various minor fixes

### DIFF
--- a/libs/aio/odc/aio/__init__.py
+++ b/libs/aio/odc/aio/__init__.py
@@ -305,6 +305,7 @@ class S3Fetcher(object):
                  addressing_style='path',
                  aws_unsigned=None):
 
+        self._closed = True
         if region_name is None:
             region_name = auto_find_region()
 
@@ -324,7 +325,6 @@ class S3Fetcher(object):
         self._s3 = None
         self._s3_ctx = None
         self._session = None
-        self._closed = False
 
         async def setup(s3_cfg):
             session = aiobotocore.get_session()
@@ -335,6 +335,7 @@ class S3Fetcher(object):
             return (session, s3, s3_ctx)
 
         session, s3, s3_ctx = self._async.submit(setup, s3_cfg).result()
+        self._closed = False
         self._session = session
         self._s3 = s3
         self._s3_ctx = s3_ctx

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -97,7 +97,7 @@ def unpack_chunksize(chunk: int, N: int) -> Tuple[int, ...]:
     Compute chunk sizes
     Example: 4, 11 -> (4, 4, 3)
     """
-    if chunk >= N:
+    if chunk >= N or chunk < 0:
         return (N,)
 
     nb = N//chunk

--- a/libs/algo/odc/algo/_warp.py
+++ b/libs/algo/odc/algo/_warp.py
@@ -102,7 +102,8 @@ def dask_reproject(src: da.Array,
     assert dims2 == ()
     deps = [src]
 
-    gbt = GeoboxTiles(dst_geobox, chunks)
+    tile_shape = (yx_chunks[0][0], yx_chunks[1][0])
+    gbt = GeoboxTiles(dst_geobox, tile_shape)
     xy_chunks_with_data = list(gbt.tiles(src_geobox.extent))
 
     name = randomize(name)

--- a/libs/algo/odc/algo/_warp.py
+++ b/libs/algo/odc/algo/_warp.py
@@ -179,7 +179,10 @@ def xr_reproject_array(src: xr.DataArray,
     dst_dims = src_dims[:axis] + geobox.dims + src_dims[axis+2:]
 
     coords = geobox.xr_coords(with_crs=True)
-    for dim in src_dims:
+
+    # copy non-spatial coords from src to dst
+    src_non_spatial_dims = src_dims[:axis] + src_dims[axis+2:]
+    for dim in src_non_spatial_dims:
         if dim not in coords:
             coords[dim] = src.coords[dim]
 

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -1,7 +1,7 @@
 """
 Sentinel-2 Geomedian
 """
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, Dict
 import xarray as xr
 
 from odc.stats.model import Task
@@ -72,7 +72,8 @@ def _gm_native_transform(xx: xr.Dataset) -> xr.Dataset:
 
 
 def gm_input_data(task: Task, resampling: str, chunk: Union[int, Tuple[int, int]] = 1600,
-                  basis: Optional[str] = None) -> xr.Dataset:
+                  basis: Optional[str] = None,
+                  load_chunks: Optional[Dict[str, int]] = None) -> xr.Dataset:
     """
     .valid  Bool
     .clear  Bool
@@ -90,7 +91,8 @@ def gm_input_data(task: Task, resampling: str, chunk: Union[int, Tuple[int, int]
                                     basis=basis,
                                     resampling=resampling,
                                     chunks={'y': chunk[0],
-                                            'x': chunk[1]})
+                                            'x': chunk[1]},
+                                    load_chunks=load_chunks)
     return xx
 
 


### PR DESCRIPTION
- allow tweaking load and reprojection chunking  separately
- support -1 chunks on reprojection code
- fix for `xr_reproject` when dealing warping from projected to geographic and back (Closes #109)
- fix for exception during exception handling when constructing `S3Fetcher` when region code is unfindable.