### PR TITLE
GQA filtering in save-tasks and GM refactor and fmask fix

### DIFF
--- a/libs/stats/odc/stats/_cli_save_tasks.py
+++ b/libs/stats/odc/stats/_cli_save_tasks.py
@@ -31,7 +31,7 @@ from ._cli_common import main
 @click.option(
     "--frequency",
     type=str,
-    help="Specify temporal binning: annual|semiannual|seasonal|all",
+    help="Specify temporal binning: annual|annual-fy|semiannual|seasonal|all",
 )
 @click.option("--env", "-E", type=str, help="Datacube environment name")
 @click.option(
@@ -105,7 +105,7 @@ def save_tasks(
         temporal_range = DateTimeRange.year(year)
 
     if frequency is not None:
-        if frequency not in ("annual", "annual-fy", "all", "semiannual", "seasonal"):
+        if frequency not in ("annual", "annual-fy", "semiannual", "seasonal", "all"):
             print(f"Frequency must be one of annual|annual-fy|semiannual|seasonal|all and not '{frequency}'")
             sys.exit(1)
 

--- a/libs/stats/odc/stats/_cli_save_tasks.py
+++ b/libs/stats/odc/stats/_cli_save_tasks.py
@@ -105,8 +105,8 @@ def save_tasks(
         temporal_range = DateTimeRange.year(year)
 
     if frequency is not None:
-        if frequency not in ("annual", "all", "semiannual", "seasonal"):
-            print(f"Frequency must be one of annual|seasonal|all and not '{frequency}'")
+        if frequency not in ("annual", "annual-fy", "all", "semiannual", "seasonal"):
+            print(f"Frequency must be one of annual|annual-fy|semiannual|seasonal|all and not '{frequency}'")
             sys.exit(1)
 
     if output == "":

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -11,60 +11,45 @@ from .model import StatsPluginInterface
 from . import _plugins
 
 
-class StatsGMS2(StatsPluginInterface):
-    NAME = "gm_s2_annual"
+class StatsGM(StatsPluginInterface):
+    NAME = "gm"
     SHORT_NAME = NAME
     VERSION = "0.0.0"
     PRODUCT_FAMILY = "geomedian"
 
     def __init__(
         self,
-        resampling: str = "bilinear",
-        bands: Optional[Tuple[str, ...]] = None,
-        filters: Optional[Tuple[int, int]] = (2, 5),
-        work_chunks: Tuple[int, int] = (400, 400),
-        mask_band: str = "SCL",
-        cloud_classes=(
-            "cloud shadows",
-            "cloud medium probability",
-            "cloud high probability",
-            "thin cirrus",
-        ),
+        bands: Tuple[str, ...],
+        mask_band: str,
+        cloud_classes: Tuple[str, ...],
+        nodata_classes: Optional[Tuple[str, ...]] = None,
+        filters: Optional[Tuple[int, int]] = (0, 0),
         basis_band=None,
-        nodata_class: Optional[str] = None,
-        aux_names=dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT"),
+        aux_names=dict(smad="smad", emad="emad", bcmad="bcmad", count="count"),
         rgb_bands=None,
         rgb_clamp=(1, 3_000),
+        resampling: str = "bilinear",
+        work_chunks: Tuple[int, int] = (400, 400),
     ):
-        if bands is None:
-            bands = (
-                "B02",
-                "B03",
-                "B04",
-                "B05",
-                "B06",
-                "B07",
-                "B08",
-                "B8A",
-                "B11",
-                "B12",
-            )
-            if rgb_bands is None:
-                rgb_bands = ("B04", "B03", "B02")
-
-        self.resampling = resampling
         self.bands = tuple(bands)
         self._basis_band = basis_band or self.bands[0]
+
+        if nodata_classes is not None:
+            nodata_classes = tuple(nodata_classes)
+
+        self._mask_band = mask_band
+        self.cloud_classes = tuple(cloud_classes)
+        self._nodata_classes = nodata_classes
+        self.filters = filters
+
         self._renames = aux_names
-        self.rgb_bands = rgb_bands
-        self.rgb_clamp = rgb_clamp
         self.aux_bands = tuple(
             self._renames.get(k, k) for k in ("smad", "emad", "bcmad", "count")
         )
-        self._mask_band = mask_band
-        self._nodata_class = nodata_class
-        self.filters = filters
-        self.cloud_classes = tuple(cloud_classes)
+        self.rgb_bands = rgb_bands
+        self.rgb_clamp = rgb_clamp
+
+        self.resampling = resampling
         self._work_chunks = work_chunks
 
     @property
@@ -82,7 +67,7 @@ class StatsGMS2(StatsPluginInterface):
         #  xx[mask == nodata] = nodata
         mask = xx[self._mask_band]
         xx = xx.drop_vars([self._mask_band])
-        keeps = enum_to_bool(mask, [self._nodata_class], invert=True)
+        keeps = enum_to_bool(mask, self._nodata_classes, invert=True)
         xx = keep_good_only(xx, keeps)
 
         return xx
@@ -104,7 +89,9 @@ class StatsGMS2(StatsPluginInterface):
         )
 
         bands_to_load = self.bands
-        if self._nodata_class is not None:
+        if self._nodata_classes is not None:
+            # NOTE: this ends up loading Mask band twice, once to compute
+            # ``.erase`` band and once to compute ``nodata`` mask.
             bands_to_load = (*bands_to_load, self._mask_band)
 
         xx = load_with_native_transform(
@@ -146,4 +133,117 @@ class StatsGMS2(StatsPluginInterface):
         return to_rgba(xx, clamp=self.rgb_clamp, bands=self.rgb_bands)
 
 
+_plugins.register("gm-generic", StatsGM)
+
+
+class StatsGMS2(StatsGM):
+    NAME = "gm_s2_annual"
+    SHORT_NAME = NAME
+    VERSION = "0.0.0"
+    PRODUCT_FAMILY = "geomedian"
+
+    def __init__(
+        self,
+        bands: Optional[Tuple[str, ...]] = None,
+        mask_band: str = "SCL",
+        cloud_classes: Tuple[str, ...] = (
+            "cloud shadows",
+            "cloud medium probability",
+            "cloud high probability",
+            "thin cirrus",
+        ),
+        nodata_classes: Optional[Tuple[str, ...]] = None,
+        filters: Optional[Tuple[int, int]] = (2, 5),
+        basis_band: Optional[str] = None,
+        aux_names=dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT"),
+        rgb_bands=None,
+        rgb_clamp=(1, 3_000),
+        resampling: str = "bilinear",
+        work_chunks: Tuple[int, int] = (400, 400),
+        **other,
+    ):
+        if bands is None:
+            bands = (
+                "B02",
+                "B03",
+                "B04",
+                "B05",
+                "B06",
+                "B07",
+                "B08",
+                "B8A",
+                "B11",
+                "B12",
+            )
+            if rgb_bands is None:
+                rgb_bands = ("B04", "B03", "B02")
+
+        super().__init__(
+            bands=bands,
+            mask_band=mask_band,
+            cloud_classes=cloud_classes,
+            nodata_classes=nodata_classes,
+            filters=filters,
+            basis_band=basis_band,
+            aux_names=aux_names,
+            rgb_bands=rgb_bands,
+            rgb_clamp=rgb_clamp,
+            resampling=resampling,
+            work_chunks=work_chunks,
+            **other,
+        )
+
+
 _plugins.register("gm-s2", StatsGMS2)
+
+
+class StatsGMLS(StatsGM):
+    NAME = "gm_ls_annual"
+    SHORT_NAME = NAME
+    VERSION = "3.0.0"
+    PRODUCT_FAMILY = "geomedian"
+
+    def __init__(
+        self,
+        bands: Optional[Tuple[str, ...]] = None,
+        mask_band: str = "fmask",
+        cloud_classes: Tuple[str, ...] = ("cloud", "shadow"),
+        nodata_classes: Optional[Tuple[str, ...]] = ("nodata",),
+        filters: Optional[Tuple[int, int]] = (0, 0),
+        basis_band: Optional[str] = None,
+        aux_names=dict(smad="sdev", emad="edev", bcmad="bcdev", count="count"),
+        rgb_bands=None,
+        rgb_clamp=(1, 3_000),
+        resampling: str = "bilinear",
+        work_chunks: Tuple[int, int] = (400, 400),
+        **other,
+    ):
+        if bands is None:
+            bands = (
+                "red",
+                "green",
+                "blue",
+                "nir",
+                "swir1",
+                "swir2",
+            )
+            if rgb_bands is None:
+                rgb_bands = ("red", "green", "blue")
+
+        super().__init__(
+            bands=bands,
+            mask_band=mask_band,
+            cloud_classes=cloud_classes,
+            nodata_classes=nodata_classes,
+            filters=filters,
+            basis_band=basis_band,
+            aux_names=aux_names,
+            rgb_bands=rgb_bands,
+            rgb_clamp=rgb_clamp,
+            resampling=resampling,
+            work_chunks=work_chunks,
+            **other,
+        )
+
+
+_plugins.register("gm-ls", StatsGMLS)

--- a/libs/stats/odc/stats/tasks.py
+++ b/libs/stats/odc/stats/tasks.py
@@ -228,6 +228,8 @@ class SaveTasks:
             tasks = bin_seasonal(cells, months=6, anchor=1)
         elif self._frequency == "seasonal":
             tasks = bin_seasonal(cells, months=3, anchor=12)
+        elif self._frequency == "annual-fy":
+            tasks = bin_seasonal(cells, months=12, anchor=7)
         elif self._frequency == "annual":
             tasks = bin_annual(cells)
         elif temporal_range is not None:

--- a/libs/stats/odc/stats/utils.py
+++ b/libs/stats/odc/stats/utils.py
@@ -99,7 +99,10 @@ def mk_season_rules(months: int, anchor: int) -> Dict[int, str]:
         for m in range(start_month, start_month + months):
             if m > 12:
                 m = m - 12
-            rules[m] = f"{start_month:02d}--P{months:d}M"
+            if months == 12:
+                rules[m] = f"{start_month:02d}--P1Y"
+            else:
+                rules[m] = f"{start_month:02d}--P{months:d}M"
 
     return rules
 


### PR DESCRIPTION
- Add `--gqa` option to `save-tasks`, allows filtering based on `odc:gqa_iterative_mean_xy` property (assumed to be present on every dataset of the source product)
- Add `--frequency=annual-fy` for financial year binning
- Split GM plugin into Generic/GM/S2 version, where GM and S2 just supply different configuration defaults
- Add extra (optional) native pixel transform to GM plugin, it erases data pixels based on the `nodata` value(s) of the mask. This is needed for Landsat GM since edge pixels do not get valid `fmask` classification and so need to be discarded. Cloud masking happens separately from this as we need to handle fusing for those differently.
