### PR TITLE
Add count and rgba output to Geomedian plugin

### DIFF
--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -28,6 +28,7 @@ from ._masking import (
 from ._geomedian import (
     xr_geomedian,
     reshape_for_geomedian,
+    geomedian_with_mads,
     int_geomedian,
     int_geomedian_np,
 )
@@ -84,6 +85,7 @@ __all__ = (
     "int_geomedian",
     "int_geomedian_np",
     "reshape_for_geomedian",
+    "geomedian_with_mads",
     "reshape_yxbt",
     "chunked_persist",
     "chunked_persist_da",

--- a/libs/algo/odc/algo/__init__.py
+++ b/libs/algo/odc/algo/__init__.py
@@ -5,6 +5,7 @@
 from ._masking import (
     keep_good_np,
     keep_good_only,
+    erase_bad,
     from_float,
     from_float_np,
     to_f32,
@@ -61,6 +62,7 @@ from ._warp import (
 __all__ = (
     "keep_good_np",
     "keep_good_only",
+    "erase_bad",
     "from_float",
     "from_float_np",
     "to_f32",

--- a/libs/algo/odc/algo/_geomedian.py
+++ b/libs/algo/odc/algo/_geomedian.py
@@ -312,9 +312,7 @@ def geomedian_with_mads(
 ) -> xr.Dataset:
     """
     TODO: make user friendly
-     - check that yxbt chunks are right
      - accept Dataset and do yxbt conversion internally
-     - allow choosing whether MADs are needed
      - then expose in `odc.algo.` and deprecate other geomedian versions
     """
     assert dask.is_dask_collection(yxbt)
@@ -322,6 +320,9 @@ def geomedian_with_mads(
     ny, nx, nb, nt = yxbt.shape
     nodata = yxbt.attrs.get("nodata", None)
     assert yxbt.chunks is not None
+    if yxbt.data.numblocks[2:4] != (1, 1):
+        raise ValueError("There should be one dask block along time and band dimension")
+
     n_extras = (3 if compute_mads else 0) + (1 if compute_count else 0)
     chunks = (*yxbt.chunks[:2], (nb + n_extras,))
 

--- a/libs/dscache/odc/dscache/apps/dstiler.py
+++ b/libs/dscache/odc/dscache/apps/dstiler.py
@@ -42,7 +42,7 @@ def cli(native, native_albers, web, grid, dbfile):
                       ^crs      ^y  ^x ^ny  ^nx
       - square     : 'epsg:3857;10;10000'
       - named      : albers_au_25
-                     albers_africa_10  (20,30,60 are also available)
+                     africa_10  (20,30,60 are also available)
     """
     cache = dscache.open_rw(dbfile)
     label = "Processing {} ({:,d} datasets)".format(dbfile, cache.count)

--- a/libs/dscache/odc/dscache/apps/slurpy.py
+++ b/libs/dscache/odc/dscache/apps/slurpy.py
@@ -43,7 +43,7 @@ def qmap(proc, q, eos_marker=None):
     type=str,
     help=(
         "Grid spec or name 'crs;pixel_resolution;shape_in_pixels',"
-        "albers_au_25, albers_africa_{10|20|30|60}"
+        "albers_au_25, africa_{10|20|30|60}"
     ),
     default=None,
 )

--- a/libs/io/odc/io/cgroups.py
+++ b/libs/io/odc/io/cgroups.py
@@ -1,0 +1,29 @@
+"""
+Query Linux cgroup fs for various info
+"""
+from typing import Optional
+from .text import read_int
+
+
+def get_cpu_quota() -> Optional[float]:
+    """
+    :returns: ``None`` if unconstrained or there is an error
+    :returns: maximum amount of CPU this pod is allowed to use
+    """
+    quota = read_int("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    if quota is None:
+        return None
+    period = read_int("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    if period is None:
+        return None
+    return quota / period
+
+
+def get_mem_quota() -> Optional[int]:
+    """
+    :returns: ``None`` if there was some error
+    :returns: maximum RAM, in bytes, this pod can use according to Linux cgroups
+
+    Note that number returned can be larger than total available memory.
+    """
+    return read_int("/sys/fs/cgroup/memory/memory.limit_in_bytes")

--- a/libs/io/odc/io/text.py
+++ b/libs/io/odc/io/text.py
@@ -86,6 +86,18 @@ def slurp_lines(fname: str, *args, **kwargs) -> List[str]:
         return [s.rstrip() for s in f.readlines()]
 
 
+def read_int(path: PathLike, default=None, base=10) -> Optional[int]:
+    """
+    Read single integer from a text file.
+
+    Useful for things like parsing content of /sys/ or /proc.
+    """
+    try:
+        return int(slurp(path), base)
+    except (FileNotFoundError, ValueError):
+        return default
+
+
 def parse_mtl(txt: str) -> Dict[str, Any]:
     def parse_value(s):
         if len(s) == 0:

--- a/libs/stats/odc/stats/_cli_run.py
+++ b/libs/stats/odc/stats/_cli_run.py
@@ -105,7 +105,7 @@ def run(
         overwrite=overwrite,
         max_processing_time=max_processing_time,
     )
-    if len(resampling) > 0:
+    if resampling is not None and len(resampling) > 0:
         if plugin_config is None:
             plugin_config = {}
         plugin_config["resampling"] = resampling

--- a/libs/stats/odc/stats/_cli_run.py
+++ b/libs/stats/odc/stats/_cli_run.py
@@ -82,7 +82,6 @@ def run(
     from .model import TaskRunnerConfig
     from .proc import TaskRunner
     from ._plugins import import_all
-    from odc.io.text import parse_yaml_file_or_inline
 
     _log = logging.getLogger(__name__)
 
@@ -112,12 +111,20 @@ def run(
         plugin_config["resampling"] = resampling
 
     if plugin_config is not None:
-        _cfg['plugin_config'] = plugin_config
+        _cfg["plugin_config"] = plugin_config
 
     if cog_config is not None:
-        _cfg['cog_opts'] = cog_config
+        per_band_cfg = {k: v for k, v in cog_config.items() if isinstance(v, dict)}
+        if per_band_cfg:
+            for k in per_band_cfg:
+                cog_config.pop(k)
+
+            _cfg["cog_opts_per_band"] = per_band_cfg
+
+        _cfg["cog_opts"] = cog_config
 
     cfg = TaskRunnerConfig(**_cfg)
+    _log.info(f"Using this config: {cfg}")
 
     runner = TaskRunner(cfg, resolution=resolution)
     if dryrun:

--- a/libs/stats/odc/stats/_cli_save_tasks.py
+++ b/libs/stats/odc/stats/_cli_save_tasks.py
@@ -9,11 +9,11 @@ from ._cli_common import main
     "--grid",
     type=str,
     help=(
-        "Grid name or spec: albers_au_25,albers_africa_{10|20|30|60},"
+        "Grid name or spec: albers_au_25,africa_{10|20|30|60},"
         "'crs;pixel_resolution;shape_in_pixels'"
     ),
     prompt="""Enter GridSpec
- one of albers_au_25, albers_africa_{10|20|30|60}
+ one of albers_au_25, africa_{10|20|30|60}
  or custom like 'epsg:3857;30;5000' (30m pixels 5,000 per side in epsg:3857)
  >""",
     default=None,

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -18,6 +18,14 @@ class StatsGMS2(StatsPluginInterface):
         bands: Optional[Tuple[str, ...]] = None,
         filters: Optional[Tuple[int, int]] = (2, 5),
         work_chunks: Tuple[int, int] = (400, 400),
+        mask_band: str = "SCL",
+        cloud_classes=(
+            "cloud shadows",
+            "cloud medium probability",
+            "cloud high probability",
+            "thin cirrus",
+        ),
+        basis_band=None,
     ):
         if bands is None:
             bands = (
@@ -35,16 +43,11 @@ class StatsGMS2(StatsPluginInterface):
 
         self.resampling = resampling
         self.bands = tuple(bands)
-        self._basis_band = self.bands[0]
+        self._basis_band = basis_band or self.bands[0]
         self.mad_bands = ("smad", "emad", "bcmad")
-        self._mask_band = "SCL"
+        self._mask_band = mask_band
         self.filters = filters
-        self.cloud_classes = (
-            "cloud shadows",
-            "cloud medium probability",
-            "cloud high probability",
-            "thin cirrus",
-        )
+        self.cloud_classes = tuple(cloud_classes)
 
         self._work_chunks = (*work_chunks, -1, -1)
 

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -14,7 +14,7 @@ from . import _plugins
 class StatsGMS2(StatsPluginInterface):
     def __init__(
         self,
-        resampling: str = "average",
+        resampling: str = "bilinear",
         bands: Optional[Tuple[str, ...]] = None,
         filters: Optional[Tuple[int, int]] = (2, 5),
         work_chunks: Tuple[int, int] = (400, 400),

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -127,6 +127,7 @@ class StatsGMS2(StatsPluginInterface):
             num_threads=1,
             scale=scale,
             offset=-1 * scale,
+            reshape_strategy="mem",
             out_chunks=(-1, -1, -1),
             work_chunks=self._work_chunks,
         )

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -134,9 +134,16 @@ class S3COGSink:
         else:
             raise ValueError(f"Can't handle url: {uri}")
 
-    def dump(self, task: Task, ds: Dataset) -> Delayed:
+    def dump(self, task: Task, ds: Dataset, aux: Optional[Dataset] = None) -> Delayed:
         paths = task.paths("absolute", ext=self._band_ext)
         cogs = self._ds_to_cog(ds, paths)
+
+        if aux is not None:
+            aux_paths = {
+                k: task.aux_path(k, relative_to="absolute", ext=self._band_ext)
+                for k in aux.data_vars
+            }
+            cogs.extend(self._ds_to_cog(aux, aux_paths))
 
         json_url = task.metadata_path("absolute", ext=self._meta_ext)
         meta = task.render_metadata(ext=self._band_ext)

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -333,6 +333,12 @@ class StatsPluginInterface(ABC):
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         pass
 
+    def rgba(self, xx: xr.Dataset) -> Optional[xr.DataArray]:
+        """
+        Given result of ``.reduce(..)`` optionally produce RGBA preview image
+        """
+        return None
+
 
 @dataclass
 class TaskResult:

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 import math
-import psutil
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -388,6 +387,3 @@ class TaskRunnerConfig:
 
     def __post_init__(self):
         self.cog_opts = dicttoolz.merge(self.default_cog_settings(), self.cog_opts)
-
-        if self.threads <= 0:
-            self.threads = psutil.cpu_count()

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -235,6 +235,17 @@ class Task:
         """
         return self._prefix(relative_to) + "." + ext
 
+    def aux_path(self, name: str, relative_to: str = "dataset", ext: str = EXT_TIFF):
+        """
+        Compute path for some auxilary file.
+
+        :param relative_to: dataset|product|absolute
+        :param name: "band"
+        :param ext: File extension, defaults to tif
+        """
+        prefix = self._prefix(relative_to)
+        return f"{prefix}_{name}.{ext}"
+
     def render_metadata(
         self, ext: str = EXT_TIFF, processing_dt: Optional[datetime] = None
     ) -> Dict[str, Any]:

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -297,7 +297,13 @@ class TaskRunner:
 
             _log.debug(f"Submitting to Dask ({task.location})")
             ds = client.persist(ds, fifo_timeout="1ms")
-            cog = sink.dump(task, ds)
+
+            aux: Optional[xr.Dataset] = None
+            rgba = proc.rgba(ds)
+            if rgba is not None:
+                aux = xr.Dataset(dict(rgba=rgba))
+
+            cog = sink.dump(task, ds, aux)
             cog = client.compute(cog, fifo_timeout="1ms")
 
             _log.debug("Waiting for completion")


### PR DESCRIPTION
- Compute input pixel count (clear only) for every output pixel of geomedian
- Generate RGBA image as part of the Task run
- Support per-band customization of COG options on the command line
example
- Configurable names for TMADS and COUNT bands, with capitalized default names
- Changes default resampling for Geomedian to be `bilinear`
- Fixes missing `nodata` attribute on the output of Geomedian data bands

```yaml
compress: deflate
zlevel: 9
rgba:
  compress: jpeg
  jpeg_quality: 90
```
- Add `erase_bad`, sibling to `keep_good_only` 
- Optionally disable computation of MADs/COUNT bands at the library function level
- Default to allocated CPU/MEMORY when running inside a pod (uses cgroup fs to find out those)
- Removed `albers_` prefix for epsg:6933 africa grids (6933 is not Albers, so that name was bad)
- Understand both `africa-10` and `africa_10` as the same grid
