### PR TITLE
Support arbitrary ACLs, change default version formatting to match DEA rules

### DIFF
--- a/libs/stats/docs/example-cfg.yaml
+++ b/libs/stats/docs/example-cfg.yaml
@@ -41,8 +41,16 @@ product:
 # input data is public-access
 aws_unsigned: true
 
-# mark output files as public read (default is false)
-s3_public: true
+# Supply arbitrary "canned" ACL for s3 put operations
+#
+# Mark objects for public read
+#  s3_acl: 'public-read'
+# When writing cross-account use this
+#  s3_acl: 'bucket-owner-full-control'
+
+# Same as s3_acl: 'public-read', use `s3_acl: public-read` instead
+# s3_public: true
+
 
 # Completion deadline in seconds, 0 (default) means take
 # as along as it takes

--- a/libs/stats/odc/stats/_cli_run.py
+++ b/libs/stats/odc/stats/_cli_run.py
@@ -99,6 +99,7 @@ def run(
         config = {}
 
     _cfg = dict(**config)
+    s3_acl = 'public-read' if public else None
 
     cfg_from_cli = {
         k: v
@@ -108,7 +109,7 @@ def run(
             threads=threads,
             memory_limit=memory_limit,
             output_location=location,
-            s3_public=public,
+            s3_acl=s3_acl,
             overwrite=overwrite,
             max_processing_time=max_processing_time,
         ).items()

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -510,6 +510,8 @@ class TaskRunnerConfig:
 
     # S3/Output config
     output_location: str = ""
+    s3_acl: Optional[str] = None
+    # s3_public is deprecated, use s3_acl="public-read" instead
     s3_public: bool = False
     cog_opts: Dict[str, Any] = field(init=True, repr=True, default_factory=dict)
     overwrite: bool = False

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -264,9 +264,9 @@ class Task:
         Product relative location for this task
         """
         rc = self.product.region_code(self.tile_index)
-        mid = len(rc)//2
+        mid = len(rc) // 2
         p1, p2 = rc[:mid], rc[mid:]
-        return "/".join([p1, p2 , self.short_time])
+        return "/".join([p1, p2, self.short_time])
 
     def _lineage(self) -> Tuple[UUID, ...]:
         return tuple(ds.id for ds in self.datasets)
@@ -424,7 +424,7 @@ class StatsPluginInterface(ABC):
         properties: Dict[str, Any] = dict(),
     ) -> OutputProduct:
         """
-        :param location: Output location string or template, example ``s3://bucket/{product}/v{version}``
+        :param location: Output location string or template, example ``s3://bucket/{product}/{version}``
         :param name: Override for product name
         :param short_name: Override for product short_name
         :param version: Override for version
@@ -444,8 +444,14 @@ class StatsPluginInterface(ABC):
             product_family = self.PRODUCT_FAMILY
 
         if "{" in location and "}" in location:
+            version_dashed = version.replace(".", "-")
             location = location.format(
-                name=name, product=name, version=version, short_name=short_name
+                name=name,
+                product=name,
+                short_name=short_name,
+                version=version_dashed,
+                version_dashed=version_dashed,
+                version_raw=version,
             )
 
         # remove trailing / if present

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -37,7 +37,9 @@ class TaskRunner:
         _log = logging.getLogger(__name__)
         self._cfg = cfg
         self._log = _log
-        self.sink = S3COGSink(cog_opts=cfg.cog_opts, public=cfg.s3_public,)
+        self.sink = S3COGSink(
+            cog_opts=cfg.cog_opts, acl=cfg.s3_acl, public=cfg.s3_public
+        )
 
         _log.info(f"Resolving plugin: {cfg.plugin}")
         mk_proc = _plugins.resolve(cfg.plugin)

--- a/libs/stats/tests/test_proc.py
+++ b/libs/stats/tests/test_proc.py
@@ -6,7 +6,7 @@ def test_runner_product_cfg(test_db_path, dummy_plugin_name):
         filedb=test_db_path,
         plugin=dummy_plugin_name,
         product={"name": "ga_test", "short_name": "tt", "version": "3.2.1"},
-        output_location="s3://data-bucket/{product}/v{version}",
+        output_location="s3://data-bucket/{product}/{version}",
         plugin_config={"bands": ["red", "nir"]},
         cog_opts={
             "compression": "deflate",
@@ -19,7 +19,7 @@ def test_runner_product_cfg(test_db_path, dummy_plugin_name):
     assert runner.product.name == "ga_test"
     assert runner.product.short_name == "tt"
     assert runner.product.version == "3.2.1"
-    assert runner.product.location == "s3://data-bucket/ga_test/v3.2.1"
+    assert runner.product.location == "s3://data-bucket/ga_test/3-2-1"
     assert runner.product.measurements == ("red", "nir")
 
     cfg = runner.sink.cog_opts("red")

--- a/libs/stats/tests/test_stats_model.py
+++ b/libs/stats/tests/test_stats_model.py
@@ -92,7 +92,7 @@ def test_parse_all_tasks():
 
 def test_plugin_product():
     plugin = DummyPlugin(bands=("red", "green"))
-    product = plugin.product("file:///tmp/{product}/v{version}")
+    product = plugin.product("file:///tmp/{product}/v{version_raw}")
     assert product.name == DummyPlugin.NAME
     assert product.short_name == DummyPlugin.SHORT_NAME
     assert product.version == DummyPlugin.VERSION


### PR DESCRIPTION
- Instead of `s3_public: true|false` use `s3_acl: <str>`.
- Instead of rendering product version as raw string, replace dots with dashes, `1.3.4` -> `1-3-4` only when expanding location template.