### PR TITLE
Remove the Landsat C2 special case.

### DIFF
--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -9,7 +9,7 @@ from toolz import get_in
 
 Document = Dict[str, Any]
 
-KNOWN_CONSTELLATIONS = ["sentinel-2", "Landsat"]
+KNOWN_CONSTELLATIONS = ["sentinel-2"]
 
 LANDSAT_PLATFORMS = ["landsat-5", "landsat-7", "landsat-8"]
 
@@ -26,8 +26,6 @@ MAPPING_STAC_TO_EO3 = {
     "view:sun_azimuth": "eo:sun_azimuth",
     "view:sun_elevation": "eo:sun_elevation",
 }
-
-LANDSAT_PRODUCTS = {"LANDSAT_8": "ls8_sr", "LANDSAT_7": "ls7_sr", "LANDSAT_5": "ls5_sr"}
 
 
 def _stac_product_lookup(item: Document) -> Tuple[str, str, Optional[str], str]:
@@ -52,13 +50,6 @@ def _stac_product_lookup(item: Document) -> Tuple[str, str, Optional[str], str]:
                 properties["sentinel:grid_square"],
             )
             default_grid = "g10m"
-        if constellation == "Landsat":
-            product_label = properties["landsat:scene_id"]
-            product_name = LANDSAT_PRODUCTS[properties["eo:platform"]]
-            region_code = "{path:03d}{row:03d}".format(
-                path=int(properties["landsat:wrs_path"]),
-                row=int(properties["landsat:wrs_row"]),
-            )
     elif properties.get("platform") in LANDSAT_PLATFORMS:
         self_href = _find_self_href(item)
         product_label = Path(self_href).stem.replace(".stac-item", "")


### PR DESCRIPTION
Decided that patching the metadata is better than writing custom code to handle every product...

I really need to spend some time on an ODC extension to the STAC standards, so that we can specify the inclusion of some fields when we want them.