### PR TITLE
More featurefull task submission to SQS and other cleanup

### DIFF
--- a/libs/stats/k8s/Makefile
+++ b/libs/stats/k8s/Makefile
@@ -48,6 +48,10 @@ fwd-lab:
 exec:
 	$(k8) exec -ti "$$($(k8) get pods -l app=$(id) | awk 'FNR==2 {print $$1}')" -- bash
 
+tmux:
+	$(k8) exec -ti "$$($(k8) get pods -l app=$(id) | awk 'FNR==2 {print $$1}')" -- env SHELL=fish TERM=$$TERM tmux
+
+
 logs:
 	$(k8) logs -f "$$($(k8) get pods -l app=$(id) | awk 'FNR==2 {print $$1}')"
 

--- a/libs/stats/k8s/stats-scratch.yaml
+++ b/libs/stats/k8s/stats-scratch.yaml
@@ -44,7 +44,7 @@ spec:
 
       containers:
       - name: sandbox
-        image: 565417506782.dkr.ecr.us-west-2.amazonaws.com/geoscienceaustralia/sandbox:latest
+        image: 565417506782.dkr.ecr.us-west-2.amazonaws.com/geoscienceaustralia/sandbox:sudo-latest
         imagePullPolicy: IfNotPresent
 
         volumeMounts:

--- a/libs/stats/odc/stats/_cli_pq_queue.py
+++ b/libs/stats/odc/stats/_cli_pq_queue.py
@@ -1,10 +1,7 @@
 import sys
 import click
 import logging
-
 from ._cli_common import main
-
-from odc.aws.queue import get_messages, get_queue
 
 
 @main.command("run-pq-queue")
@@ -36,6 +33,7 @@ def run_pq_queue(
     from .tasks import TaskReader
     from datacube.utils.dask import start_local_dask
     from datacube.utils.rio import configure_s3_access
+    from odc.aws.queue import get_messages, get_queue
 
     # config
     resampling = "nearest"

--- a/libs/stats/odc/stats/_cli_pq_queue.py
+++ b/libs/stats/odc/stats/_cli_pq_queue.py
@@ -22,19 +22,6 @@ def run_pq_queue(
     """
     Run Pixel Quality stats on tasks provided in a SQS queue
 
-    Task could be one of the 3 things
-
-    \b
-    1. Comma-separated triplet: period,x,y or 'x[+-]<int>/y[+-]<int>/period
-       2019--P1Y,+003,-004
-       2019--P1Y/3/-4          `/` is also accepted
-       x+003/y-004/2019--P1Y   is accepted as well
-    2. A zero based index
-    3. A slice following python convention <start>:<stop>[:<step]
-        ::10 -- every tenth task: 0,10,20,..
-       1::10 -- every tenth but skip first one 1, 11, 21 ..
-        :100 -- first 100 tasks
-
     \b
     E.g:
         odc-stats run-pq-queue s3://deafrica-stats-processing/orchestration_test/s2_l2a_2020--P1Y.db \\

--- a/libs/stats/odc/stats/_cli_publish_tasks.py
+++ b/libs/stats/odc/stats/_cli_publish_tasks.py
@@ -1,42 +1,66 @@
-from pathlib import Path
-import os
+import sys
 import click
 
-from odc.aws.queue import get_queue, publish_message, publish_messages
-from ._cli_run_pq import run_pq
 from ._cli_common import main, parse_all_tasks
-from .tasks import TaskReader
+
+
+def do_dry_run(tasks):
+    for period, ix, iy in tasks:
+        print(f"{period}/{ix:+04d}/{iy:+04d}")
 
 
 @main.command("publish-tasks")
 @click.argument("db", type=str)
 @click.argument("queue", type=str)
-@click.option("--limit", type=int, default=None)
-def publish_to_queue(db, queue, limit):
-    def get_tasks(cache_file):
-        rdr = TaskReader(cache_file)
+@click.option('--verbose', '-v', is_flag=True, help='Be verbose')
+@click.option('--dryrun', is_flag=True,
+              help='Do not publish just print what would be submitted')
+@click.option('--bunch-size', type=int, default=10,
+              help="Number of messages to submit in one go")
+@click.argument('tasks', type=str, nargs=-1)
+def publish_to_queue(db, queue, verbose, dryrun, bunch_size, tasks):
+    """
+    Publish tasks to SQS.
+
+    Task could be one of the 3 things
+
+    \b
+    1. Comma-separated triplet: period,x,y or 'x[+-]<int>/y[+-]<int>/period
+       2019--P1Y,+003,-004
+       2019--P1Y/3/-4          `/` is also accepted
+       x+003/y-004/2019--P1Y   is accepted as well
+    2. A zero based index
+    3. A slice following python convention <start>:<stop>[:<step]
+        ::10 -- every tenth task: 0,10,20,..
+       1::10 -- every tenth but skip first one 1, 11, 21 ..
+        :100 -- first 100 tasks
+
+    If no tasks are supplied all tasks will be published the queue.
+    """
+    from odc.aws.queue import get_queue, publish_messages
+    from .tasks import TaskReader
+    import toolz
+
+    rdr = TaskReader(db)
+    if len(tasks) == 0:
         tasks = rdr.all_tiles
-        print(f"Found {len(tasks):,d} tasks in the file")
-        return tasks
+        if verbose:
+            print(f"Found {len(tasks):,d} tasks in the file")
+    else:
+        try:
+            tasks = parse_all_tasks(tasks, rdr.all_tiles)
+        except ValueError as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
+
+    if dryrun:
+        do_dry_run(tasks)
+        sys.exit(0)
 
     queue = get_queue(queue)
-    tasks = get_tasks(db)
+    messages = (dict(Id=str(idx),
+                     MessageBody=f'{period},{ix},{iy}')
+                for idx, (period, ix, iy) in enumerate(tasks))
 
-    messages = []
-    counter = 0
-
-    for ta in tasks[:limit]:
-        task = (ta[0], str(ta[1]), str(ta[2]))
-        task = ",".join(task)
-        message = {
-                "Id": str(counter),
-                "MessageBody": task
-            }
-        messages.append(message)
-        counter += 1
-
-        if counter % 10 == 0:
-            publish_messages(queue, messages)
-            messages = []
-    if messages:
-        publish_messages(queue, messages)
+    for bunch in toolz.partition_all(bunch_size, messages):
+        publish_messages(queue, bunch)

--- a/libs/stats/odc/stats/_cli_run_gm.py
+++ b/libs/stats/odc/stats/_cli_run_gm.py
@@ -17,7 +17,7 @@ from ._cli_common import main, parse_all_tasks
 @click.argument('tasks', type=str, nargs=-1)
 def run_gm(cache_file, tasks, dryrun, verbose, threads, x_chunks, y_chunks, overwrite, public, location):
     """
-    Run Pixel Quality stats
+    Run Geomedian
 
     Task could be one of the 3 things
 
@@ -47,8 +47,8 @@ def run_gm(cache_file, tasks, dryrun, verbose, threads, x_chunks, y_chunks, over
 
     dask.config.set({'distributed.worker.memory.target': False})
     dask.config.set({'distributed.worker.memory.spill': False})
-    dask.config.set({'distributed.worker.memory.pause': False})
-    dask.config.set({'distributed.worker.memory.terminate': False})
+    dask.config.set({'distributed.worker.memory.pause': 0.93})
+    dask.config.set({'distributed.worker.memory.terminate': 0.95})
 
     # config
     resampling = 'bilinear'

--- a/libs/stats/odc/stats/_cli_run_pq.py
+++ b/libs/stats/odc/stats/_cli_run_pq.py
@@ -35,6 +35,7 @@ def run_pq(cache_file, tasks, dryrun, verbose, threads, memory_limit, overwrite,
     """
     from tqdm.auto import tqdm
     from functools import partial
+    import psutil
     from .io import S3COGSink
     from ._pq import pq_input_data, pq_reduce, pq_product
     from .proc import process_tasks
@@ -48,7 +49,11 @@ def run_pq(cache_file, tasks, dryrun, verbose, threads, memory_limit, overwrite,
                     predict=2,
                     zlevel=6,
                     blocksize=800)
+    ncpus = psutil.cpu_count()
     # ..
+
+    if threads <= 0:
+        threads = ncpus
 
     rdr = TaskReader(cache_file)
     product = pq_product(location=location)

--- a/libs/stats/odc/stats/_cli_run_pq.py
+++ b/libs/stats/odc/stats/_cli_run_pq.py
@@ -48,7 +48,9 @@ def run_pq(cache_file, tasks, dryrun, verbose, threads, memory_limit, overwrite,
     COG_OPTS = dict(compress='deflate',
                     predict=2,
                     zlevel=6,
-                    blocksize=800)
+                    blocksize=800,
+                    ovr_blocksize=256,  # ovr_blocksize must be powers of 2 for some reason in GDAL
+                    overview_resampling='average')
     ncpus = psutil.cpu_count()
     # ..
 

--- a/libs/stats/odc/stats/tasks.py
+++ b/libs/stats/odc/stats/tasks.py
@@ -5,9 +5,6 @@ from datetime import datetime
 import pickle
 import json
 import os
-import boto3
-import botocore
-from pathlib import Path
 from tqdm.auto import tqdm
 
 from odc.dscache import DatasetCache


### PR DESCRIPTION
Mostly publish-tasks

```
Usage: odc-stats publish-tasks [OPTIONS] DB QUEUE [TASKS]...

  Publish tasks to SQS.

  Task could be one of the 3 things

  1. Comma-separated triplet: period,x,y or 'x[+-]<int>/y[+-]<int>/period
     2019--P1Y,+003,-004
     2019--P1Y/3/-4          `/` is also accepted
     x+003/y-004/2019--P1Y   is accepted as well
  2. A zero based index
  3. A slice following python convention <start>:<stop>[:<step]
      ::10 -- every tenth task: 0,10,20,..
     1::10 -- every tenth but skip first one 1, 11, 21 ..
      :100 -- first 100 tasks

  If no tasks are supplied all tasks will be published the queue.

Options:
  -v, --verbose         Be verbose
  --dryrun              Do not publish just print what would be submitted
  --bunch-size INTEGER  Number of messages to submit in one go
  --help                Show this message and exit.
```

instead of limit can use `:100`, but it supports any python slicing as well as referencing by "name" (`2020--P1Y/3/4`). Allows for more flexible selection of tasks during testing stages.