### PR TITLE
Compute day boundaries taking care of local time

### DIFF
--- a/libs/index/odc/index/_index.py
+++ b/libs/index/odc/index/_index.py
@@ -10,6 +10,7 @@ from datacube.api.query import Query
 from datacube.index.hl import Doc2Dataset
 from datacube.model import Range, Dataset
 from odc.io.text import parse_yaml
+from ._grouper import solar_offset
 
 
 def from_metadata_stream(metadata_stream, index, **kwargs):
@@ -249,6 +250,7 @@ def bin_dataset_stream(gridspec, dss, cells, persist=None):
 
      .idx     - tile index (x,y)
      .geobox  - tile geobox
+     .utc_offset - timedelta to add to timestamp to get day component in local time
      .dss     - list of UUIDs, or results of `persist(dataset)` if custom `persist` is supplied
     """
 
@@ -260,7 +262,10 @@ def bin_dataset_stream(gridspec, dss, cells, persist=None):
     def register(tile, geobox, val):
         cell = cells.get(tile)
         if cell is None:
-            cells[tile] = SimpleNamespace(geobox=geobox, idx=tile, dss=[val])
+            utc_ofset = solar_offset(geobox.extent)
+            cells[tile] = SimpleNamespace(
+                geobox=geobox, idx=tile, utc_offset=utc_ofset, dss=[val]
+            )
         else:
             cell.dss.append(val)
 

--- a/libs/stats/odc/stats/utils.py
+++ b/libs/stats/odc/stats/utils.py
@@ -44,8 +44,8 @@ def bin_seasonal(
 
     tasks = {}
     for tidx, cell in cells.items():
-        # TODO: deal with UTC offsets for day boundary determination
-        grouped = toolz.groupby(lambda ds: binner(ds.time), cell.dss)
+        utc_offset = cell.utc_offset
+        grouped = toolz.groupby(lambda ds: binner(ds.time + utc_offset), cell.dss)
 
         for temporal_k, dss in grouped.items():
             if temporal_k != "":
@@ -71,8 +71,8 @@ def bin_annual(
     """
     tasks = {}
     for tidx, cell in cells.items():
-        # TODO: deal with UTC offsets for day boundary determination
-        grouped = toolz.groupby(lambda ds: ds.time.year, cell.dss)
+        utc_offset = cell.utc_offset
+        grouped = toolz.groupby(lambda ds: (ds.time + utc_offset).year, cell.dss)
 
         for year, dss in grouped.items():
             temporal_k = (f"{year}--P1Y",)

--- a/libs/stats/tests/test_utils.py
+++ b/libs/stats/tests/test_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 import pystac
 
@@ -18,6 +18,7 @@ from . import gen_compressed_dss
 
 def test_stac(test_db_path):
     from odc.stats._gm import StatsGMS2
+
     product = StatsGMS2().product(location="/tmp/")
     reader = TaskReader(test_db_path, product)
     task = reader.load_task(reader.all_tiles[0])
@@ -34,7 +35,11 @@ def test_stac(test_db_path):
 
 def test_binning():
     dss = list(gen_compressed_dss(100, dt0=datetime(2000, 1, 1), step=27))
-    cells = {(0, 1): SimpleNamespace(dss=dss, geobox=None, idx=None)}
+    cells = {
+        (0, 1): SimpleNamespace(
+            dss=dss, geobox=None, idx=None, utc_offset=timedelta(seconds=0)
+        )
+    }
 
     def verify(task):
         for (t, *_), dss in task.items():


### PR DESCRIPTION
- Add extra field `.utc_offset` to output of bin_datasets
- Adjust timestamp by that amount before deciding what "day"
  dataset was captured on