### PR TITLE
Dataset and product fusing

### DIFF
--- a/libs/stats/odc/stats/utils.py
+++ b/libs/stats/odc/stats/utils.py
@@ -1,8 +1,15 @@
 import toolz
-from typing import Dict, Tuple, List, Any, Callable
+from typing import Dict, Tuple, List, Any, Callable, Optional
 from collections import namedtuple
 from datetime import datetime
 from .model import DateTimeRange
+from datacube import Datacube
+from datacube.model import DatasetType, Dataset
+from odc.index import odc_uuid
+from datacube.storage import measurement_paths
+from datacube.model import Dataset, DatasetType
+from datacube.index.eo3 import prep_eo3
+
 
 CompressedDataset = namedtuple("CompressedDataset", ["id", "time"])
 Cell = Any
@@ -170,3 +177,90 @@ def dedup_s2_datasets(dss):
         out.append(chunk[-1])
         skipped.extend(chunk[:-1])
     return out, skipped
+
+
+def fuse_products(type_1: DatasetType, type_2: DatasetType) -> DatasetType:
+    """
+    Fuses two products. This function requires access to a Datacube to access the metadata type.
+    
+    Fusing two products requires that:
+      - both metadata types are eo3
+      - there are no conflicting band names
+      - the file formats are identical
+    """
+
+    def_1, def_2 = type_1.definition, type_2.definition
+    fused_def = dict()
+
+    assert def_1["metadata_type"] == def_2["metadata_type"]
+    assert def_1["metadata_type"] == "eo3"
+
+    measurements_1 = set(m["name"] for m in def_1['measurements'])
+    measurements_2 = set(m["name"] for m in def_2['measurements'])
+    assert len(measurements_1.intersection(measurements_2)) == 0
+
+    file_format = def_1["metadata"]["properties"]["odc:file_format"]
+    assert file_format == def_2["metadata"]["properties"]["odc:file_format"]
+
+    name = f"fused__{def_1['name']}__{def_2['name']}"
+
+    fused_def["name"] = name
+    fused_def["metadata"] = {"product": {"name": name}, "properties": {"odc:file_format": file_format}}
+    fused_def["description"] = f"Fused products: {def_1['description']}, {def_2['description']}"
+    fused_def["measurements"] = def_1["measurements"] + def_2["measurements"] 
+    fused_def["metadata_type"] = def_1["metadata_type"]
+
+    return DatasetType(type_1.metadata_type, fused_def)
+
+
+def fuse_ds(ds_1: Dataset, ds_2: Dataset, product: Optional[DatasetType] = None) -> Dataset:
+    """
+    This function fuses two datasets. It requires that:
+      - the products are fusable
+      - grids with the same name are identical
+      - labels are in the format 'product_suffix' with identical suffixes
+      - CRSs' are identical
+      - datetimes are identical
+      - $schemas are identical 
+    """
+    
+    doc_1, doc_2 = ds_1.metadata_doc, ds_2.metadata_doc
+    
+    if product is None:
+        product = fuse_products(ds_1.type, ds_2.type)
+    
+    fused_doc = dict()
+
+    fused_doc["id"] = str(odc_uuid(product.name, "0.0.0", sources=[doc_1["id"], doc_2["id"]]))
+    fused_doc["lineage"] = {"source_datasets": [doc_1["id"], doc_2["id"]]}
+
+    # check that all grids with the same name are identical
+    common_grids = set(doc_1["grids"].keys()).intersection(doc_2["grids"].keys())
+    assert all(doc_1["grids"][g] == doc_2["grids"][g] for g in common_grids)
+    
+    # TODO: handle the case that grids have conflicts in a seperate function
+    fused_doc["grids"] = {**doc_1["grids"], **doc_2["grids"]}
+    
+    label_suffix = doc_1["label"].replace(doc_1["product"]["name"], "")
+    assert label_suffix == doc_2["label"].replace(doc_2["product"]["name"], "") 
+    fused_doc["label"] = f"{product.name}{label_suffix}"
+
+    equal_keys = ["$schema", "crs"]
+    for key in equal_keys:
+        assert doc_1[key] == doc_2[key]
+        fused_doc[key] = doc_1[key]
+    
+    fused_doc["properties"] = dict()
+    assert doc_1["properties"]["datetime"] == doc_2["properties"]["datetime"] # datetime is the only manditory property
+    
+    # copy over all identical properties
+    for key, val in doc_1["properties"].items():
+        if val == doc_2["properties"].get(key, None):
+            fused_doc["properties"][key] = val
+    
+    fused_doc["measurements"] = {**doc_1["measurements"], **doc_2["measurements"]}
+    for key, path in {**measurement_paths(ds_1), **measurement_paths(ds_2)}.items():
+        fused_doc["measurements"][key]["path"] = path
+
+    fused_ds = Dataset(product, prep_eo3(fused_doc), uris=[""])
+    return fused_ds

--- a/libs/stats/tests/test_utils.py
+++ b/libs/stats/tests/test_utils.py
@@ -1,8 +1,14 @@
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from copy import deepcopy
 
 import pystac
 import pytest
+from datacube import Datacube
+from datacube.model import Dataset, DatasetType, metadata_from_doc
+from datacube.index.eo3 import prep_eo3
+from datacube.index.index import default_metadata_type_docs
+
 from odc.index.stac import stac_transform
 from odc.stats.model import DateTimeRange
 from odc.stats.tasks import TaskReader
@@ -13,6 +19,8 @@ from odc.stats.utils import (
     bin_seasonal,
     mk_season_rules,
     season_binner,
+    fuse_products, 
+    fuse_ds
 )
 
 from . import gen_compressed_dss
@@ -117,3 +125,195 @@ def test_bin_seasonal_mk_season_rules(months, anchor):
     assert {'01--P6M', '07--P6M'} == set(season_rules.values())
 
 
+@pytest.fixture
+def fc_definition():
+    definition = {
+        'name': 'ga_ls_fc_3',
+        'metadata': {
+            'product': {'name': 'ga_ls_fc_3'},
+            'properties': {'odc:file_format': 'GeoTIFF', 'odc:product_family': 'fc'}
+        },
+        'description': 'Geoscience Australia Landsat Fractional Cover Collection 3',
+        'measurements': [
+            {'name': 'bs', 'dtype': 'uint8', 'units': 'percent', 'nodata': 255, 'aliases': ['bare']},
+            {'name': 'pv', 'dtype': 'uint8', 'units': 'percent', 'nodata': 255, 'aliases': ['green_veg']}, 
+            {'name': 'npv', 'dtype': 'uint8', 'units': 'percent', 'nodata': 255, 'aliases': ['dead_veg']},
+            {'name': 'ue', 'dtype': 'uint8', 'units': '1', 'nodata': 255, 'aliases': ['err']}],
+        'metadata_type': 'eo3'
+    }
+    return definition
+
+
+@pytest.fixture
+def wo_definition():
+    definition = {
+        'name': 'ga_ls_wo_3',
+        'metadata': {
+            'product': {'name': 'ga_ls_wo_3'},
+            'properties': {'odc:file_format': 'GeoTIFF', 'odc:product_family': 'wo'}
+        },
+        'description': 'Geoscience Australia Landsat Water Observations Collection 3',
+        'measurements': [{'name': 'water', 'dtype': 'uint8', 'units': '1', 'nodata': 1}],
+        'metadata_type': 'eo3'
+    }
+    return definition
+
+
+@pytest.fixture
+def dc():
+    return Datacube()
+
+
+def test_fuse_products(wo_definition, fc_definition):
+    standard_metadata_types = {d["name"]: metadata_from_doc(d) for d in default_metadata_type_docs()}
+    eo3 = standard_metadata_types["eo3"]
+
+    wo_product = DatasetType(eo3, wo_definition)
+    fc_product = DatasetType(eo3, fc_definition)
+    fused_product = fuse_products(wo_product, fc_product)
+
+    bad_definition = deepcopy(wo_definition)
+    bad_definition["metadata"]["properties"]["odc:file_format"] = "bad"
+    bad_product = DatasetType(eo3, bad_definition)
+    with pytest.raises(AssertionError):
+        fuse_products(bad_product, fc_product)
+            
+    bad_definition = deepcopy(wo_definition)
+    bad_definition["measurements"].append(fc_definition["measurements"][1])
+    bad_product = DatasetType(eo3, bad_definition)
+    with pytest.raises(AssertionError):
+        fuse_products(bad_product, fc_product)
+
+
+def _get_msr_paths(ds):
+    return set(m["path"] for m in ds.metadata_doc["measurements"].values())
+
+
+def test_fuse_dss(wo_definition, fc_definition):
+
+    standard_metadata_types = {d["name"]: metadata_from_doc(d) for d in default_metadata_type_docs()}
+    eo3 = standard_metadata_types["eo3"]
+
+    wo_product = DatasetType(eo3, wo_definition)
+    fc_product = DatasetType(eo3, fc_definition)
+    fused_product = fuse_products(wo_product, fc_product)
+
+    wo_metadata = {
+        'id': 'e9fb6737-b93d-5cd9-bfe6-7e634abc9905',
+        'crs': 'epsg:32655',
+        'grids': {'default': {'shape': [7211, 8311], 'transform': [30.0, 0.0, 423285.0, 0.0, -30.0, -4040385.0, 0.0, 0.0, 1.0]}},
+        'label': 'ga_ls_wo_3_091086_2020-04-04_final',
+        '$schema': 'https://schemas.opendatacube.org/dataset',
+        'lineage': {'source_datasets': {}},
+        'product': {'name': 'ga_ls_wo_3'},
+        'properties': {'title': 'ga_ls_wo_3_091086_2020-04-04_final',
+        'eo:gsd': 30.0,
+        'created': '2021-03-09T23:22:42.130266Z',
+        'datetime': '2020-04-04T23:33:10.644420Z',
+        'proj:epsg': 32655,
+        'proj:shape': [7211, 8311],
+        'eo:platform': 'landsat-7',
+        'odc:product': 'ga_ls_wo_3',
+        'odc:producer': 'ga.gov.au',
+        'eo:instrument': 'ETM',
+        'eo:cloud_cover': 44.870310145260326,
+        'eo:sun_azimuth': 49.20198554,
+        'proj:transform': [30.0, 0.0, 423285.0, 0.0, -30.0, -4040385.0, 0.0, 0.0, 1.0],
+        'landsat:wrs_row': 86,
+        'odc:file_format': 'GeoTIFF',
+        'odc:region_code': '091086',
+        'dtr:end_datetime': '2020-04-04T23:33:24.461679Z',
+        'eo:sun_elevation': 32.7056476,
+        'landsat:wrs_path': 91,
+        'dtr:start_datetime': '2020-04-04T23:32:56.662365Z',
+        'odc:product_family': 'wo',
+        'odc:dataset_version': '1.6.0',
+        'dea:dataset_maturity': 'final',
+        'odc:collection_number': 3,
+        'odc:naming_conventions': 'dea_c3',
+        'odc:processing_datetime': '2020-04-04T23:33:10.644420Z',
+        'landsat:landsat_scene_id': 'LE70910862020095ASA00',
+        'landsat:collection_number': 1,
+        'landsat:landsat_product_id': 'LE07_L1TP_091086_20200404_20200501_01_T1',
+        'landsat:collection_category': 'T1'},
+        'measurements': {'water': {'path': 'ga_ls_wo_3_091086_2020-04-04_final_water.tif'}}
+    }
+    
+    fc_metadata = {
+        'id': '41980746-4f17-5e0c-86a0-92cca8d3c99d',
+        'crs': 'epsg:32655',
+        'grids': {'default': {'shape': [7211, 8311], 'transform': [30.0, 0.0, 423285.0, 0.0, -30.0, -4040385.0, 0.0, 0.0, 1.0]}},
+        'label': 'ga_ls_fc_3_091086_2020-04-04_final',
+        '$schema': 'https://schemas.opendatacube.org/dataset',
+        'product': {'name': 'ga_ls_fc_3'},
+        'properties': {'title': 'ga_ls_fc_3_091086_2020-04-04_final',
+        'eo:gsd': 30.0,
+        'created': '2021-03-10T04:14:49.645196Z',
+        'datetime': '2020-04-04T23:33:10.644420Z',
+        'proj:epsg': 32655,
+        'proj:shape': [7211, 8311],
+        'eo:platform': 'landsat-7',
+        'odc:product': 'ga_ls_fc_3',
+        'odc:producer': 'ga.gov.au',
+        'eo:instrument': 'ETM',
+        'eo:cloud_cover': 44.870310145260326,
+        'eo:sun_azimuth': 49.20198554,
+        'proj:transform': [30.0, 0.0, 423285.0, 0.0, -30.0, -4040385.0, 0.0, 0.0, 1.0],
+        'landsat:wrs_row': 86,
+        'odc:file_format': 'GeoTIFF',
+        'odc:region_code': '091086',
+        'dtr:end_datetime': '2020-04-04T23:33:24.461679Z',
+        'eo:sun_elevation': 32.7056476,
+        'landsat:wrs_path': 91,
+        'dtr:start_datetime': '2020-04-04T23:32:56.662365Z',
+        'odc:product_family': 'fc',
+        'odc:dataset_version': '2.5.0',
+        'dea:dataset_maturity': 'final',
+        'odc:collection_number': 3,
+        'odc:naming_conventions': 'dea_c3',
+        'odc:processing_datetime': '2020-04-04T23:33:10.644420Z',
+        'landsat:landsat_scene_id': 'LE70910862020095ASA00',
+        'landsat:collection_number': 1,
+        'landsat:landsat_product_id': 'LE07_L1TP_091086_20200404_20200501_01_T1',
+        'landsat:collection_category': 'T1'},
+        'measurements': {'bs': {'path': 'ga_ls_fc_3_091086_2020-04-04_final_bs.tif'},
+        'pv': {'path': 'ga_ls_fc_3_091086_2020-04-04_final_pv.tif'},
+        'ue': {'path': 'ga_ls_fc_3_091086_2020-04-04_final_ue.tif'},
+        'npv': {'path': 'ga_ls_fc_3_091086_2020-04-04_final_npv.tif'}}
+    }
+    
+    # paths get made absolute here
+    # TODO: force paths to stay relative
+    uris = ["s3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/091/086/2020/04/04/ga_ls_wo_3_091086_2020-04-04_final.stac-item.json"]
+    wo_ds = Dataset(wo_product, prep_eo3(wo_metadata), uris=uris)
+    uris = ["s3://dea-public-data/derivative/ga_ls_fc_3/2-5-0/091/086/2020/04/04/ga_ls_fc_3_091086_2020-04-04_final.stac-item.json"]
+    fc_ds = Dataset(fc_product, prep_eo3(fc_metadata), uris=uris)
+
+    fused_ds = fuse_ds(wo_ds, fc_ds, fused_product)
+    assert _get_msr_paths(fused_ds) == _get_msr_paths(fc_ds).union(_get_msr_paths(wo_ds))
+    fused_ds = fuse_ds(wo_ds, fc_ds)
+    assert _get_msr_paths(fused_ds) == _get_msr_paths(fc_ds).union(_get_msr_paths(wo_ds))
+
+    bad_metadata = deepcopy(fc_metadata)
+    bad_metadata["properties"]["datetime"] = '2020-04-03T23:33:10.644420Z'
+    bad_ds = Dataset(fc_product, prep_eo3(bad_metadata), uris=uris)
+    with pytest.raises(AssertionError):
+        fused_ds = fuse_ds(wo_ds, bad_ds, fused_product)
+
+    bad_metadata = deepcopy(fc_metadata)
+    bad_metadata["crs"] = "epsg:32656"
+    bad_ds = Dataset(fc_product, prep_eo3(bad_metadata), uris=uris)
+    with pytest.raises(AssertionError):
+        fused_ds = fuse_ds(wo_ds, bad_ds, fused_product)
+
+    bad_metadata = deepcopy(fc_metadata)
+    bad_metadata['grids']['default']['shape'] = [7212, 8311]
+    bad_ds = Dataset(fc_product, prep_eo3(bad_metadata), uris=uris)
+    with pytest.raises(AssertionError):
+        fused_ds = fuse_ds(wo_ds, bad_ds, fused_product)
+
+    bad_metadata = deepcopy(fc_metadata)
+    bad_metadata['label'] += 'a'
+    bad_ds = Dataset(fc_product, prep_eo3(bad_metadata), uris=uris)
+    with pytest.raises(AssertionError):
+        fused_ds = fuse_ds(wo_ds, bad_ds, fused_product)

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -43,7 +43,7 @@ docutils==0.15.2
 ecdsa==0.14.1
 entrypoints==0.3
 future==0.18.2
-hdstats==0.1.8.post1
+hdstats==0.2.1
 HeapDict==1.0.1
 idna==2.10
 imageio==2.9.0


### PR DESCRIPTION
This PR adds strict dataset and product fusing. Currently this sets the lineage of the fused datasets to simply be the parent datasets but this can be changed to accomodate fusing two virtual datasets.