### PR TITLE
Add Azure indexing methods

### DIFF
--- a/apps/cloud/odc/apps/cloud/azure_to_tar.py
+++ b/apps/cloud/odc/apps/cloud/azure_to_tar.py
@@ -1,0 +1,45 @@
+import tarfile
+import click
+from odc.azure import find_blobs, download_yamls
+
+from odc.io.tar import tar_mode, add_txt_file
+from urllib.parse import urlparse
+
+
+@click.command('azure-to-tar')
+
+@click.argument("account_url", type=str, nargs=1)
+@click.argument("container_name", type=str, nargs=1)
+@click.argument("credential", type=str, nargs=1)
+@click.argument("prefix", type=str, nargs=1)
+@click.argument("suffix", type=str, nargs=1)
+@click.option('--workers', '-w', type=int, default=32, help="Number of threads to download blobs")
+@click.option('--outfile', type=str, default="metadata.tar.gz", help="Sets the output file name")
+def cli( account_url: str,
+        container_name: str,
+        credential: str,
+        prefix: str,
+        suffix: str,
+        workers: int,
+        outfile:str):
+
+    print(f"Opening AZ Container {container_name} on {account_url}")
+    print(f"Searching on prefix '{prefix}' for files matching suffix '{suffix}'")
+    yaml_urls = find_blobs(account_url, container_name, credential, prefix, suffix)
+
+    print(f"Found {len(yaml_urls)} datasets")
+    yamls = download_yamls(account_url, container_name, credential, yaml_urls, workers)
+
+    url_prefix = (account_url + "/" + container_name + "/")[len("https://") :]
+
+    # jam it all in a tar
+    tar_opts = dict(name=outfile, mode='w' + tar_mode(gzip=True, xz=True, is_pipe=False))
+    with tarfile.open(**tar_opts) as tar:
+        for yaml in yamls:
+            add_txt_file(tar=tar, content=yaml[0], fname= url_prefix + yaml[1])
+
+    print("Done!")
+
+
+if __name__ == '__main__':
+    cli()

--- a/apps/cloud/odc/apps/cloud/azure_to_tar.py
+++ b/apps/cloud/odc/apps/cloud/azure_to_tar.py
@@ -6,22 +6,27 @@ from odc.io.tar import tar_mode, add_txt_file
 from urllib.parse import urlparse
 
 
-@click.command('azure-to-tar')
-
+@click.command("azure-to-tar")
 @click.argument("account_url", type=str, nargs=1)
 @click.argument("container_name", type=str, nargs=1)
 @click.argument("credential", type=str, nargs=1)
 @click.argument("prefix", type=str, nargs=1)
 @click.argument("suffix", type=str, nargs=1)
-@click.option('--workers', '-w', type=int, default=32, help="Number of threads to download blobs")
-@click.option('--outfile', type=str, default="metadata.tar.gz", help="Sets the output file name")
-def cli( account_url: str,
-        container_name: str,
-        credential: str,
-        prefix: str,
-        suffix: str,
-        workers: int,
-        outfile:str):
+@click.option(
+    "--workers", "-w", type=int, default=32, help="Number of threads to download blobs"
+)
+@click.option(
+    "--outfile", type=str, default="metadata.tar.gz", help="Sets the output file name"
+)
+def cli(
+    account_url: str,
+    container_name: str,
+    credential: str,
+    prefix: str,
+    suffix: str,
+    workers: int,
+    outfile: str,
+):
 
     print(f"Opening AZ Container {container_name} on {account_url}")
     print(f"Searching on prefix '{prefix}' for files matching suffix '{suffix}'")
@@ -33,13 +38,15 @@ def cli( account_url: str,
     url_prefix = (account_url + "/" + container_name + "/")[len("https://") :]
 
     # jam it all in a tar
-    tar_opts = dict(name=outfile, mode='w' + tar_mode(gzip=True, xz=True, is_pipe=False))
+    tar_opts = dict(
+        name=outfile, mode="w" + tar_mode(gzip=True, xz=True, is_pipe=False)
+    )
     with tarfile.open(**tar_opts) as tar:
         for yaml in yamls:
-            add_txt_file(tar=tar, content=yaml[0], fname= url_prefix + yaml[1])
+            add_txt_file(tar=tar, content=yaml[0], fname=url_prefix + yaml[1])
 
     print("Done!")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/apps/cloud/setup.py
+++ b/apps/cloud/setup.py
@@ -13,16 +13,18 @@ setup(
     license="Apache License 2.0",
     tests_require=["pytest"],
     install_requires=[
-        "odc_aws",
-        "odc_io",
-        "odc_aio",
-        "odc_ppt",
-        "odc_thredds",
+        'odc_aws',
+        'odc_io',
+        'odc_aio',
+        'odc_ppt',
+        'odc_thredds',
+        'odc_azure',
         "click",
     ],
     extras_require={
-        "GCP": ["google-cloud-storage"],
-        "THREDDS": ["thredds_crawler", "requests"],
+        'GCP': ['google-cloud-storage'],
+        'THREDDS': ['thredds_crawler', 'requests'],
+        'AZURE': ['azure-storage-blob']
     },
     entry_points={
         "console_scripts": [

--- a/apps/dc_tools/odc/apps/dc_tools/azure_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/azure_to_dc.py
@@ -14,16 +14,17 @@ from typing import List, Tuple
 
 
 def dump_list_to_odc(
-        account_url,
-        container_name,
-        yaml_content_list: List[Tuple[bytes, str, str]],
-        dc: Datacube,
-        products: List[str],
-        **kwargs,
+    account_url,
+    container_name,
+    yaml_content_list: List[Tuple[bytes, str, str]],
+    dc: Datacube,
+    products: List[str],
+    **kwargs,
 ):
     expand_stream = (
-        (account_url + "/" + container_name + "/" + d[1][:d[1].rfind("/") + 1], d[0]) for d in yaml_content_list if
-        d[0] is not None
+        (account_url + "/" + container_name + "/" + d[1][: d[1].rfind("/") + 1], d[0])
+        for d in yaml_content_list
+        if d[0] is not None
     )
 
     ds_stream = from_yaml_doc_stream(
@@ -61,8 +62,8 @@ def dump_list_to_odc(
     is_flag=True,
     default=True,
     help=(
-            "Default is to fail if lineage documents not present in the database. "
-            "Set auto add to try to index lineage documents."
+        "Default is to fail if lineage documents not present in the database. "
+        "Set auto add to try to index lineage documents."
     ),
 )
 @click.option(
@@ -71,25 +72,31 @@ def dump_list_to_odc(
     default=False,
     help="Default is no verification. Set to verify parent dataset definitions.",
 )
-@click.option('--product', '-p', 'product_names',
-              help=('Only match against products specified with this option, '
-                    'you can supply several by repeating this option with a new product name'),
-              multiple=True)
+@click.option(
+    "--product",
+    "-p",
+    "product_names",
+    help=(
+        "Only match against products specified with this option, "
+        "you can supply several by repeating this option with a new product name"
+    ),
+    multiple=True,
+)
 @click.argument("account_url", type=str, nargs=1)
 @click.argument("containter_name", type=str, nargs=1)
 @click.argument("credential", type=str, nargs=1)
 @click.argument("prefix", type=str, nargs=1)
 @click.argument("suffix", type=str, nargs=1)
 def cli(
-        skip_lineage: bool,
-        fail_on_missing_lineage: bool,
-        verify_lineage: bool,
-        account_url: str,
-        container_name: str,
-        credential: str,
-        product_names: List[str],
-        prefix: str,
-        suffix: str,
+    skip_lineage: bool,
+    fail_on_missing_lineage: bool,
+    verify_lineage: bool,
+    account_url: str,
+    container_name: str,
+    credential: str,
+    product_names: List[str],
+    prefix: str,
+    suffix: str,
 ):
     print(f"Opening AZ Container {container_name} on {account_url}")
     print(f"Searching on prefix '{prefix}' for files matching suffix '{suffix}'")
@@ -109,7 +116,7 @@ def cli(
         product_names,
         skip_lineage=skip_lineage,
         fail_on_missing_lineage=fail_on_missing_lineage,
-        verify_lineage=verify_lineage
+        verify_lineage=verify_lineage,
     )
 
     print(f"Added {added} Datasets, Failed to add {failed} Datasets")

--- a/apps/dc_tools/odc/apps/dc_tools/azure_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/azure_to_dc.py
@@ -1,0 +1,115 @@
+"""Crawl Thredds for prefixes and fetch YAML's for indexing
+and dump them into a Datacube instance
+"""
+import sys
+import logging
+from typing import Tuple
+
+import click
+from odc.azure import find_blobs, download_yamls
+from odc.index import from_yaml_doc_stream
+from datacube import Datacube
+
+from typing import List, Tuple
+
+
+def dump_list_to_odc(
+        account_url,
+        container_name,
+        yaml_content_list: List[Tuple[bytes, str, str]],
+        dc: Datacube,
+        products: List[str],
+        **kwargs,
+):
+    expand_stream = (
+        (account_url + "/" + container_name + "/" + d[1][:d[1].rfind("/") + 1], d[0]) for d in yaml_content_list if
+        d[0] is not None
+    )
+
+    ds_stream = from_yaml_doc_stream(
+        expand_stream, dc.index, products=products, **kwargs
+    )
+    ds_added = 0
+    ds_failed = 0
+    # Consume chained streams to DB
+    for result in ds_stream:
+        ds, err = result
+        if err is not None:
+            logging.error(err)
+            ds_failed += 1
+        else:
+            logging.info(ds)
+            try:
+                dc.index.datasets.add(ds)
+                ds_added += 1
+            except Exception as e:
+                logging.error(e)
+                ds_failed += 1
+
+    return ds_added, ds_failed
+
+
+@click.command("azure-to-dc")
+@click.option(
+    "--skip-lineage",
+    is_flag=True,
+    default=False,
+    help="Default is not to skip lineage. Set to skip lineage altogether.",
+)
+@click.option(
+    "--fail-on-missing-lineage/--auto-add-lineage",
+    is_flag=True,
+    default=True,
+    help=(
+            "Default is to fail if lineage documents not present in the database. "
+            "Set auto add to try to index lineage documents."
+    ),
+)
+@click.option(
+    "--verify-lineage",
+    is_flag=True,
+    default=False,
+    help="Default is no verification. Set to verify parent dataset definitions.",
+)
+@click.option('--product', '-p', 'product_names',
+              help=('Only match against products specified with this option, '
+                    'you can supply several by repeating this option with a new product name'),
+              multiple=True)
+@click.argument("account_url", type=str, nargs=1)
+@click.argument("containter_name", type=str, nargs=1)
+@click.argument("credential", type=str, nargs=1)
+@click.argument("prefix", type=str, nargs=1)
+@click.argument("suffix", type=str, nargs=1)
+def cli(
+        skip_lineage: bool,
+        fail_on_missing_lineage: bool,
+        verify_lineage: bool,
+        account_url: str,
+        container_name: str,
+        credential: str,
+        product_names: List[str],
+        prefix: str,
+        suffix: str,
+):
+    print(f"Opening AZ Container {container_name} on {account_url}")
+    print(f"Searching on prefix '{prefix}' for files matching suffix '{suffix}'")
+    yaml_urls = find_blobs(account_url, container_name, credential, prefix, suffix)
+
+    print(f"Found {len(yaml_urls)} datasets")
+    yaml_contents = download_yamls(yaml_urls)
+
+    print(f"Matching to {product_names} products")
+    # Consume generator and fetch YAML's
+    dc = Datacube()
+    added, failed = dump_list_to_odc(
+        account_url,
+        container_name,
+        yaml_contents,
+        dc,
+        product_names,
+        skip_lineage=skip_lineage,
+        fail_on_missing_lineage=fail_on_missing_lineage,
+        verify_lineage=verify_lineage
+    )
+
+    print(f"Added {added} Datasets, Failed to add {failed} Datasets")

--- a/libs/azure/odc/azure/__init__.py
+++ b/libs/azure/odc/azure/__init__.py
@@ -1,0 +1,56 @@
+"""Azure blob storage crawling and YAML fetching utilities
+"""
+from azure.storage.blob import ContainerClient, BlobClient
+from typing import List, Tuple, Optional
+from multiprocessing.dummy import Pool as ThreadPool
+from functools import partial
+
+def find_blobs(account_url: str, container_name: str, credential: str, prefix: str, suffix: str):
+    blob_list = []
+    container = ContainerClient(account_url=account_url, container_name=container_name, credential=credential)
+    for blob_record in container.list_blobs(name_starts_with=prefix):
+        blob_name = blob_record['name']
+
+        if blob_name.endswith(suffix):
+            blob_list.append(blob_name)
+    return blob_list
+
+
+def download_yamls(account_url: str, container_name: str, credential: str, yaml_urls: List[str],
+                   workers: int = 32) -> List[Tuple[Optional[bytes], str, Optional[str]]]:
+    """Download all YAML's in a list of blob names and generate content
+    Arguments:
+        account_url {str} -- Azure account url
+        container_name {str} -- Azure container name
+        credential {str} -- Azure credential token
+
+        yaml_urls {list} -- List of URL's to download YAML's from
+        workers {int} -- Number of workers to use for Thredds Downloading
+    Returns:
+        list -- tuples of contents and filenames
+    """
+    # use a threadpool to download from Azure blobstore
+
+    pool = ThreadPool(workers)
+    yamls = pool.map(partial(_download, account_url, container_name, credential), yaml_urls)
+    pool.close()
+    pool.join()
+    return yamls
+
+
+def _download(account_url: str, container_name: str, credential: str,
+              blob_name: str) -> Tuple[Optional[bytes], str, Optional[str]]:
+    """Internal method to download YAML's from Azure via BlobClient
+    Arguments:
+        account_url {str} -- Azure account url
+        container_name {str} -- Azure container name
+        credential {str} -- Azure credential token
+        blob_name {str} -- Blob name to download
+    Returns:
+        tuple -- URL content, target file and placeholder for error
+    """
+
+    blob = BlobClient(account_url=account_url, container_name=container_name, credential=credential,
+                      blob_name=blob_name)
+
+    return (blob.download_blob().readall(), blob_name, None)

--- a/libs/azure/setup.py
+++ b/libs/azure/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+setup(
+    name='odc_azure',
+
+    use_scm_version={"root": "../..", "relative_to": __file__},
+    setup_requires=['setuptools_scm'],
+
+    author='Open Data Cube',
+    author_email='',
+    maintainer='Open Data Cube',
+
+    description='Various Azure helper methods (experimental)',
+    long_description='',
+
+    license='Apache License 2.0',
+
+    tests_require=['pytest'],
+    install_requires=[
+        'azure-storage-blob'
+    ],
+
+    packages=['odc.azure'],
+    zip_safe=False,
+)

--- a/libs/azure/tests/test_azure.py
+++ b/libs/azure/tests/test_azure.py
@@ -1,16 +1,32 @@
 """Test thredds downloader code
 """
-from odc.azure import find_blobs, download_yamls
+import pytest
+from odc.azure import download_yamls, find_blobs
 
 
-def test_find_blobs():
-    """Find blobs in a sample Azure account, this will fail if the blob store changes or is removed
-    """
+@pytest.mark.skip("Takes too long to run, enable manually")
+def test_fail_blob(credential, test_blob_names):
+    """Search for a non-existant blob"""
+
+    account_name = "not-real"
+    account_url = "https://" + account_name + ".blob.core.windows.net"
+    container_name = "fake"
+    suffix = "odc-metadata.yaml"
+    prefix = "fake/path"
+
+    blob_names = find_blobs(account_url, container_name, credential, prefix, suffix)
+    assert len(blob_names) == 0
+
+    results = download_yamls(account_url, container_name, credential, test_blob_names)
+    assert results
+
+
+def test_find_blobs(credential):
+    """Find blobs in a sample Azure account, this will fail if the blob store changes or is removed"""
 
     account_name = "geoau"
     account_url = "https://" + account_name + ".blob.core.windows.net"
     container_name = "ey-gsa"
-    credential = "sv=2019-10-10&si=ey-gsa-ro&sr=c&sig=4T2mncGZ2v%2FqVsjjyHp%2Fv7BZytih8b251pSW0QelT98%3D"
     suffix = "odc-metadata.yaml"
     prefix = "baseline/ga_ls7e_ard_3/092/087/2018/05/25"
 
@@ -18,21 +34,27 @@ def test_find_blobs():
     assert blob_names
     assert len(blob_names) == 1
 
-def test_download_yamls():
-    """Test pass/fail arms of YAML download from Azure blobstore
-    """
+
+def test_download_yamls(credential, test_blob_names):
+    """Test pass/fail arms of YAML download from Azure blobstore"""
 
     account_name = "geoau"
     account_url = "https://" + account_name + ".blob.core.windows.net"
     container_name = "ey-gsa"
-    credential = "sv=2019-10-10&si=ey-gsa-ro&sr=c&sig=4T2mncGZ2v%2FqVsjjyHp%2Fv7BZytih8b251pSW0QelT98%3D"
 
-    test_blob_names = [
-        "baseline/ga_ls7e_ard_3/092/087/2018/05/25/ga_ls7e_ard_3-0-0_092087_2018-05-25_final.odc-metadata.yaml"
-    ]
     results = download_yamls(account_url, container_name, credential, test_blob_names)
     assert results
     assert len(results) == 1
-    print(results)
     assert results[0][0] is not None
 
+
+@pytest.fixture
+def credential():
+    return "sv=2019-10-10&si=ey-gsa-ro&sr=c&sig=4T2mncGZ2v%2FqVsjjyHp%2Fv7BZytih8b251pSW0QelT98%3D"
+
+
+@pytest.fixture
+def test_blob_names():
+    return [
+        "baseline/ga_ls7e_ard_3/092/087/2018/05/25/ga_ls7e_ard_3-0-0_092087_2018-05-25_final.odc-metadata.yaml"
+    ]

--- a/libs/azure/tests/test_azure.py
+++ b/libs/azure/tests/test_azure.py
@@ -1,0 +1,38 @@
+"""Test thredds downloader code
+"""
+from odc.azure import find_blobs, download_yamls
+
+
+def test_find_blobs():
+    """Find blobs in a sample Azure account, this will fail if the blob store changes or is removed
+    """
+
+    account_name = "geoau"
+    account_url = "https://" + account_name + ".blob.core.windows.net"
+    container_name = "ey-gsa"
+    credential = "sv=2019-10-10&si=ey-gsa-ro&sr=c&sig=4T2mncGZ2v%2FqVsjjyHp%2Fv7BZytih8b251pSW0QelT98%3D"
+    suffix = "odc-metadata.yaml"
+    prefix = "baseline/ga_ls7e_ard_3/092/087/2018/05/25"
+
+    blob_names = find_blobs(account_url, container_name, credential, prefix, suffix)
+    assert blob_names
+    assert len(blob_names) == 1
+
+def test_download_yamls():
+    """Test pass/fail arms of YAML download from Azure blobstore
+    """
+
+    account_name = "geoau"
+    account_url = "https://" + account_name + ".blob.core.windows.net"
+    container_name = "ey-gsa"
+    credential = "sv=2019-10-10&si=ey-gsa-ro&sr=c&sig=4T2mncGZ2v%2FqVsjjyHp%2Fv7BZytih8b251pSW0QelT98%3D"
+
+    test_blob_names = [
+        "baseline/ga_ls7e_ard_3/092/087/2018/05/25/ga_ls7e_ard_3-0-0_092087_2018-05-25_final.odc-metadata.yaml"
+    ]
+    results = download_yamls(account_url, container_name, credential, test_blob_names)
+    assert results
+    assert len(results) == 1
+    print(results)
+    assert results[0][0] is not None
+

--- a/libs/azure/tests/test_azure.py
+++ b/libs/azure/tests/test_azure.py
@@ -1,5 +1,7 @@
 """Test thredds downloader code
 """
+import os
+
 import pytest
 from odc.azure import download_yamls, find_blobs
 
@@ -50,7 +52,7 @@ def test_download_yamls(credential, test_blob_names):
 
 @pytest.fixture
 def credential():
-    return "sv=2019-10-10&si=ey-gsa-ro&sr=c&sig=4T2mncGZ2v%2FqVsjjyHp%2Fv7BZytih8b251pSW0QelT98%3D"
+    return os.environ.get("AZURE_STORAGE_SAS_TOKEN")
 
 
 @pytest.fixture

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - DB_PORT=5432
       - AWS_DEFAULT_REGION=ap-southeast-2
       - STAC_API_URL=https://earth-search.aws.element84.com/v0/
+      - AZURE_STORAGE_SAS_TOKEN=${AZURE_STORAGE_SAS_TOKEN}
     depends_on:
       - postgres
     volumes:


### PR DESCRIPTION
Add methods used to index datasets from Azure blobstore.
Indexing uses Azure blob and container clients to search an Azure blobstore, uses a prefix and suffix as filtering for json/yaml needs to be done client side.
https://docs.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.containerclient?view=azure-python#list-blobs-name-starts-with-none--include-none----kwargs-
Files are indexed with HTTPS protocol, so this is unsuitable for non-public blobs. Secured blobs will require `az` protocol added to RaserIO and ODC in line with GDAL vsi* protocol support.

Also includes azure-to-tar, while we are deprecating this as a pattern, it was convenient to use for the EY challenge so that everyone could index once without needing special Azure credentials.