### PR TITLE
added dask + numpy percentile

### DIFF
--- a/libs/algo/odc/algo/_percentile.py
+++ b/libs/algo/odc/algo/_percentile.py
@@ -1,0 +1,78 @@
+from typing import List, Sequence
+import dask.array as da
+import xarray as xr
+import numpy as np
+from ._masking import keep_good_np
+from dask.base import tokenize
+from functools import partial
+
+
+def np_percentile(xx, percentile, nodata):
+
+    if np.isnan(nodata):
+        high = True
+        mask = ~np.isnan(xx)
+    else:
+        high = nodata >= xx.max()
+        mask = xx != nodata
+
+    valid_counts = mask.sum(axis=0)
+
+    xx = np.sort(xx, axis=0)
+    
+    indices = np.round(percentile * (valid_counts - 1))
+    if not high:
+        indices += (xx.shape[0] - valid_counts)
+        indices[valid_counts == 0] = 0
+
+    indices = indices.astype(np.int64).flatten()
+    step = (xx.size // xx.shape[0])
+    indices = step * indices + np.arange(len(indices))
+
+    xx = xx.take(indices).reshape(xx.shape[1:])
+
+    return keep_good_np(xx, (valid_counts >= 3), nodata)
+
+
+def xr_percentile(
+    src: xr.Dataset,
+    percentiles: Sequence,
+    nodata,
+) -> xr.Dataset:
+
+    """
+    Calculates the percentiles of the input data along the time dimension.
+
+    This approach is approximately 700x faster than the `numpy` and `xarray` nanpercentile functions.
+
+    :param src: xr.Dataset, bands can be either
+        float or integer with `nodata` values to indicate gaps in data.
+        `nodata` must be the largest or smallest values in the dataset or NaN.
+
+    :param percentiles: A sequence of percentiles in the [0.0, 1.0] range
+
+    :param nodata: The `nodata` value
+    """
+
+    data_vars = {}
+    for band, xx in src.data_vars.items():
+       
+        xx_data = xx.data
+        if len(xx.chunks[0]) > 1:
+            xx_data = xx_data.rechunk({0: -1})
+        
+        tk = tokenize(xx_data, percentiles, nodata)
+        for percentile in percentiles:
+            name = f"{band}_pc_{int(100 * percentile)}"
+            yy = da.map_blocks(
+                partial(np_percentile, percentile=percentile, nodata=nodata), 
+                xx_data, 
+                drop_axis=0, 
+                meta=np.array([], dtype=xx.dtype),
+                name=f"{name}-{tk}",
+            )
+            
+            data_vars[name] = (xx.dims[1:], yy)
+
+    coords = dict((dim, src.coords[dim]) for dim in xx.dims[1:])
+    return xr.Dataset(data_vars=data_vars, coords=coords, attrs=src.attrs)

--- a/libs/algo/tests/test_percentile.py
+++ b/libs/algo/tests/test_percentile.py
@@ -1,0 +1,88 @@
+from odc.algo._percentile import np_percentile, xr_percentile
+import numpy as np
+import pytest
+import dask.array as da
+import xarray as xr
+
+
+def test_np_percentile():
+    arr = np.array(
+        [[0, 1, 4, 6, 8, 10, 15, 22, 25, 27], [3, 5, 6, 8, 9, 11, 15, 28, 31, 50]]
+    )
+
+    np.random.shuffle(arr[0, :])
+    np.random.shuffle(arr[1, :])
+    arr = arr.transpose()
+
+    assert (np_percentile(arr, 0.5, 255) == np.array([8, 9])).all()
+    assert (np_percentile(arr, 0.7, 255) == np.array([15, 15])).all()
+    assert (np_percentile(arr, 1.0, 255) == np.array([27, 50])).all()
+    assert (np_percentile(arr, 0.0, 255) == np.array([0, 3])).all()
+
+
+@pytest.mark.parametrize("nodata", [255, 200, np.nan, -1])
+def test_np_percentile_some_bad_data(nodata):
+    arr = np.array(
+        [[0, 1, 4, 6, 8, nodata, nodata, nodata, nodata, nodata], [3, 5, 6, 8, 9, 11, 15, 28, 31, 50]]
+    )
+
+    np.random.shuffle(arr[0, :])
+    np.random.shuffle(arr[1, :])
+    arr = arr.transpose()
+
+    assert (np_percentile(arr, 0.5, nodata) == np.array([4, 9])).all()
+    assert (np_percentile(arr, 0.7, nodata) == np.array([6, 15])).all()
+    assert (np_percentile(arr, 1.0, nodata) == np.array([8, 50])).all()
+    assert (np_percentile(arr, 0.0, nodata) == np.array([0, 3])).all()
+
+
+@pytest.mark.parametrize("nodata", [255, 200, np.nan])
+def test_np_percentile_bad_data(nodata):
+    arr = np.array(
+        [
+            [0, 1, nodata, nodata, nodata, nodata, nodata, nodata, nodata, nodata],
+            [3, 5, 6, 8, 9, 11, 15, 28, 31, 50],
+        ]
+    )
+
+    np.random.shuffle(arr[0, :])
+    np.random.shuffle(arr[1, :])
+    arr = arr.transpose()
+
+    np.testing.assert_equal(np_percentile(arr, 0.5, nodata), np.array([nodata, 9]))
+    np.testing.assert_equal(np_percentile(arr, 0.7, nodata), np.array([nodata, 15]))
+    np.testing.assert_equal(np_percentile(arr, 1.0, nodata), np.array([nodata, 50]))
+    np.testing.assert_equal(np_percentile(arr, 0.0, nodata), np.array([nodata, 3]))
+
+
+@pytest.mark.parametrize("nodata", [255, 200, np.nan, -1]) #should do -1
+def test_xr_percentile(nodata):
+    band_1 = np.random.randint(0, 100, size=(10, 100, 200)).astype(type(nodata))
+    band_2 = np.random.randint(0, 100, size=(10, 100, 200)).astype(type(nodata))
+
+    band_1[np.random.random(size=band_1.shape) > 0.5] = nodata
+    band_2[np.random.random(size=band_1.shape) > 0.5] = nodata
+
+    true_results = dict()
+    true_results["band_1_pc_20"] = np_percentile(band_1, 0.2, nodata)
+    true_results["band_2_pc_20"] = np_percentile(band_2, 0.2, nodata)
+    true_results["band_1_pc_60"] = np_percentile(band_1, 0.6, nodata)
+    true_results["band_2_pc_60"] = np_percentile(band_2, 0.6, nodata)
+
+    band_1 = da.from_array(band_1, chunks=(2, 20, 20))
+    band_2 = da.from_array(band_2, chunks=(2, 20, 20))
+
+    attrs = {"test": "attrs"}
+    coords = {
+        "x": np.linspace(10, 20, band_1.shape[2]), 
+        "y": np.linspace(0, 5, band_1.shape[1]), 
+        "t": np.linspace(0, 5, band_1.shape[0])
+    }
+
+    data_vars = {"band_1": (("t", "y", "x"), band_1), "band_2": (("t", "y", "x"), band_2)}
+
+    dataset = xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs)
+    output = xr_percentile(dataset, [0.2, 0.6], nodata).compute()
+
+    for key in output.keys():
+        np.testing.assert_equal(output[key], true_results[key])


### PR DESCRIPTION
This PR adds functionality in `odc.algo` to calculate percentiles of an `xr.Dataset`. Currently this is replicating the index rounding behaviour of [`argpercentile`](https://github.com/opendatacube/datacube-stats/blob/14054f8820ddf2b79691996af8ac7d41e200fe49/datacube_stats/stat_funcs.py#L108) which as fair as I could tell is what's being used to create the `fc_percentile*` products. Although linear interpolation of values may be more appropriate here instead.

One caveat of my implementation is that it assumes `nodata` is the largest possible value and will fail with `int` data that uses `-1` as no data values. This fits our use case of calculating percentiles of `ga_ls_fc_3` but we may want something more general in the future

 I'm planning on adding an accompanying `odc.stats` class in a seperate PR and for now I'm using the code like this:


```python
src = dc.load(datasets=fused_products, output_crs=crs, resolution=(-30, 30), dask_chunks={'x': -1, 'y': -1})

# create dataset without water band
data_vars = dict((band, data) for band, data in src.data_vars.items() if band != "water")
xx = xr.Dataset(data_vars=data_vars, coords=src.coords, attrs=src.attrs)

# mask out bits that aren't dry
is_ok = (src["water"] == 0)
xx = keep_good_only(xx, is_ok, nodata=255)

xr_percentiles = xr_uint_percentile(xx, [0.1, 0.5, 0.9], 255)
```