### PR TITLE
SQS absolute paths

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -112,12 +112,6 @@ def dump_to_odc(
     default=False,
     help="Needed when accessing requester pays public buckets",
 )
-@click.option(
-    "--absolute",
-    is_flag=True,
-    default=False,
-    help="Use absolute measurements file paths instead of relative.",
-)
 @click.argument("uri", type=str, nargs=1)
 @click.argument("product", type=str, nargs=1)
 def cli(
@@ -130,7 +124,6 @@ def cli(
     skip_check,
     no_sign_request,
     request_payer,
-    absolute,
     uri,
     product,
 ):

--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -112,6 +112,12 @@ def dump_to_odc(
     default=False,
     help="Needed when accessing requester pays public buckets",
 )
+@click.option(
+    "--absolute",
+    is_flag=True,
+    default=False,
+    help="Use absolute measurements file paths instead of relative.",
+)
 @click.argument("uri", type=str, nargs=1)
 @click.argument("product", type=str, nargs=1)
 def cli(
@@ -124,6 +130,7 @@ def cli(
     skip_check,
     no_sign_request,
     request_payer,
+    absolute,
     uri,
     product,
 ):

--- a/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
@@ -385,6 +385,12 @@ def queue_to_odc(
     default=None,
     help="A path to a list (one item per line, in txt or gzip format) of valide region_codes to include",
 )
+@click.option(
+    "--absolute",
+    is_flag=True,
+    default=False,
+    help="Use absolute paths when converting from stac",
+)
 @click.argument("queue_name", type=str, nargs=1)
 @click.argument("product", type=str, nargs=1)
 def cli(
@@ -400,6 +406,7 @@ def cli(
     allow_unsafe,
     record_path,
     region_code_list_uri,
+    absolute,
     queue_name,
     product,
 ):
@@ -407,7 +414,7 @@ def cli(
 
     transform = None
     if stac:
-        transform = stac_transform
+        transform = lambda stat_doc: stac_transform(stat_doc, not absolute)
 
     candidate_products = product.split()
 

--- a/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
@@ -414,7 +414,7 @@ def cli(
 
     transform = None
     if stac:
-        transform = lambda stat_doc: stac_transform(stat_doc, not absolute)
+        transform = lambda stat_doc: stac_transform(stat_doc, relative=not absolute)
 
     candidate_products = product.split()
 


### PR DESCRIPTION
This PR adds an `--absolute` flag to `sqs-to-dc` that triggers `stac_transform` to use absolute paths. 

Prior to this the `stac_transform` would use relative paths which works under the assumption that each dataset has a flat directory structure. For datasets like L2 ARD the metadata document is located at `/dataset/metadata.yaml` and measurements are located at `/dataset/subfolder/measurement.TIF`. `stac_transform(metadata, relative=True)` stores the incorrect relative path of `measurement.TIF. ` instead of `subfolder/measurement.TIF` causing errors when data is loaded.