### PR TITLE
Support custom external plugins

### DIFF
--- a/libs/stats/README.md
+++ b/libs/stats/README.md
@@ -138,6 +138,16 @@ cog_opts:
 
 Note that configurations will vary between different products. See this [sample configuration for Australian Landsat-8](https://bitbucket.org/geoscienceaustralia/datakube-apps/src/develop/workspaces/dea-dev/processing/06_stats.yaml).
 
+It is also possible to define custom plugins outside of `odc.stats.*`. To do that, define class deriving from `odc.stats.model.StatsPluginInterface` and implement `.input_data` and `.reduce` methods. You can then specify fully qualified name of your custom plugin in `cfg.yaml`.
+
+```yaml
+plugin: mycustomlib.SomePluginOfMine
+plugin_config:
+   param1: 100
+   param2: "string param"
+   # ...
+```
+
 ## Orchestration
 
 > :warning: **This documentation section references some private configuration**

--- a/libs/stats/README.md
+++ b/libs/stats/README.md
@@ -78,7 +78,13 @@ Statistician has multiple different execution modes:
 A sample command to run a single task:
 
 ```
-odc-stats run ga_ls8c_ard_3_all.db  2015--P1Y/41/13 --threads=16 --memory-limit=60Gi --resolution=30 --config cfg.yaml --location file:///localpath/
+odc-stats run ga_ls8c_ard_3_all.db \
+ 2015--P1Y/41/13 \
+ --config cfg.yaml \
+ --resolution=30 \
+ --location file:///localpath/ \
+ --threads=16 \
+ --memory-limit=60Gi
 ```
 
 ```
@@ -164,7 +170,7 @@ Note that each queue will have a corresponding dead letter queue.
 
 The user and the queue will be created using a Terraform module which contains code similar to the following:
 
-```
+```terraform
 module "odc_stats_geomedian" {
 
   source = "../../../modules/statistician"

--- a/libs/stats/docs/example-cfg.yaml
+++ b/libs/stats/docs/example-cfg.yaml
@@ -6,6 +6,9 @@
 output_location: 's3://deafrica-services/s2_stats_annual/{product}/{version}/'
 
 # Configure Plugin and Product Attributes
+# Either pre-defined name like: pq, gm-generic, gm-s2, gm-ls
+# OR an external class
+#  plugin: mycustomlib.SomePluginOfMine
 plugin: pq
 plugin_config:
   # Plugin specific configuration

--- a/libs/stats/odc/stats/_plugins.py
+++ b/libs/stats/odc/stats/_plugins.py
@@ -18,8 +18,7 @@ def resolve(name: str) -> PluginFactory:
     if maker is None:
         maker = pydoc.locate(name)
         if maker is not None:
-            mro = getattr(maker, "__mro__", tuple())
-            if StatsPluginInterface not in mro:
+            if not issubclass(maker, (StatsPluginInterface,)):
                 raise ValueError(f"Custom StatsPlugin '{name}' is not derived from StatsPluginInterface")
             return partial(_new, maker)
 

--- a/libs/stats/tests/test_proc.py
+++ b/libs/stats/tests/test_proc.py
@@ -1,3 +1,4 @@
+import pytest
 from odc.stats.proc import TaskRunner, TaskRunnerConfig
 
 
@@ -33,3 +34,19 @@ def test_runner_product_cfg(test_db_path, dummy_plugin_name):
     assert cfg["blocksize"] == 1024
     assert cfg["compression"] == "webp"
     assert cfg["webp_level"] == 80
+
+
+def test_plugin_resolve():
+    from odc.stats._plugins import resolve
+    from odc.stats._gm import StatsGM
+
+    assert resolve("gm-generic") is not None
+    assert resolve("odc.stats._gm.StatsGM") is not None
+
+    # Test no such class
+    with pytest.raises(ValueError):
+        resolve("odc.nosuch.Class")
+
+    # Test wrong class
+    with pytest.raises(ValueError):
+        resolve("queue.Queue")


### PR DESCRIPTION
Basically

```yaml
plugin: somelib.MyPlugin
```

where `somelib.MyPlugin` must derive from `odc.stats.model.StatsPluginInterface`
