### PR TITLE
Stats work

### DIFF
--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -35,6 +35,7 @@ from ._dask import (
 from ._memsink import (
     DataSink,
     store_to_mem,
+    yxbt_sink,
 )
 
 from ._rgba import (
@@ -70,6 +71,7 @@ __all__ = (
     "chunked_persist_ds",
     "randomize",
     "store_to_mem",
+    "yxbt_sink",
     "DataSink",
     "is_rgb",
     "to_rgba",

--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -32,6 +32,11 @@ from ._dask import (
     randomize,
 )
 
+from ._memsink import (
+    DataSink,
+    store_to_mem,
+)
+
 from ._rgba import (
     is_rgb,
     to_rgba,
@@ -64,6 +69,8 @@ __all__ = (
     "chunked_persist_da",
     "chunked_persist_ds",
     "randomize",
+    "store_to_mem",
+    "DataSink",
     "is_rgb",
     "to_rgba",
     "to_rgba_np",

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -157,7 +157,7 @@ def _get_chunks_asarray(xx: da.Array) -> np.ndarray:
     - First one contains dask tasks: (name: str, idx0:int, idx1:int)
     - Second one contains sizes of blocks (Tuple[int,...])
     """
-    shape_in_chunks = tuple(map(len, xx.chunks))
+    shape_in_chunks = xx.numblocks
     name = xx.name
 
     chunks = np.ndarray(shape_in_chunks, dtype='object')
@@ -186,7 +186,7 @@ def _get_chunks_for_all_bands(xx: xr.Dataset):
 
 
 def _get_all_chunks(xx: da.Array, flat: bool = True) -> List[Any]:
-    shape_in_chunks = tuple(map(len, xx.chunks))
+    shape_in_chunks = xx.numblocks
     name = xx.name
     chunks = [(name, *idx) for idx in np.ndindex(shape_in_chunks)]
     if flat:
@@ -276,7 +276,7 @@ def _extract_as_one_block(axis, crop, shape_in_blocks, *blocks):
     return out[crop]
 
 
-def _chunk_getter(xx):
+def _chunk_getter(xx: da.Array):
     """
     _chunk_getter(xx)(np.s_[:3, 2:4]) -> (
     (xx.name, 0, 2),
@@ -284,7 +284,7 @@ def _chunk_getter(xx):
     (xx.name, 1, 2),
     ...)
     """
-    shape_in_chunks = tuple(map(len, xx.chunks))
+    shape_in_chunks = xx.numblocks
     name = xx.name
     xx = np.asarray([{'v': tuple(idx)} for idx in np.ndindex(shape_in_chunks)]).reshape(shape_in_chunks)
 

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -2,7 +2,7 @@
 Generic dask helpers
 """
 
-from typing import Tuple, Union, cast, Iterator, List, Any
+from typing import Tuple, Union, cast, Iterator, List, Any, Dict, Hashable
 from random import randint
 from bisect import bisect_right, bisect_left
 import numpy as np
@@ -500,8 +500,11 @@ def reshape_yxbt(xx: xr.Dataset,
                     dtype=dtype,
                     shape=shape)
 
+    coords: Dict[Hashable, Any] = {k: c for k, c in xx.coords.items()}
+    coords['band'] = list(xx.data_vars)
+
     return xr.DataArray(data=data,
                         dims=dims,
-                        coords=xx.coords,
+                        coords=coords,
                         name=name0,
                         attrs=xx.attrs)

--- a/libs/algo/odc/algo/_masking.py
+++ b/libs/algo/odc/algo/_masking.py
@@ -22,10 +22,16 @@ def default_nodata(dtype):
     return dtype.type(0)
 
 
-def keep_good_np(xx, where, nodata):
-    yy = np.full_like(xx, nodata)
-    np.copyto(yy, xx, where=where)
-    return yy
+def keep_good_np(xx, where, nodata, out=None):
+    if out is None:
+        out = np.full_like(xx, nodata)
+    else:
+        assert out.shape == xx.shape
+        assert out.dtype == xx.dtype
+        assert out is not xx
+        out[:] = nodata
+    np.copyto(out, xx, where=where)
+    return out
 
 
 def keep_good_only(x, where,
@@ -76,11 +82,14 @@ def keep_good_only(x, where,
                         name=x.name)
 
 
-def from_float_np(x, dtype, nodata, scale=1, offset=0, where=None):
+def from_float_np(x, dtype, nodata, scale=1, offset=0, where=None, out=None):
     scale = np.float32(scale)
     offset = np.float32(offset)
 
-    out = np.empty_like(x, dtype=dtype)
+    if out is None:
+        out = np.empty_like(x, dtype=dtype)
+    else:
+        assert out.shape == x.shape
 
     params = dict(x=x,
                   nodata=nodata,
@@ -104,7 +113,7 @@ def from_float_np(x, dtype, nodata, scale=1, offset=0, where=None):
     return out
 
 
-def to_float_np(x, nodata=None, scale=1, offset=0, dtype='float32'):
+def to_float_np(x, nodata=None, scale=1, offset=0, dtype='float32', out=None):
     float_type = np.dtype(dtype).type
 
     _nan = float_type(np.nan)
@@ -116,7 +125,10 @@ def to_float_np(x, nodata=None, scale=1, offset=0, dtype='float32'):
                   offset=offset,
                   x=x,
                   nodata=nodata)
-    out = np.empty_like(x, dtype=dtype)
+    if out is None:
+        out = np.empty_like(x, dtype=dtype)
+    else:
+        assert out.shape == x.shape
 
     if nodata is None:
         return ne.evaluate('x*scale + offset',
@@ -135,8 +147,8 @@ def to_float_np(x, nodata=None, scale=1, offset=0, dtype='float32'):
                            local_dict=params)
 
 
-def to_f32_np(x, nodata=None, scale=1, offset=0):
-    return to_float_np(x, nodata=nodata, scale=scale, offset=offset, dtype='float32')
+def to_f32_np(x, nodata=None, scale=1, offset=0, out=None):
+    return to_float_np(x, nodata=nodata, scale=scale, offset=offset, dtype='float32', out=out)
 
 
 def to_float(x, scale=1, offset=0, dtype='float32'):

--- a/libs/algo/odc/algo/_memsink.py
+++ b/libs/algo/odc/algo/_memsink.py
@@ -1,0 +1,129 @@
+from typing import Tuple, Union, Optional, Dict
+import numpy as np
+import dask.array as da
+from distributed import Client
+import uuid
+
+ShapeLike = Union[int, Tuple[int, ...]]
+DtypeLike = Union[str, np.dtype]
+ROI = Union[slice, Tuple[slice, ...]]
+MaybeROI = Optional[ROI]
+
+_cache: Dict[str, np.ndarray] = {}
+
+
+class Cache:
+    @staticmethod
+    def new(shape: ShapeLike, dtype: DtypeLike) -> str:
+        return Cache.put(np.ndarray(shape, dtype=dtype))
+
+    @staticmethod
+    def put(x: np.ndarray) -> str:
+        k = uuid.uuid4().hex
+        _cache[k] = x
+        return k
+
+    @staticmethod
+    def get(k: str) -> Optional[np.ndarray]:
+        return _cache.get(k, None)
+
+    @staticmethod
+    def pop(k: str) -> Optional[np.ndarray]:
+        return _cache.pop(k, None)
+
+
+class DataSink:
+    def __init__(self, cache_key: str, roi: MaybeROI = None):
+        self._k = cache_key
+        self._roi = roi
+
+    @staticmethod
+    def new(shape: ShapeLike, dtype: DtypeLike) -> 'DataSink':
+        k = Cache.new(shape, dtype)
+        return DataSink(k)
+
+    @staticmethod
+    def wrap(x: np.ndarray) -> 'DataSink':
+        return DataSink(Cache.put(x))
+
+    @property
+    def data(self):
+        xx = Cache.get(self._k)
+        if xx is None:
+            return None
+        if self._roi is not None:
+            xx = xx[self._roi]
+        return xx
+
+    def view(self, roi: ROI) -> 'DataSink':
+        if self._roi is None:
+            return DataSink(self._k, roi)
+        else:
+            raise NotImplementedError("Nested views are not supported yet")
+
+    def unlink(self):
+        """ This will invalidate this object and all views also
+        """
+        if self._k != "":
+            Cache.pop(self._k)
+            self._k = ""
+            self._roi = None
+
+    def __setitem__(self, key, item):
+        self.data[key] = item
+
+    def __getitem__(self, key: ROI) -> 'DataSink':
+        return self.view(key)
+
+
+def store_to_mem(xx: da.Array,
+                 client: Client,
+                 out: Optional[np.ndarray] = None) -> np.ndarray:
+    assert client.scheduler.address.startswith('inproc://')
+    if out is None:
+        sink = DataSink.new(xx.shape, xx.dtype)
+    else:
+        assert out.shape == xx.shape
+        sink = DataSink.wrap(out)
+
+    try:
+        da.store(xx, sink, lock=False, compute=True)
+        return sink.data
+    finally:
+        sink.unlink()
+
+
+def test_cache():
+    k = Cache.new((5,), 'uint8')
+    assert isinstance(k, str)
+    xx = Cache.get(k)
+    assert xx.shape == (5,)
+    assert xx.dtype == 'uint8'
+    assert Cache.get(k) is xx
+    assert Cache.get('some bad key') is None
+    assert Cache.pop(k) is xx
+    assert Cache.get(k) is None
+
+
+def test_data_sink():
+    import pytest
+
+    ds = DataSink.new((100, 200), 'uint16')
+    xx = ds.data
+    assert xx.shape == (100, 200)
+    assert xx.dtype == 'uint16'
+    assert ds.data is xx
+
+    ds[:] = 0x1020
+    assert (xx == 0x1020).all()
+
+    ds2 = ds[:10, :20]
+    assert ds2.data.shape == (10, 20)
+    ds2[:, :] = 133
+    assert (ds.data[:10, :20] == ds2.data).all()
+    assert (ds.data[:10, :20] == 133).all()
+
+    with pytest.raises(NotImplementedError):
+        ds2.view(np.s_[:3])
+
+    ds.unlink()

--- a/libs/algo/setup.py
+++ b/libs/algo/setup.py
@@ -24,7 +24,7 @@ setup(
         'xarray',
         'numpy',
         'toolz',
-        'hdstats',
+        'hdstats>=0.1.7.post5',
         'odc-index',
         'datacube',
         'scikit-image',

--- a/libs/stats/k8s/stats-scratch.yaml
+++ b/libs/stats/k8s/stats-scratch.yaml
@@ -19,24 +19,45 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
+            # - matchExpressions:
+            #   - key: nodetype
+            #     operator: In
+            #     values:
+            #     - spot
             - matchExpressions:
               - key: nodegroup
                 operator: In
                 values:
                 - memory-optimised-r5-8xl
+                # - compute-optimised-m5-16xl
+      volumes:
+        - name: stats-persist-volume
+          persistentVolumeClaim:
+            claimName: stats-persist-volume
+
       containers:
       - name: sandbox
-        image: 565417506782.dkr.ecr.us-west-2.amazonaws.com/statistician:0.0.10-26-ge5642c6
+        image: 565417506782.dkr.ecr.us-west-2.amazonaws.com/geoscienceaustralia/sandbox:latest
         imagePullPolicy: IfNotPresent
 
         resources:
             requests:
-              memory: 233Gi 
+              # memory: 233Gi
+              # cpu: 63000m
+
+              memory: 233Gi
               cpu: 31000m
+
+              # memory: 4Gi
+              # cpu: 2
+
+        volumeMounts:
+          - name: stats-persist-volume
+            mountPath: /home/jovyan
 
         env:
             - name: DB_HOSTNAME
-              value: database.local
+              value: db-reader
             - name: DB_PORT
               value: "5432"
             - name: DB_DATABASE
@@ -83,11 +104,13 @@ spec:
 
                 [ -f /build.info ] && cat /build.info
 
-                aws s3 cp "${TASK_DB_S3}" tasks.db
+                ## aws s3 cp "${TASK_DB_S3}" tasks.db
+                (cd odc-tools && ./scripts/dev-install.sh) || true
+                #pip install "https://packages.dea.ga.gov.au/hdstats/hdstats-0.1.7.post4.tar.gz"
 
-                (git clone https://github.com/opendatacube/odc-tools.git -b stats \
-                 && cd odc-tools \
-                 && ./scripts/dev-install.sh)
+                ## (git clone https://github.com/opendatacube/odc-tools.git -b stats \
+                ## && cd odc-tools \
+                ## && ./scripts/dev-install.sh)
 
                 while true ; do
                    for i in {1..10}; do

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -6,7 +6,7 @@ import xarray as xr
 
 from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
-from odc.algo import enum_to_bool, int_geomedian, keep_good_only
+from odc.algo import enum_to_bool, int_geomedian, keep_good_only, cloud_buffer
 from .model import OutputProduct
 
 
@@ -52,7 +52,8 @@ def gm_product(location: Optional[str] = None,
                          href=f'https://collections.digitalearth.africa/product/{name}')
 
 
-def _gm_native_transform(xx: xr.Dataset) -> xr.Dataset:
+def _gm_native_transform(xx: xr.Dataset,
+                         buffer_clouds: Optional[Tuple[int, int]] = None) -> xr.Dataset:
     """
     config:
     bad_pixel_classes
@@ -65,6 +66,11 @@ def _gm_native_transform(xx: xr.Dataset) -> xr.Dataset:
 
     # TODO: fancier computation of clear_pix with padding for cloud
     clear_pix = enum_to_bool(xx.SCL, bad_pixel_classes+cloud_classes, invert=True)
+    if buffer_clouds is not None:
+        radius, dilation_radius = buffer_clouds
+        clear_pix = cloud_buffer(clear_pix,
+                                 radius=radius,
+                                 dilation_radius=dilation_radius)
 
     xx = keep_good_only(xx[bands], clear_pix)
 
@@ -73,7 +79,8 @@ def _gm_native_transform(xx: xr.Dataset) -> xr.Dataset:
 
 def gm_input_data(task: Task, resampling: str, chunk: Union[int, Tuple[int, int]] = 1600,
                   basis: Optional[str] = None,
-                  load_chunks: Optional[Dict[str, int]] = None) -> xr.Dataset:
+                  load_chunks: Optional[Dict[str, int]] = None,
+                  buffer_clouds: Optional[Tuple[int, int]] = (6, 2)) -> xr.Dataset:
     """
     .valid  Bool
     .clear  Bool
@@ -86,7 +93,7 @@ def gm_input_data(task: Task, resampling: str, chunk: Union[int, Tuple[int, int]
     xx = load_with_native_transform(task.datasets,
                                     [*task.product.measurements, 'SCL'],
                                     task.geobox,
-                                    _gm_native_transform,
+                                    lambda xx: _gm_native_transform(xx, buffer_clouds=buffer_clouds),
                                     groupby='solar_day',
                                     basis=basis,
                                     resampling=resampling,


### PR DESCRIPTION
- Persist Dask collection into RAM incrementally allowing larger than 1/2 RAM sized datasets to be loaded for processing
- Version of above that also reshapes into YXBT order needed by Geomedian
- Another version of reshape to YXBT approach that is pure Dask (allows to  decouple load chunk size from processing chunk size)
- Adding cloud buffer to geomedian plugin
- Some other minor cleanups in odc.algo
