### PR TITLE
Refactor Output Product Construction/Configuration

### DIFF
--- a/libs/stats/odc/stats/_cli_run.py
+++ b/libs/stats/odc/stats/_cli_run.py
@@ -114,13 +114,6 @@ def run(
         _cfg["plugin_config"] = plugin_config
 
     if cog_config is not None:
-        per_band_cfg = {k: v for k, v in cog_config.items() if isinstance(v, dict)}
-        if per_band_cfg:
-            for k in per_band_cfg:
-                cog_config.pop(k)
-
-            _cfg["cog_opts_per_band"] = per_band_cfg
-
         _cfg["cog_opts"] = cog_config
 
     cfg = TaskRunnerConfig(**_cfg)

--- a/libs/stats/odc/stats/_cli_save_tasks.py
+++ b/libs/stats/odc/stats/_cli_save_tasks.py
@@ -9,7 +9,7 @@ from ._cli_common import main
     "--grid",
     type=str,
     help=(
-        "Grid name or spec: au-{10|20|39|60},africa-{10|20|30|60}, albers-au-25 (legacy one)"
+        "Grid name or spec: au-{10|20|30|60},africa-{10|20|30|60}, albers-au-25 (legacy one)"
         "'crs;pixel_resolution;shape_in_pixels'"
     ),
     prompt="""Enter GridSpec

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -12,6 +12,11 @@ from . import _plugins
 
 
 class StatsGMS2(StatsPluginInterface):
+    NAME = "gm_s2_annual"
+    SHORT_NAME = NAME
+    VERSION = '0.0.0'
+    PRODUCT_FAMILY = "geomedian"
+
     def __init__(
         self,
         resampling: str = "bilinear",
@@ -60,35 +65,9 @@ class StatsGMS2(StatsPluginInterface):
         self.cloud_classes = tuple(cloud_classes)
         self._work_chunks = work_chunks
 
-    def product(self, location: Optional[str] = None, **kw) -> OutputProduct:
-        name = "ga_s2_gm"
-        short_name = "ga_s2_gm"
-        version = "0.0.0"
-
-        if location is None:
-            bucket = "deafrica-stats-processing"
-            location = f"s3://{bucket}/{name}/v{version}"
-        else:
-            location = location.rstrip("/")
-
-        measurements = self.bands + self.aux_bands
-
-        properties = {
-            "odc:file_format": "GeoTIFF",
-            "odc:producer": "ga.gov.au",
-            "odc:product_family": "statistics",  # TODO: ???
-            "platform": "sentinel-2",
-        }
-
-        return OutputProduct(
-            name=name,
-            version=version,
-            short_name=short_name,
-            location=location,
-            properties=properties,
-            measurements=measurements,
-            href=f"https://collections.digitalearth.africa/product/{name}",
-        )
+    @property
+    def measurements(self) -> Tuple[str, ...]:
+        return self.bands + self.aux_bands
 
     def input_data(self, task: Task) -> xr.Dataset:
         basis = self._basis_band

--- a/libs/stats/odc/stats/_wofs.py
+++ b/libs/stats/odc/stats/_wofs.py
@@ -1,50 +1,29 @@
 """
 Wofs Summary
 """
-from typing import Optional
+from typing import Optional, Tuple
 import xarray as xr
 from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
 from odc.algo import safe_div, apply_numexpr
-from .model import OutputProduct, StatsPluginInterface
+from .model import StatsPluginInterface
 from . import _plugins
 
 
 class StatsWofs(StatsPluginInterface):
+    NAME = "ga_ls_wo_summary"
+    SHORT_NAME = NAME
+    VERSION = '0.0.0'
+    PRODUCT_FAMILY = "wo_summary"
+
     def __init__(
         self, resampling: str = "bilinear",
     ):
         self.resampling = resampling
 
-    def product(self, location: Optional[str] = None, **kw) -> OutputProduct:
-        name = "ga_s2_wo_summary"
-        short_name = "ga_s2_wo_summary"
-        version = "0.0.0"
-
-        if location is None:
-            bucket = "deafrica-stats-processing"  # TODO: ??
-            location = f"s3://{bucket}/{name}/v{version}"
-        else:
-            location = location.rstrip("/")
-
-        measurements = ("count_wet", "count_clear", "frequency")
-
-        properties = {
-            "odc:file_format": "GeoTIFF",
-            "odc:producer": "ga.gov.au",
-            "odc:product_family": "statistics",  # TODO: ???
-            "platform": "landsat",  # TODO: ???
-        }
-
-        return OutputProduct(
-            name=name,
-            version=version,
-            short_name=short_name,
-            location=location,
-            properties=properties,
-            measurements=measurements,
-            href=f"https://collections.digitalearth.africa/product/{name}",
-        )
+    @property
+    def measurements(self) -> Tuple[str, ...]:
+        return ("count_wet", "count_clear", "frequency")
 
     def _native_tr(self, xx):
         wet = xx.water == 128

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -2,7 +2,7 @@
 Various I/O adaptors
 """
 
-from typing import Dict, Any, Optional, List, Union
+from typing import Dict, Any, Optional, List, Union, cast
 import json
 from urllib.parse import urlparse
 import logging
@@ -82,7 +82,9 @@ class S3COGSink:
             tmp.update(cog_opts)
             cog_opts = tmp
 
-        cog_opts_per_band = cog_opts.pop("overrides", {})
+        cog_opts_per_band = cast(
+            Dict[str, Dict[str, Any]], cog_opts.pop("overrides", {})
+        )
         per_band_cfg = {k: v for k, v in cog_opts.items() if isinstance(v, dict)}
         if per_band_cfg:
             for k in per_band_cfg:

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -52,15 +52,42 @@ class S3COGSink:
         self,
         creds: Union[ReadOnlyCredentials, str, None] = None,
         cog_opts: Optional[Dict[str, Any]] = None,
-        cog_opts_per_band: Optional[Dict[str, Dict[str, Any]]] = None,
         public: bool = False,
     ):
+        """
+        :param creds: S3 write credentials
+        :param cog_opts: Configure compression settings, globally and per-band
+        :param public: Mark objects as public access
+
+        Example of COG config
+
+        .. code-block:: python
+
+           # - Lossless compression for all bands but rgba
+           # - Webp compression for rgba band
+           cfg = {
+               "compression": "deflate",
+               "zlevel": 9,
+               "blocksize": 1024,
+               "overrides": {"rgba": {"compression": "webp", "webp_level": 80}},
+           }
+
+
+        """
 
         if cog_opts is None:
             cog_opts = dict(**DEFAULT_COG_OPTS)
+        else:
+            tmp = dict(**DEFAULT_COG_OPTS)
+            tmp.update(cog_opts)
+            cog_opts = tmp
 
-        if cog_opts_per_band is None:
-            cog_opts_per_band = {}
+        cog_opts_per_band = cog_opts.pop("overrides", {})
+        per_band_cfg = {k: v for k, v in cog_opts.items() if isinstance(v, dict)}
+        if per_band_cfg:
+            for k in per_band_cfg:
+                cog_opts.pop(k)
+            cog_opts_per_band.update(per_band_cfg)
 
         self._creds = creds
         self._cog_opts = cog_opts

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 import math
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -320,8 +320,13 @@ class Task:
 
 
 class StatsPluginInterface(ABC):
-    @abstractmethod
-    def product(self, location: Optional[str] = None, **kw: Any) -> OutputProduct:
+    NAME = "*unset*"
+    SHORT_NAME = ""
+    VERSION = "0.0.0"
+    PRODUCT_FAMILY = "statistics"
+
+    @abstractproperty
+    def measurements(self) -> Tuple[str, ...]:
         pass
 
     @abstractmethod
@@ -337,6 +342,57 @@ class StatsPluginInterface(ABC):
         Given result of ``.reduce(..)`` optionally produce RGBA preview image
         """
         return None
+
+    def product(
+        self,
+        location: str,
+        name: Optional[str] = None,
+        short_name: Optional[str] = None,
+        version: Optional[str] = None,
+        product_family: Optional[str] = None,
+        collections_site: str = "collections.dea.ga.gov.au",
+        producer: str = "ga.gov.au",
+        properties: Dict[str, Any] = dict(),
+    ) -> OutputProduct:
+        """
+        :param location: Output location string or template, example ``s3://bucket/{product}/v{version}``
+        :param name: Override for product name
+        :param short_name: Override for product short_name
+        :param version: Override for version
+        :param product_family: Override for odc:product_family
+        :param collections_site: href=f"https://{collections_site}/product/{name}"
+        :param producer: Producer ``ga.gov.au``
+        """
+        if name is None:
+            name = self.NAME
+        if short_name is None:
+            short_name = self.SHORT_NAME
+            if len(short_name) == 0:
+                short_name = name
+        if version is None:
+            version = self.VERSION
+        if product_family is None:
+            product_family = self.PRODUCT_FAMILY
+
+        if "{" in location and "}" in location:
+            location = location.format(
+                name=name, product=name, version=version, short_name=short_name
+            )
+
+        return OutputProduct(
+            name=name,
+            version=version,
+            short_name=short_name,
+            location=location,
+            properties={
+                "odc:file_format": "GeoTIFF",
+                "odc:product_family": product_family,
+                "odc:producer": producer,
+                **properties,
+            },
+            measurements=self.measurements,
+            href=f"https://{collections_site}/product/{name}",
+        )
 
 
 @dataclass
@@ -371,6 +427,11 @@ class TaskRunnerConfig:
     plugin: str = ""
     plugin_config: Dict[str, Any] = field(init=True, repr=False, default_factory=dict)
 
+    # Output Product
+    #  .{name| short_name| version| product_family|
+    #    collections_site| producer| properties: Dict[str, Any]}
+    product: Dict[str, Any] = field(init=True, repr=True, default_factory=dict)
+
     # Dask config
     threads: int = -1
     memory_limit: str = ""
@@ -379,7 +440,9 @@ class TaskRunnerConfig:
     output_location: str = ""
     s3_public: bool = False
     cog_opts: Dict[str, Any] = field(init=True, repr=True, default_factory=dict)
-    cog_opts_per_band: Dict[str, Dict[str, Any]] = field(init=True, repr=True, default_factory=dict)
+    cog_opts_per_band: Dict[str, Dict[str, Any]] = field(
+        init=True, repr=True, default_factory=dict
+    )
     overwrite: bool = False
 
     # SQS config when applicable

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -425,7 +425,7 @@ class TaskRunnerConfig:
 
     # Plugin
     plugin: str = ""
-    plugin_config: Dict[str, Any] = field(init=True, repr=False, default_factory=dict)
+    plugin_config: Dict[str, Any] = field(init=True, repr=True, default_factory=dict)
 
     # Output Product
     #  .{name| short_name| version| product_family|

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -440,9 +440,6 @@ class TaskRunnerConfig:
     output_location: str = ""
     s3_public: bool = False
     cog_opts: Dict[str, Any] = field(init=True, repr=True, default_factory=dict)
-    cog_opts_per_band: Dict[str, Dict[str, Any]] = field(
-        init=True, repr=True, default_factory=dict
-    )
     overwrite: bool = False
 
     # SQS config when applicable

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -44,7 +44,7 @@ class TaskRunner:
         _log.info(f"Resolving plugin: {cfg.plugin}")
         mk_proc = _plugins.resolve(cfg.plugin)
         self.proc = mk_proc(**cfg.plugin_config)
-        self.product = self.proc.product(cfg.output_location)
+        self.product = self.proc.product(cfg.output_location, **cfg.product)
         _log.info(f"Output product: {self.product}")
 
         _log.info(f"Constructing task reader: {cfg.filedb}")

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -37,7 +37,6 @@ class TaskRunner:
         self._log = _log
         self.sink = S3COGSink(
             cog_opts=cfg.cog_opts,
-            cog_opts_per_band=cfg.cog_opts_per_band,
             public=cfg.s3_public,
         )
 

--- a/libs/stats/tests/__init__.py
+++ b/libs/stats/tests/__init__.py
@@ -1,0 +1,17 @@
+"""
+Utilities for unit tests
+"""
+
+from datetime import datetime, timedelta
+from uuid import UUID
+from odc.stats.utils import CompressedDataset
+
+
+def gen_compressed_dss(n, dt0=datetime(2010, 1, 1, 11, 30, 27), step=timedelta(days=1)):
+    if isinstance(step, int):
+        step = timedelta(days=step)
+
+    dt = dt0
+    for i in range(n):
+        yield CompressedDataset(UUID(int=i), dt)
+        dt = dt + step

--- a/libs/stats/tests/__init__.py
+++ b/libs/stats/tests/__init__.py
@@ -5,6 +5,27 @@ Utilities for unit tests
 from datetime import datetime, timedelta
 from uuid import UUID
 from odc.stats.utils import CompressedDataset
+from odc.stats.model import StatsPluginInterface
+
+
+class DummyPlugin(StatsPluginInterface):
+    NAME = "test_long"
+    SHORT_NAME = "test_short"
+    VERSION = "1.2.3"
+    PRODUCT_FAMILY = "test"
+
+    def __init__(self, bands=("a", "b", "c")):
+        self._bands = tuple(bands)
+
+    @property
+    def measurements(self):
+        return self._bands
+
+    def input_data(self, task):
+        return None
+
+    def reduce(self, xx):
+        return xx
 
 
 def gen_compressed_dss(n, dt0=datetime(2010, 1, 1, 11, 30, 27), step=timedelta(days=1)):

--- a/libs/stats/tests/conftest.py
+++ b/libs/stats/tests/conftest.py
@@ -1,5 +1,6 @@
 import pathlib
 import pytest
+from . import DummyPlugin
 
 TEST_DIR = pathlib.Path(__file__).parent.absolute()
 
@@ -10,5 +11,14 @@ def test_dir():
 
 
 @pytest.fixture
-def test_db(test_dir):
-    return test_dir / "test_tiles.db"
+def test_db_path(test_dir):
+    return str(test_dir / "test_tiles.db")
+
+
+@pytest.fixture
+def dummy_plugin_name():
+    from odc.stats._plugins import register
+
+    name = "dummy-plugin"
+    register(name, DummyPlugin)
+    return name

--- a/libs/stats/tests/conftest.py
+++ b/libs/stats/tests/conftest.py
@@ -1,0 +1,14 @@
+import pathlib
+import pytest
+
+TEST_DIR = pathlib.Path(__file__).parent.absolute()
+
+
+@pytest.fixture
+def test_dir():
+    return TEST_DIR
+
+
+@pytest.fixture
+def test_db(test_dir):
+    return test_dir / "test_tiles.db"

--- a/libs/stats/tests/test_proc.py
+++ b/libs/stats/tests/test_proc.py
@@ -1,0 +1,17 @@
+from odc.stats.proc import TaskRunner, TaskRunnerConfig
+
+
+def test_runner_product_cfg(test_db_path, dummy_plugin_name):
+    cfg = TaskRunnerConfig(
+        filedb=test_db_path,
+        plugin=dummy_plugin_name,
+        product={"name": "ga_test", "short_name": "tt", "version": "3.2.1"},
+        output_location="s3://data-bucket/{product}/v{version}",
+        plugin_config={'bands': ['red', 'nir']}
+    )
+    runner = TaskRunner(cfg)
+    assert runner.product.name == "ga_test"
+    assert runner.product.short_name == "tt"
+    assert runner.product.version == "3.2.1"
+    assert runner.product.location == 's3://data-bucket/ga_test/v3.2.1'
+    assert runner.product.measurements == ('red', 'nir')

--- a/libs/stats/tests/test_proc.py
+++ b/libs/stats/tests/test_proc.py
@@ -7,11 +7,29 @@ def test_runner_product_cfg(test_db_path, dummy_plugin_name):
         plugin=dummy_plugin_name,
         product={"name": "ga_test", "short_name": "tt", "version": "3.2.1"},
         output_location="s3://data-bucket/{product}/v{version}",
-        plugin_config={'bands': ['red', 'nir']}
+        plugin_config={"bands": ["red", "nir"]},
+        cog_opts={
+            "compression": "deflate",
+            "zlevel": 9,
+            "blocksize": 1024,
+            "overrides": {"rgba": {"compression": "webp", "webp_level": 80}},
+        },
     )
     runner = TaskRunner(cfg)
     assert runner.product.name == "ga_test"
     assert runner.product.short_name == "tt"
     assert runner.product.version == "3.2.1"
-    assert runner.product.location == 's3://data-bucket/ga_test/v3.2.1'
-    assert runner.product.measurements == ('red', 'nir')
+    assert runner.product.location == "s3://data-bucket/ga_test/v3.2.1"
+    assert runner.product.measurements == ("red", "nir")
+
+    cfg = runner.sink.cog_opts("red")
+    assert "overrides" not in cfg
+    assert cfg["blocksize"] == 1024
+    assert cfg["compression"] == "deflate"
+    assert cfg["zlevel"] == 9
+
+    cfg = runner.sink.cog_opts("rgba")
+    assert "overrides" not in cfg
+    assert cfg["blocksize"] == 1024
+    assert cfg["compression"] == "webp"
+    assert cfg["webp_level"] == 80

--- a/libs/stats/tests/test_utils.py
+++ b/libs/stats/tests/test_utils.py
@@ -16,10 +16,10 @@ from odc.stats.utils import (
 from . import gen_compressed_dss
 
 
-def test_stac(test_db):
+def test_stac(test_db_path):
     from odc.stats._gm import StatsGMS2
     product = StatsGMS2().product(location="/tmp/")
-    reader = TaskReader(str(test_db), product)
+    reader = TaskReader(test_db_path, product)
     task = reader.load_task(reader.all_tiles[0])
 
     stac_meta = task.render_metadata()

--- a/libs/stats/tests/test_utils.py
+++ b/libs/stats/tests/test_utils.py
@@ -1,14 +1,11 @@
-import pathlib
-from datetime import datetime, timedelta
+from datetime import datetime
 from types import SimpleNamespace
-from uuid import UUID
 import pystac
 
 from odc.index.stac import stac_transform
 from odc.stats.model import DateTimeRange
 from odc.stats.tasks import TaskReader
 from odc.stats.utils import (
-    CompressedDataset,
     bin_annual,
     bin_full_history,
     bin_generic,
@@ -16,24 +13,13 @@ from odc.stats.utils import (
     mk_season_rules,
     season_binner,
 )
-
-TEST_DIR = pathlib.Path(__file__).parent.absolute()
-
-
-def gen_compressed_dss(n, dt0=datetime(2010, 1, 1, 11, 30, 27), step=timedelta(days=1)):
-    if isinstance(step, int):
-        step = timedelta(days=step)
-
-    dt = dt0
-    for i in range(n):
-        yield CompressedDataset(UUID(int=i), dt)
-        dt = dt + step
+from . import gen_compressed_dss
 
 
-def test_stac():
+def test_stac(test_db):
     from odc.stats._gm import StatsGMS2
     product = StatsGMS2().product(location="/tmp/")
-    reader = TaskReader(str(TEST_DIR / "test_tiles.db"), product)
+    reader = TaskReader(str(test_db), product)
     task = reader.load_task(reader.all_tiles[0])
 
     stac_meta = task.render_metadata()


### PR DESCRIPTION
- Change StatsPluginInterface
- Add some unit tests for product construction
- Add --config option to `odc-stats runner`

Example config:

```yaml
plugin: pq
plugin_config:
  filters: [[2, 5], [0, 5]]
  resampling: average
product:
  name: pc_s2_annual
  short_name: pc_s2_annual
  version: 0.0.2
  collections_site: collections.digitalearth.africa
  producer: deafrica

s3_public: true
overwrite: false
output_location: "s3://some-bucket/{product}/v{version}"
```