### PR TITLE
Reworking Geomedian Plugin

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore = E731, E226
+ignore = E731, E226, E203, W503

--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -40,9 +40,10 @@ from ._dask import (
 )
 
 from ._memsink import (
-    DataSink,
     store_to_mem,
     yxbt_sink,
+    da_yxbt_sink,
+    da_mem_sink,
 )
 
 from ._rgba import (
@@ -87,7 +88,8 @@ __all__ = (
     "randomize",
     "store_to_mem",
     "yxbt_sink",
-    "DataSink",
+    "da_mem_sink",
+    "da_yxbt_sink",
     "is_rgb",
     "to_rgba",
     "to_rgba_np",

--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -41,7 +41,7 @@ from ._dask import (
 
 from ._memsink import (
     store_to_mem,
-    yxbt_sink,
+    yxbt_sink_to_mem,
     da_yxbt_sink,
     da_mem_sink,
 )
@@ -87,7 +87,7 @@ __all__ = (
     "chunked_persist_ds",
     "randomize",
     "store_to_mem",
-    "yxbt_sink",
+    "yxbt_sink_to_mem",
     "da_mem_sink",
     "da_yxbt_sink",
     "is_rgb",

--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -43,6 +43,7 @@ from ._memsink import (
     store_to_mem,
     yxbt_sink_to_mem,
     da_yxbt_sink,
+    yxbt_sink,
     da_mem_sink,
 )
 
@@ -88,6 +89,7 @@ __all__ = (
     "randomize",
     "store_to_mem",
     "yxbt_sink_to_mem",
+    "yxbt_sink",
     "da_mem_sink",
     "da_yxbt_sink",
     "is_rgb",

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -7,6 +7,7 @@ from random import randint
 from bisect import bisect_right, bisect_left
 import numpy as np
 import xarray as xr
+import dask
 from dask.distributed import wait as dask_wait
 import dask.array as da
 from dask.highlevelgraph import HighLevelGraph
@@ -90,6 +91,11 @@ def randomize(prefix: str) -> str:
     Append random token to name
     """
     return "{}-{:08x}".format(prefix, randint(0, 0xFFFFFFFF))
+
+
+@dask.delayed
+def with_deps(value, *deps):
+    return value
 
 
 def list_reshape(x: List[Any], shape: Tuple[int, ...]) -> List[Any]:

--- a/libs/algo/odc/algo/_dask.py
+++ b/libs/algo/odc/algo/_dask.py
@@ -18,7 +18,8 @@ from ._tools import ROI, roi_shape, slice_in_out
 
 
 def chunked_persist(data, n_concurrent, client, verbose=False):
-    """Force limited concurrency when persisting a large collection.
+    """
+    Force limited concurrency when persisting a large collection.
 
     This is useful to control memory usage when operating close to capacity.
 
@@ -114,6 +115,16 @@ def unpack_chunksize(chunk: int, N: int) -> Tuple[int, ...]:
         return tuple(chunk for _ in range(nb))
 
     return tuple(chunk for _ in range(nb)) + (last_chunk,)
+
+
+def unpack_chunks(
+    chunks: Tuple[int, ...], shape: Tuple[int, ...]
+) -> Tuple[Tuple[int, ...], ...]:
+    """
+    Expand chunks
+    """
+    assert len(chunks) == len(shape)
+    return tuple(unpack_chunksize(ch, n) for ch, n in zip(chunks, shape))
 
 
 def _roi_from_chunks(chunks: Tuple[int, ...]) -> Iterator[slice]:

--- a/libs/algo/odc/algo/_geomedian.py
+++ b/libs/algo/odc/algo/_geomedian.py
@@ -302,6 +302,11 @@ def geomedian_with_mads(
     num_threads: int = 1,
 ) -> xr.Dataset:
     """
+    TODO: make user friendly
+     - check that yxbt chunks are right
+     - accept Dataset and do yxbt conversion internally
+     - allow choosing whether MADs are needed
+     - then expose in `odc.algo.` and deprecate other geomedian versions
     """
     assert dask.is_dask_collection(yxbt)
 

--- a/libs/algo/odc/algo/_memsink.py
+++ b/libs/algo/odc/algo/_memsink.py
@@ -1,93 +1,130 @@
-from typing import Tuple, Union, Optional, Dict
+from typing import Any, Dict, Optional, Tuple, Union
 import numpy as np
+import dask
 import dask.array as da
+from dask.highlevelgraph import HighLevelGraph
 from distributed import Client
 import uuid
+from ._dask import randomize, unpack_chunks, _roi_from_chunks, with_deps
+
 
 ShapeLike = Union[int, Tuple[int, ...]]
 DtypeLike = Union[str, np.dtype]
 ROI = Union[slice, Tuple[slice, ...]]
 MaybeROI = Optional[ROI]
+Delayed = Any
+CacheKey = Union["Token", str]
 
 _cache: Dict[str, np.ndarray] = {}
 
 
+class Token:
+    __slots__ = ["_k"]
+
+    def __init__(self, k: str):
+        # print(f"Token.init(<{k}>)@0x{id(self):08X}")
+        self._k = k
+
+    def __str__(self) -> str:
+        return self._k
+
+    def __bool__(self):
+        return len(self._k) > 0
+
+    def release(self):
+        if self:
+            Cache.pop(self)
+            self._k = ""
+
+    def __del__(self):
+        # print(f"Token.del(<{self._k}>)@0x{id(self):08X}")
+        self.release()
+
+    def __getstate__(self):
+        print(f"Token.__getstate__() <{self._k}>@0x{id(self):08X}")
+        raise ValueError("Token should not be pickled")
+
+    def __setstate__(self, k):
+        print(f"Token.__setstate__(<{k}>)@0x{id(self):08X}")
+        raise ValueError("Token should not be pickled")
+
+
 class Cache:
     @staticmethod
-    def new(shape: ShapeLike, dtype: DtypeLike) -> str:
+    def new(shape: ShapeLike, dtype: DtypeLike) -> Token:
         return Cache.put(np.ndarray(shape, dtype=dtype))
 
     @staticmethod
-    def put(x: np.ndarray) -> str:
+    def put(x: np.ndarray) -> Token:
         k = uuid.uuid4().hex
         _cache[k] = x
-        return k
+        return Token(k)
 
     @staticmethod
-    def get(k: str) -> Optional[np.ndarray]:
-        return _cache.get(k, None)
+    def get(k: CacheKey) -> Optional[np.ndarray]:
+        return _cache.get(str(k), None)
 
     @staticmethod
-    def pop(k: str) -> Optional[np.ndarray]:
-        return _cache.pop(k, None)
+    def pop(k: CacheKey) -> Optional[np.ndarray]:
+        return _cache.pop(str(k), None)
 
 
-class DataSink:
-    def __init__(self, cache_key: str, roi: MaybeROI = None):
-        self._k = cache_key
-        self._roi = roi
-
-    @staticmethod
-    def new(shape: ShapeLike, dtype: DtypeLike) -> "DataSink":
-        k = Cache.new(shape, dtype)
-        return DataSink(k)
-
-    @staticmethod
-    def wrap(x: np.ndarray) -> "DataSink":
-        return DataSink(Cache.put(x))
+class CachedArray:
+    def __init__(self, token_or_key: CacheKey):
+        self._tk = token_or_key
 
     @property
-    def data(self):
-        xx = Cache.get(self._k)
+    def data(self) -> np.ndarray:
+        xx = Cache.get(self._tk)
         if xx is None:
-            return None
-        if self._roi is not None:
-            xx = xx[self._roi]
+            raise ValueError("Source array is missing from cache")
         return xx
 
-    def view(self, roi: ROI) -> "DataSink":
-        if self._roi is None:
-            return DataSink(self._k, roi)
-        else:
-            raise NotImplementedError("Nested views are not supported yet")
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self.data.shape
 
-    def unlink(self):
-        """This will invalidate this object and all views also"""
-        if self._k != "":
-            Cache.pop(self._k)
-            self._k = ""
-            self._roi = None
+    @property
+    def dtype(self):
+        return self.data.dtype
+
+    @property
+    def ndim(self):
+        return self.data.ndim
+
+    def __getitem__(self, key: ROI) -> np.ndarray:
+        return self.data[key]
 
     def __setitem__(self, key, item):
         self.data[key] = item
 
-    def __getitem__(self, key: ROI) -> "DataSink":
-        return self.view(key)
+    @staticmethod
+    def new(shape: ShapeLike, dtype: DtypeLike) -> "CachedArray":
+        return CachedArray(Cache.new(shape, dtype))
+
+    @staticmethod
+    def wrap(x: np.ndarray) -> "CachedArray":
+        return CachedArray(Cache.put(x))
+
+    def release(self) -> Optional[np.ndarray]:
+        return Cache.pop(self._tk)
 
 
 class _YXBTSink:
     def __init__(
-        self, cache_key: str, band: Union[int, Tuple[slice, slice, slice, slice]]
+        self,
+        token_or_key: CacheKey,
+        band: Union[int, Tuple[slice, slice, slice, slice]],
     ):
         if isinstance(band, int):
             band = np.s_[:, :, band, :]
 
-        self._k = cache_key
+        self._tk = token_or_key
         self._roi = band
 
     @property
     def data(self):
-        xx = Cache.get(self._k)
+        xx = Cache.get(self._tk)
         if xx is None:
             return None
         return xx[self._roi]
@@ -104,40 +141,169 @@ def store_to_mem(
     xx: da.Array, client: Client, out: Optional[np.ndarray] = None
 ) -> np.ndarray:
     assert client.scheduler.address.startswith("inproc://")
+    token = None
     if out is None:
-        sink = DataSink.new(xx.shape, xx.dtype)
+        sink = dask.delayed(CachedArray.new)(xx.shape, xx.dtype)
     else:
         assert out.shape == xx.shape
-        sink = DataSink.wrap(out)
+        token = Cache.put(out)
+        sink = dask.delayed(CachedArray)(str(token))
 
     try:
         fut = da.store(xx, sink, lock=False, compute=False)
-        fut = client.compute(fut)
+        fut, _sink = client.compute([fut, sink])
         fut.result()
-        return sink.data
+        return _sink.result().data
     finally:
-        sink.unlink()
+        if token is not None:
+            token.release()
 
 
-def yxbt_sink(bands: Tuple[da.Array, ...], client) -> np.ndarray:
+def yxbt_sink(bands: Tuple[da.Array, ...], client: Client) -> np.ndarray:
+    assert client.scheduler.address.startswith("inproc://")
+
     b = bands[0]
     dtype = b.dtype
     nt, ny, nx = b.shape
     nb = len(bands)
-    out_key = Cache.new((ny, nx, nb, nt), dtype)
-    sinks = [_YXBTSink(out_key, idx) for idx in range(nb)]
+    token = Cache.new((ny, nx, nb, nt), dtype)
+    sinks = [_YXBTSink(str(token), idx) for idx in range(nb)]
     try:
         fut = da.store(bands, sinks, lock=False, compute=False)
         fut = client.compute(fut)
         fut.result()
-        return Cache.get(out_key)
+        return Cache.get(token)
     finally:
-        Cache.pop(out_key)
+        token.release()
+
+
+def _chunk_extractor(cache_key: CacheKey, roi: ROI, *deps) -> np.ndarray:
+    src = Cache.get(cache_key)
+    assert src is not None
+    return src[roi]
+
+
+def _da_from_mem(
+    token: Delayed,
+    shape: ShapeLike,
+    dtype: DtypeLike,
+    chunks: Tuple[int, ...],
+    name: str = "from_mem",
+) -> da.Array:
+    """
+    Construct dask view of some yet to be computed in RAM store.
+
+    :param token: Should evaluate to either Token or string key in to the Cache,
+                  which is expected to contain ``numpy`` array of supplied
+                  ``shape`` and ``dtype``
+
+    :param shape: Expected shape of the future array
+
+    :param dtype: Expected dtype of the future array
+
+    :param chunks: Tuple of integers describing chunk partitioning for output array
+
+    :param name: Dask name
+
+    Gotchas
+    =======
+
+    - Output array can not be moved from one worker to another.
+      - Works with in-process Client
+      - Works with single worker cluster
+      - Can work if scheduler is told to schedule this on a single worker
+
+    - Cache life cycle management can be tough. If token evaluates to a
+      ``Token`` object then automatic cache cleanup should happen when output
+      array is destroyed. If it is just a string, then it's up to caller to
+      ensure that there is cleanup and no use after free.
+
+    Returns
+    =======
+    Dask Array
+    """
+    if not isinstance(shape, tuple):
+        shape = (shape,)
+
+    assert dask.is_dask_collection(token)
+    assert len(shape) == len(chunks)
+
+    _chunks = unpack_chunks(chunks, shape)
+    _rois = [tuple(_roi_from_chunks(ch)) for ch in _chunks]
+    _roi = lambda idx: tuple(_rois[i][k] for i, k in enumerate(idx))
+
+    shape_in_chunks = tuple(len(ch) for ch in _chunks)
+
+    dsk = {}
+    name = randomize(name)
+
+    for idx in np.ndindex(shape_in_chunks):
+        dsk[(name, *idx)] = (_chunk_extractor, token.key, _roi(idx))
+
+    dsk = HighLevelGraph.from_collections(name, dsk, dependencies=[token])
+
+    return da.Array(dsk, name, shape=shape, dtype=dtype, chunks=_chunks)
+
+
+def da_mem_sink(xx: da.Array, chunks: Tuple[int, ...], name="memsink") -> da.Array:
+    """
+    It's a kind of fancy rechunk for special needs.
+
+    Assumptions
+    - Single worker only
+    - ``xx`` can fit in RAM of the worker
+
+    Note that every output chunk depends on ALL of input chunks.
+
+    On some Dask worker:
+    - Fully evaluate ``xx`` and serialize to RAM
+    - Present in RAM view of the result with a different chunking regime
+
+    A common use case would be to load a large collection (>50% of RAM) that
+    needs to be processed by some non-Dask code as a whole. A simple
+    ``do_stuff(xx.compute())`` would not work as duplicating RAM is not an
+    option in that scenario. Normal rechunk might also run out of RAM and
+    introduces large memory copy overhead as all input chunks need to be cached
+    then re-assembled into a different chunking structure.
+    """
+    token = dask.delayed(Cache.new)(xx.shape, xx.dtype)
+
+    sink = dask.delayed(CachedArray)(token)
+    fut = da.store(xx, sink, lock=False, compute=False)
+
+    return _da_from_mem(
+        with_deps(token, fut), shape=xx.shape, dtype=xx.dtype, chunks=chunks, name=name
+    )
+
+
+def da_yxbt_sink(
+    bands: Tuple[da.Array, ...], chunks: Tuple[int, ...], name="yxbt"
+) -> da.Array:
+    """
+    each band is in <t,y,x>
+    output is <y,x,b,t>
+
+    eval(bands) |> transpose(YXBT) |> Store(RAM) |> DaskArray(RAM, chunks)
+    """
+    b = bands[0]
+    dtype = b.dtype
+    nt, ny, nx = b.shape
+    nb = len(bands)
+    shape = (ny, nx, nb, nt)
+
+    token = dask.delayed(Cache.new)(shape, dtype)
+
+    sinks = [dask.delayed(_YXBTSink)(token, idx) for idx in range(nb)]
+    fut = da.store(bands, sinks, lock=False, compute=False)
+
+    return _da_from_mem(
+        with_deps(token, fut), shape=shape, dtype=dtype, chunks=chunks, name=name
+    )
 
 
 def test_cache():
     k = Cache.new((5,), "uint8")
-    assert isinstance(k, str)
+    assert isinstance(k, Token)
     xx = Cache.get(k)
     assert xx.shape == (5,)
     assert xx.dtype == "uint8"
@@ -147,10 +313,8 @@ def test_cache():
     assert Cache.get(k) is None
 
 
-def test_data_sink():
-    import pytest
-
-    ds = DataSink.new((100, 200), "uint16")
+def test_cached_array():
+    ds = CachedArray.new((100, 200), "uint16")
     xx = ds.data
     assert xx.shape == (100, 200)
     assert xx.dtype == "uint16"
@@ -165,7 +329,23 @@ def test_data_sink():
     assert (ds.data[:10, :20] == ds2.data).all()
     assert (ds.data[:10, :20] == 133).all()
 
-    with pytest.raises(NotImplementedError):
-        ds2.view(np.s_[:3])
+    ds.release()
 
-    ds.unlink()
+
+def test_da_from_mem():
+    shape = (100, 200)
+    chunks = (10, 101)
+    xx = (np.random.uniform(size=shape) * 1000).astype("uint16")
+
+    k = Cache.put(xx)
+    yy = _da_from_mem(
+        dask.delayed(str(k)), xx.shape, xx.dtype, chunks=chunks, name="yy"
+    )
+    assert yy.name.startswith("yy-")
+    assert yy.shape == xx.shape
+    assert yy.dtype == xx.dtype
+    assert yy.chunks[1] == (101, 99)
+
+    assert (yy.compute() == xx).all()
+
+    assert (yy[:3, :5].compute() == xx[:3, :5]).all()

--- a/libs/algo/odc/algo/_memsink.py
+++ b/libs/algo/odc/algo/_memsink.py
@@ -159,7 +159,7 @@ def store_to_mem(
             token.release()
 
 
-def yxbt_sink(bands: Tuple[da.Array, ...], client: Client) -> np.ndarray:
+def yxbt_sink_to_mem(bands: Tuple[da.Array, ...], client: Client) -> np.ndarray:
     assert client.scheduler.address.startswith("inproc://")
 
     b = bands[0]

--- a/libs/algo/odc/algo/_warp.py
+++ b/libs/algo/odc/algo/_warp.py
@@ -7,7 +7,7 @@ import xarray as xr
 from dask import is_dask_collection
 import dask.array as da
 from dask.highlevelgraph import HighLevelGraph
-from ._dask import randomize, crop_2d_dense, unpack_chunksize, empty_maker
+from ._dask import randomize, crop_2d_dense, unpack_chunks, empty_maker
 from datacube.utils.geometry import GeoBox, rio_reproject, compute_reproject_roi
 from datacube.utils.geometry.gbox import GeoboxTiles
 from datacube.utils import spatial_dims
@@ -96,7 +96,7 @@ def dask_reproject(
 
     assert src.shape[axis : axis + 2] == src_geobox.shape
     yx_shape = dst_geobox.shape
-    yx_chunks = tuple(unpack_chunksize(ch, n) for ch, n in zip(chunks, yx_shape))
+    yx_chunks = unpack_chunks(chunks, yx_shape)
 
     dst_chunks = src.chunks[:axis] + yx_chunks + src.chunks[axis + 2 :]
     dst_shape = src.shape[:axis] + yx_shape + src.shape[axis + 2 :]

--- a/libs/stats/tests/test_utils.py
+++ b/libs/stats/tests/test_utils.py
@@ -1,4 +1,3 @@
-import json
 import pathlib
 from datetime import datetime, timedelta
 from types import SimpleNamespace
@@ -6,8 +5,7 @@ from uuid import UUID
 import pystac
 
 from odc.index.stac import stac_transform
-from odc.stats._gm import gm_product
-from odc.stats.model import DateTimeRange, Task
+from odc.stats.model import DateTimeRange
 from odc.stats.tasks import TaskReader
 from odc.stats.utils import (
     CompressedDataset,
@@ -33,12 +31,16 @@ def gen_compressed_dss(n, dt0=datetime(2010, 1, 1, 11, 30, 27), step=timedelta(d
 
 
 def test_stac():
-    product = gm_product(location="/tmp/")
+    from odc.stats._gm import StatsGMS2
+    product = StatsGMS2().product(location="/tmp/")
     reader = TaskReader(str(TEST_DIR / "test_tiles.db"), product)
     task = reader.load_task(reader.all_tiles[0])
 
     stac_meta = task.render_metadata()
     odc_meta = stac_transform(stac_meta)
+
+    # TODO: actually test content of odc_meta?
+    assert isinstance(odc_meta, dict)
 
     stac_item = pystac.Item.from_dict(stac_meta)
     stac_item.validate()


### PR DESCRIPTION
- Different masking strategy: cloud in any view for this pixel -- no input pixel
- Adds cloud preprocessing: shrink away small clouds (helps with persistent misclassifications), then pad out remaining clouds. This computation happens in the native resolution of the mask band.
- Compute TMADs as part of the output
- Use floating point version of `hdstats.geomedian`, as TMADs for uint version do not work correctly
   - This adds some memory overhead, but too much and it can be controlled by choosing smaller/bigger work chunk size
   - Floating point version of geomedian is more robust and actually runs faster even though it needs to read twice as much data from RAM.
- Use more memory stable approach for loading data

![image](https://user-images.githubusercontent.com/1428024/104670426-f0cd5500-572f-11eb-8f1e-4f99b37c2bed.png)

Storage is pre-allocated at the start of load operation and every Band-time-slice goes into the right spot (that includes transposition into YXBT order). Only after all the load have completed geomedian computation starts. Compared to a properly dask native approach this can only work on single worker cluster, but has much more predictable performance and lower peak memory usage, also typically faster.



