### PR TITLE
Fix SQS renew logic

### DIFF
--- a/libs/stats/odc/stats/_sqs.py
+++ b/libs/stats/odc/stats/_sqs.py
@@ -55,9 +55,8 @@ class SQSWorkToken(WorkTokenInterface):
             return False
 
         new_deadline = self.now() + timedelta(seconds=seconds)
-        new_timeout = int((new_deadline - self._t0).total_seconds())
 
-        rr = self._msg.change_visibility(VisibilityTimeout=new_timeout)
+        rr = self._msg.change_visibility(VisibilityTimeout=seconds)
         ok = toolz.get_in(["ResponseMetadata", "HTTPStatusCode"], rr, default=-1) == 200
 
         if ok:

--- a/libs/stats/odc/stats/tasks.py
+++ b/libs/stats/odc/stats/tasks.py
@@ -361,7 +361,7 @@ class TaskReader:
         self,
         sqs_queue,
         product: Optional[OutputProduct] = None,
-        visibility_timeout: int = 3600,
+        visibility_timeout: int = 300,
         **kw,
     ) -> Iterator[Task]:
         from odc.aws.queue import get_messages, get_queue


### PR DESCRIPTION
AWS api interprets new timeout relative to "now" not relative to when message was removed from the queue.