### PR TITLE
Change Grids to be positive index only

### DIFF
--- a/libs/dscache/odc/dscache/tools/tiling.py
+++ b/libs/dscache/odc/dscache/tools/tiling.py
@@ -10,41 +10,44 @@ from odc.io.text import split_and_check, parse_range_int
 epsg3577 = CRS("epsg:3577")
 epsg6933 = CRS("epsg:6933")
 
-
+# Origin was chosen such that there are no negative indexed tiles for any valid
+# point within a given CRS's valid region, and also making sure that x=0,y=0
+# lines fall on tile edges.
+#
 GRIDS = {
     "albers_au_25": GridSpec(
         crs=epsg3577, tile_size=(100_000.0, 100_000.0), resolution=(-25, 25)
     ),
     "au": GridSpec(
-        crs=epsg3577, tile_size=(96_000.0, 96_000.0), resolution=(-96_000, 96_000)
+        crs=epsg3577,
+        tile_size=(96_000.0, 96_000.0),
+        resolution=(-96_000, 96_000),
+        origin=(-5088000, -2208000),
     ),
-    "au_10": GridSpec(
-        crs=epsg3577, tile_size=(96_000.0, 96_000.0), resolution=(-10, 10)
-    ),
-    "au_20": GridSpec(
-        crs=epsg3577, tile_size=(96_000.0, 96_000.0), resolution=(-20, 20)
-    ),
-    "au_30": GridSpec(
-        crs=epsg3577, tile_size=(96_000.0, 96_000.0), resolution=(-30, 30)
-    ),
-    "au_60": GridSpec(
-        crs=epsg3577, tile_size=(96_000.0, 96_000.0), resolution=(-60, 60)
-    ),
+    **{
+        f"au_{n}": GridSpec(
+            crs=epsg3577,
+            tile_size=(96_000.0, 96_000.0),
+            resolution=(-n, n),
+            origin=(-5088000, -2208000),
+        )
+        for n in (10, 20, 30, 60)
+    },
     "global": GridSpec(
-        crs=epsg6933, tile_size=(96_000.0, 96_000.0), resolution=(-96_000, 96_000)
+        crs=epsg6933,
+        tile_size=(96_000.0, 96_000.0),
+        resolution=(-96_000, 96_000),
+        origin=(-7392000, -17376000),
     ),
-    "global_10": GridSpec(
-        crs=epsg6933, tile_size=(96_000.0, 96_000.0), resolution=(-10, 10)
-    ),
-    "global_20": GridSpec(
-        crs=epsg6933, tile_size=(96_000.0, 96_000.0), resolution=(-20, 20)
-    ),
-    "global_30": GridSpec(
-        crs=epsg6933, tile_size=(96_000.0, 96_000.0), resolution=(-30, 30)
-    ),
-    "global_60": GridSpec(
-        crs=epsg6933, tile_size=(96_000.0, 96_000.0), resolution=(-60, 60)
-    ),
+    **{
+        f"global_{n}": GridSpec(
+            crs=epsg6933,
+            tile_size=(96_000.0, 96_000.0),
+            resolution=(-n, n),
+            origin=(-7392000, -17376000),
+        )
+        for n in (10, 20, 30, 60)
+    },
 }
 
 

--- a/libs/stats/docs/example-cfg.yaml
+++ b/libs/stats/docs/example-cfg.yaml
@@ -21,6 +21,9 @@ product:
   collections_site: explorer.digitalearth.africa
   producer: digitalearthafrica.org
 
+  # For Africa we need to pad to 3 chars for fixed width
+  region_code_format: "x{x:03d}y{y:03d}"
+
   # Any extra fields to add to .properties section of the STAC/EO3
   # for each dataset document
   properties: {}

--- a/libs/stats/docs/example-cfg.yaml
+++ b/libs/stats/docs/example-cfg.yaml
@@ -1,0 +1,73 @@
+# Sample configuration file for `odc-stats run` command
+#
+#    odc-stats run --config <this-file|content of this file> ...
+
+# It's a template {product} and {version} are replaced at run time
+output_location: 's3://deafrica-services/s2_stats_annual/{product}/{version}/'
+
+# Configure Plugin and Product Attributes
+plugin: pq
+
+# Generic product attributes
+product:
+  name: pc_s2_annual
+  short_name: pc_s2_annual
+  version: 1.0.0
+  product_family: pixel_quality_statistics
+
+  # specific to a site: Africa
+  # (for AU just keep defaults)
+  #collections_site: collections.digitalearthafrica.org
+  collections_site: explorer.digitalearth.africa
+  producer: digitalearthafrica.org
+
+  # Any extra fields to add to .properties section of the STAC/EO3
+  # for each dataset document
+  properties: {}
+
+
+# Plugin Specific Configuration
+# defaults for PQ are currently this
+#
+# plugin_config:
+#   filters: [[2, 5], [0, 5]]
+#   resampling: nearest
+
+# Other common settings
+
+# input data is public-access
+aws_unsigned: true
+
+# mark output files as public read (default is false)
+s3_public: true
+
+# Completion deadline in seconds, 0 (default) means take
+# as along as it takes
+max_processing_time: 0
+
+# SQS specific settings
+#  300s, i.e. 5 minutes is max lease at any given time
+#  extended when getting within 30s of expiry
+#  polling every 5 seconds
+job_queue_max_lease: 300
+renew_safety_margin: 30
+future_poll_interval: 5
+
+# TIFF compression settings
+cog_opts:
+  # Default settings for bands
+  compression: deflate
+  zlevel: 9
+  blocksize: 800
+
+  # overview settings
+  ovr_blocksize: 512
+  overview_resampling: average
+  overview_levels: [2,4,8,16,32]
+
+  # Bands that require special treatment
+  # Applies to Geomedian Product
+  overrides:
+    rgba:
+      compression: webp
+      webp_level: 90

--- a/libs/stats/odc/stats/_gjson.py
+++ b/libs/stats/odc/stats/_gjson.py
@@ -43,8 +43,8 @@ def compute_grid_info(
     """
     if title_width == 0:
         nmax = max([max(abs(ix), abs(iy)) for ix, iy in cells])
-        # title_width is the number of digits in the index, +1 for positive or negative
-        title_width = len(str(nmax)) + 1
+        # title_width is the number of digits in the index
+        title_width = len(str(nmax))
 
     grid_info = {}
 
@@ -61,7 +61,7 @@ def compute_grid_info(
             "type": "Feature",
             "geometry": geom.json,
             "properties": {
-                "title": f"{ix:+0{title_width}d},{iy:+0{title_width}d}",
+                "title": f"{ix:0{title_width}d},{iy:0{title_width}d}",
                 "utc_offset": utc_offset,
                 "total": len(cell.dss),
             },

--- a/libs/stats/odc/stats/_gjson.py
+++ b/libs/stats/odc/stats/_gjson.py
@@ -62,6 +62,9 @@ def compute_grid_info(
             "geometry": geom.json,
             "properties": {
                 "title": f"{ix:0{title_width}d},{iy:0{title_width}d}",
+                "region_code": f"x{ix:0{title_width}d}y{iy:0{title_width}d}",
+                "ix": ix,
+                "iy": iy,
                 "utc_offset": utc_offset,
                 "total": len(cell.dss),
             },

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -448,6 +448,9 @@ class StatsPluginInterface(ABC):
                 name=name, product=name, version=version, short_name=short_name
             )
 
+        # remove trailing / if present
+        location = location.rstrip("/")
+
         return OutputProduct(
             name=name,
             version=version,

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -141,17 +141,19 @@ class OutputProduct:
     properties: Dict[str, str]
     measurements: Tuple[str, ...]
     href: str = ""
+    region_code_format: str = "x{x:02d}y{y:02d}"
     cfg: Any = None
 
     def __post_init__(self):
         if self.href == "":
             self.href = f"{default_href_prefix}/{self.name}"
 
-    def region_code(self, tidx: TileIdx_xy, sep="", n=4) -> str:
+    def region_code(self, tidx: TileIdx_xy) -> str:
         """
         Render tile index into a string.
         """
-        return f"x{tidx[0]:+0{n}d}{sep}y{tidx[1]:+0{n}d}"
+        x, y = tidx
+        return self.region_code_format.format(x=x, y=y)
 
     @staticmethod
     def dummy(
@@ -261,7 +263,10 @@ class Task:
         """
         Product relative location for this task
         """
-        return self.product.region_code(self.tile_index, "/") + "/" + self.short_time
+        rc = self.product.region_code(self.tile_index)
+        mid = len(rc)//2
+        p1, p2 = rc[:mid], rc[mid:]
+        return "/".join([p1, p2 , self.short_time])
 
     def _lineage(self) -> Tuple[UUID, ...]:
         return tuple(ds.id for ds in self.datasets)

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -330,8 +330,9 @@ class Task:
             processing_dt, timespec="seconds"
         )
         properties["odc:region_code"] = region_code
-        properties["odc:lineage"] = dict(inputs=inputs)
         properties["odc:product"] = product.name
+        properties["odc:dataset_version"] = product.version
+        properties["odc:lineage"] = dict(inputs=inputs)
 
         geobox_wgs84 = geobox.extent.to_crs(
             "epsg:4326", resolution=math.inf, wrapdateline=True

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -141,11 +141,8 @@ class TaskRunner:
             nds = len(task.datasets)
             # TODO: take care of utc offset for day boundaries when computing ndays
             ndays = len(set(ds.center_time.date() for ds in task.datasets))
-            task_id = (
-                f"{task.short_time}/{task.tile_index[0]:+05d}/{task.tile_index[1]:+05d}"
-            )
             flag = flag_mapping.get(exists, "")
-            msg = f"{task_id} days={ndays:03} ds={nds:04} {uri}{flag}"
+            msg = f"{task.location} days={ndays:03} ds={nds:04} {uri}{flag}"
 
             yield TaskResult(task, uri, skipped=skipped, meta=msg)
 

--- a/libs/stats/odc/stats/tasks.py
+++ b/libs/stats/odc/stats/tasks.py
@@ -63,7 +63,7 @@ def sanitize_query(query):
 
 def render_task(tidx: TileIdx_txy) -> str:
     period, xi, yi = tidx
-    return f"{period}/{xi:+04d}/{yi:+04d}"
+    return f"{period}/{xi:02d}/{yi:02d}"
 
 
 def parse_task(s: str) -> TileIdx_txy:

--- a/libs/stats/tests/test_stats_model.py
+++ b/libs/stats/tests/test_stats_model.py
@@ -121,3 +121,5 @@ def test_plugin_product():
     assert product.properties["odc:producer"] == "custom-producer"
     assert product.properties["odc:custom-key"] == 33
     assert product.href == f"https://custom-site.com/product/{product.name}"
+
+    assert product.region_code((1, 22)) == 'x01y22'


### PR DESCRIPTION
- Offset AU and Global/Africa grids to never have negative index values
- New grids still have the same footprint as before, just different label
- Change default region_code formatting to be something like `x03y23`
- Allow region code formatting customization from config (python format string)
- Record product version in every dataset document in `properties["odc:dataset_version"]`, not my choice of naming, this is what is used by `eodataset3` lib, it was originally intended to be "dataset version" with the last digit changing whenever Dataset is re-processed.