### PR TITLE
Use the dev-install.sh script in test environment

### DIFF
--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -16,7 +16,7 @@ install_all_in_edit_mode () {
     #  1. without deps -- install odc-* but none of their dependents
     #  2. with deps -- now that all `odc-*` are here, reinstall getting all other deps
     python3 -m pip install --no-deps -r "${reqs}"
-    python3 -m pip install -r "${reqs}"
+    python3 -m pip install --extra-index-url https://packages.dea.ga.gov.au/ -r "${reqs}"
 
     rm "${reqs}"
 }

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -18,22 +18,9 @@ RUN env-build-tool new /conf/requirements.txt ${py_env_path} /wheels
 # Install the tools
 ADD ./ /code
 WORKDIR /code
-# TODO: work out why this needs `--editable`
-RUN /env/bin/pip install --extra-index-url https://packages.dea.ga.gov.au/ \
-    --editable apps/dc_tools[tests] \
-    --editable apps/cloud \
-    --editable apps/dnsup \
-    --editable libs/algo \
-    --editable libs/aio \
-    --editable libs/aws \
-    --editable libs/dscache \
-    --editable libs/geom \
-    --editable libs/index \
-    --editable libs/io \
-    --editable libs/ppt \
-    --editable libs/stats \
-    --editable libs/thredds \
-    --editable libs/ui
+
+# This installs things twice because of circular dependencies
+RUN /code/scripts/dev-install.sh
 
 # Copy in the test runner script
 COPY ./tests/run_tests.sh /usr/local/bin/run_tests.sh

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,18 @@
+.PHONY: test
+
+DEV=--file docker-compose.yml --file docker-compose.dev.yml
+
+build:
+	docker-compose build
+
+test:
+	docker-compose up -d
+	docker-compose exec -T tools-tester run_tests.sh
+	docker-compose down
+
+up:
+	docker-compose ${DEV} \
+		up
+
+shell:
+	docker-compose ${DEV} exec tools-tester bash

--- a/tests/docker-compose.dev.yml
+++ b/tests/docker-compose.dev.yml
@@ -1,0 +1,6 @@
+version: '3.7'
+
+services:
+  tools-tester:
+    volumes:
+      - ../:/code


### PR DESCRIPTION
A bunch of tests don't work still when installing using that script.

It's an import error:
```
ImportError while importing test module '/code/libs/stats/tests/test_utils.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.6/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
libs/stats/tests/test_utils.py:8: in <module>
    from odc.stats._gm import gm_product
E   ModuleNotFoundError: No module named 'odc.stats'
=========================== short test summary info ============================
ERROR apps/dc_tools/tests/test_sqs_to_dc.py
ERROR libs/algo/odc/algo/test_dask.py
ERROR libs/algo/odc/algo/test_masking.py
ERROR libs/dscache/odc/dscache/tools/test_tiling.py
ERROR libs/dscache/tests/test_dscache.py
ERROR libs/dscache/tests/test_jsoncache.py
ERROR libs/index/tests/test_stac.py
ERROR libs/stats/tests/test_stats_model.py
ERROR libs/stats/tests/test_utils.py
!!!!!!!!!!!!!!!!!!! Interrupted: 9 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 9 errors in 1.90s ===============================
```


I need to look into it more.