### PR TITLE
Handle JSON decode error in SQS to DC

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
@@ -27,15 +27,17 @@ class SQStoDCException(Exception):
     """
     Exception to raise for error during SQS to DC indexing/archiving
     """
+
     pass
+
 
 def extract_metadata_from_message(message):
     try:
         body = json.loads(message.body)
         metadata = json.loads(body["Message"])
-    except KeyError as ke:
+    except (KeyError, json.JSONDecodeError) as e:
         raise SQStoDCException(
-            f"Failed to load metadata from the SQS message due to Key Error - {ke}"
+            f"Failed to load metadata from the SQS message due to Key Error - {e}"
         )
 
     if metadata:

--- a/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
@@ -37,7 +37,7 @@ def extract_metadata_from_message(message):
         metadata = json.loads(body["Message"])
     except (KeyError, json.JSONDecodeError) as e:
         raise SQStoDCException(
-            f"Failed to load metadata from the SQS message due to Key Error - {e}"
+            f"Failed to load metadata from the SQS message due to error: {e}"
         )
 
     if metadata:


### PR DESCRIPTION
Some badlly formed messages don't have any content and this raises an exception that we're not handling.

This change handles those messages... it possibly should delete them, but I think this way they'll end up in a dead queue after a few trues.