### PR TITLE
Dask Auto Persist

### DIFF
--- a/libs/algo/setup.py
+++ b/libs/algo/setup.py
@@ -23,6 +23,7 @@ setup(
         "datacube",
         "scikit-image",
         "dask_image",
+        "networkx",
     ],
     extras_require={'hdstats': ["hdstats>=0.1.7.post5"]},
     packages=["odc.algo"],


### PR DESCRIPTION
This PR adds functionality to automatically parse a dask graph and persist certain nodes to minimize peak memory usage. It currently makes a couple of assumptions:

- the dask graph is connected
- there is only one output node

I don't know whether these assumptions are realistic but they can be easily changed!

The graph parsing works by finding and removing the nodes that are the common descents of all  root nodes. This yields a disconnected graph with multiple connected components. The connected components can then be computed independently from one another, and are grouped by a user specified concurrency limit and computed.

Here's a toy example of a wofs graph with 5 scenes:

Original graph:

![image](https://user-images.githubusercontent.com/23410124/117234014-87508e00-ae67-11eb-9410-6ff8b7f2aedb.png)

Processed graph:

![image](https://user-images.githubusercontent.com/23410124/117234043-97686d80-ae67-11eb-9a47-1611a44a2029.png)


