### PR TITLE
Add sha1 output

### DIFF
--- a/libs/index/odc/index/__init__.py
+++ b/libs/index/odc/index/__init__.py
@@ -17,6 +17,7 @@ from ._index import (
     ordered_dss,
     chopped_dss,
     all_datasets,
+    product_from_yaml,
 )
 
 from ._uuid import (
@@ -55,6 +56,7 @@ __all__ = (
     "ordered_dss",
     "chopped_dss",
     "all_datasets",
+    "product_from_yaml",
     "odc_uuid",
     "utm_region_code",
     "utm_zone_to_epsg",

--- a/libs/stats/docs/example-cfg.yaml
+++ b/libs/stats/docs/example-cfg.yaml
@@ -7,6 +7,11 @@ output_location: 's3://deafrica-services/s2_stats_annual/{product}/{version}/'
 
 # Configure Plugin and Product Attributes
 plugin: pq
+plugin_config:
+  # Plugin specific configuration
+  filters: [[2, 5], [0, 5]]
+  resampling: 'nearest'
+
 
 # Generic product attributes
 product:

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -337,7 +337,6 @@ class Task:
         properties["odc:region_code"] = region_code
         properties["odc:product"] = product.name
         properties["odc:dataset_version"] = product.version
-        properties["odc:lineage"] = dict(inputs=inputs)
 
         geobox_wgs84 = geobox.extent.to_crs(
             "epsg:4326", resolution=math.inf, wrapdateline=True
@@ -350,11 +349,12 @@ class Task:
             bbox=[bbox.left, bbox.bottom, bbox.right, bbox.top],
             datetime=self.time_range.start.replace(tzinfo=timezone.utc),
             properties=properties,
+            stac_extensions=["projection"]
         )
 
-        # Enable the Projection extension
-        item.ext.enable("projection")
         item.ext.projection.epsg = geobox.crs.epsg
+        # Lineage last
+        item.properties["odc:lineage"] = dict(inputs=inputs)
 
         # Add all the assets
         for band, path in self.paths(ext=ext).items():

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -151,13 +151,13 @@ class TaskRunner:
     def _safe_result(self, f: Future, task: Task) -> TaskResult:
         _log = self._log
         try:
-            path, ok = f.result()
-            if ok:
-                return TaskResult(task, path)
+            rr = f.result()
+            if rr.error is None:
+                return TaskResult(task, rr.path)
             else:
-                error_msg = f"Failed to write: {path}"
+                error_msg = f"Failed to write: {rr.path}"
                 _log.error(error_msg)
-                return TaskResult(task, path, error=error_msg)
+                return TaskResult(task, rr.path, error=error_msg)
         except Exception as e:
             _log.error(f"Error during processing of {task.location} {e}")
             return TaskResult(task, error=str(e))

--- a/libs/stats/tests/__init__.py
+++ b/libs/stats/tests/__init__.py
@@ -17,9 +17,11 @@ class DummyPlugin(StatsPluginInterface):
     VERSION = "1.2.3"
     PRODUCT_FAMILY = "test"
 
-    def __init__(self, bands=("a", "b", "c"), delay=0):
+    def __init__(self, bands=("a", "b", "c"), delay=0, nodata=-9999, dtype="int16"):
         self._bands = tuple(bands)
         self._delay = delay
+        self._nodata = nodata
+        self._dtype = dtype
 
     @property
     def measurements(self):
@@ -28,7 +30,11 @@ class DummyPlugin(StatsPluginInterface):
     def input_data(self, task):
         ts = sorted([ds.center_time for ds in task.datasets])
         xx = mk_dask_xx(
-            task.geobox, timestamps=ts, mode="random", attrs=dict(nodata=-9999)
+            task.geobox,
+            timestamps=ts,
+            mode="random",
+            attrs=dict(nodata=self._nodata),
+            dtype=self._dtype,
         )
         return xr.Dataset(dict(xx=xx))
 


### PR DESCRIPTION
Write `.sha1` file with hashes of written files.

- Generate STAC file content and compute SHA1 of that
- Write all COGs (parallel as completed order) and compute SHA1 hashes of each
- Write `.sha1` file (including hash of STAC file that was not written yet)
- Finally write STAC json

### Other Changes

- Change stac output file name to end with `.stac-item.json`, rather than just `.json`
- Update example config with `plugin_config` section.

