### PR TITLE
Add exit codes to flag failing work

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -175,6 +175,9 @@ def cli(
 
     print(f"Added {added} Datasets, Failed {failed} Datasets")
 
+    if failed > 0:
+        sys.exit(failed)
+
 
 if __name__ == "__main__":
     cli()

--- a/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
@@ -3,6 +3,7 @@
 """
 import json
 import logging
+import sys
 import uuid
 from pathlib import PurePath
 from typing import Tuple
@@ -403,6 +404,9 @@ def cli(
         result_msg += f"Added {success} Dataset(s), "
     result_msg += f"Failed {failed} Dataset(s)"
     print(result_msg)
+
+    if failed > 0:
+        sys.exit(failed)
 
 
 if __name__ == "__main__":

--- a/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
@@ -227,6 +227,9 @@ def cli(
 
     print(f"Added {added} Datasets, failed {failed} Datasets")
 
+    if failed > 0:
+        sys.exit(failed)
+
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
Sometimes indexing scripts are watermelons, and it would be nice to know when things are failing so we can fix them earlier.

This should give us more visibility of failing tasks, especially in Airflow.