### PR TITLE
Switch test docker to buildkit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,80 @@
+# repo specific
+notebooks/
+docs/
+tests/
+.github/
+docker/.cache
+docker/.build
+
+*.pickle
+/test_env
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+.mypy_cache/
+dask-worker-space/
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis
+.pytest_cache
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+.idea/
+
+# iPython Notebook
+.ipynb_checkpoints
+
+# Mac OS X
+.DS_Store
+docs/html/
+
+# Generated Documentation
+generate/
+docs/notebooks/
+
+#Local Visual Studio Code configurations
+.vscode/
+

--- a/.github/workflows/build-test-docker.yml
+++ b/.github/workflows/build-test-docker.yml
@@ -29,10 +29,13 @@ jobs:
         echo "::set-output name=push_image::${push_image}"
 
     - uses: actions/cache@v2
-      name: Cache Python Env
+      name: Cache Python Env Files
       id: cache_env
       with:
-        path: docker/.build
+        path: |
+          docker/.build
+          docker/wheels
+
         key: ${{ runner.os }}-env-${{ hashFiles('docker/requirements.txt', 'docker/constraints.txt', 'docker/nobinary.txt', 'docker/Makefile') }}
 
     - uses: actions/cache@v2
@@ -42,16 +45,15 @@ jobs:
       with:
         path: |
           docker/.cache
-          docker/wheels
 
         key: ${{ runner.os }}-pip-${{ github.run_id }}
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Build test environment
+    - name: Build Wheels
       if: steps.cache_env.outputs.cache-hit != 'true'
       run: |
-        make -C docker env
+        make -C docker compile
 
     - name: Build test docker
       run: |
@@ -59,9 +61,11 @@ jobs:
         make -C docker dkr-no-deps
 
     - name: Run tests
-      timeout-minutes: 20
+      timeout-minutes: 10
       run: |
-        make -C docker run-test
+        cd tests
+        docker-compose up -d
+        docker-compose exec -T tools-tester pytest --timeout=30
 
     - name: DockerHub Login
       if: steps.cfg.outputs.push_image == 'yes'
@@ -73,3 +77,4 @@ jobs:
       if: steps.cfg.outputs.push_image == 'yes'
       run: |
         docker push opendatacube/odc-test-runner:latest
+

--- a/.github/workflows/test-dc-tools.yml
+++ b/.github/workflows/test-dc-tools.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         cd tests
         docker-compose up -d
-        docker-compose exec -T tools-tester pytest
+        docker-compose exec -T tools-tester pytest --timeout=30

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,3 +1,2 @@
 .cache
-wheels
 env.tgz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM opendatacube/geobase-runner:3.3.0
+#syntax=docker/dockerfile:1.2
+ARG V_BASE=3.3.0
+FROM opendatacube/geobase-runner:${V_BASE}
 ENV LC_ALL=C.UTF-8
 ENV PATH="/env/bin:${PATH}"
 
@@ -22,13 +24,22 @@ RUN groupadd --gid 1000 odc \
     && adduser odc users \
     && adduser odc sudo \
     && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && mkdir /conf \
+    && install -d /env -g odc -o odc \
+    && install -d /code -g odc -o odc \
     && true
 
 
-COPY with_bootstrap /usr/local/bin
+COPY docker/with_bootstrap /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/with_bootstrap"]
 VOLUME ["/code"]
 WORKDIR /code
 
-# Environment contains odc-tools installed in edit mode in /code folder
-ADD .build/env /env
+COPY docker/rr-odc-tools.in docker/constraints.txt docker/requirements.txt /conf
+USER odc
+RUN --mount=type=bind,target=/src \
+    --mount=type=cache,target=/home/odc/.cache/pip,uid=1000,gid=1000 \
+    (cd /src && tar c .git libs apps ) | (cd /code && tar x) \
+    && env-build-tool new_no_index /conf/rr-odc-tools.in /conf/constraints.txt /env /src/docker/wheels \
+    && rm -rf /code/*
+USER root

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,6 @@
 # Base image to use for constructing environment
-BUILDER_IMG ?= opendatacube/geobase-builder:3.3.0
+V_BASE ?= 3.3.0
+BUILDER_IMG ?= opendatacube/geobase-builder:$(V_BASE)
 
 # Docker we are building
 DKR_IMG ?= opendatacube/odc-test-runner:latest
@@ -9,14 +10,11 @@ WK := $(shell pwd)
 
 # Absolute path to code
 CODE := $(shell readlink -f ..)
+TTY := $(shell bash -c "tty -s && echo '-t' || true")
 
-# ENV -- location of python env inside the docker
-ENV := "/env"
-
-dkr := docker run --rm -i \
+dkr := docker run --rm -i $(TTY) \
         -v $(CODE):/code \
         -v $(WK):/wk \
-        -v $(WK)/.build/env:$(ENV) \
         -e TZ=Australia/Sydney \
         -e NOBINARY=/wk/nobinary.txt \
         $(BUILDER_IMG)
@@ -25,13 +23,9 @@ all: dkr
 
 download: .build/download.info.txt
 compile: .build/compile.info.txt
-env: .build/env.info.txt
-
-env.tgz: .cache/env.info.txt
-	@$(dkr) tar czf $@ $(ENV)
 
 .build/prepared.txt:
-	@mkdir -p .cache/pip .build/env
+	@mkdir -p .cache/pip .build
 	@date > $@
 
 .build/download.info.txt: requirements.txt constraints.txt nobinary.txt .build/prepared.txt
@@ -40,10 +34,6 @@ env.tgz: .cache/env.info.txt
 
 .build/compile.info.txt: .build/download.info.txt
 	@$(dkr) env-build-tool compile ./wheels
-	@date > $@
-
-.build/env.info.txt: .build/compile.info.txt
-	@$(dkr) env-build-tool new_no_index rr-odc-tools.in constraints.txt $(ENV) ./wheels
 	@date > $@
 
 bash: .build/prepared.txt
@@ -57,22 +47,21 @@ bash-runner:
 
 dbg: .build/prepared.txt
 	@echo "dkr: " $(dkr)
-	@$(dkr) python --version
+	@$(dkr) python3 --version
 
-dkr: .build/env.info.txt Dockerfile
-	docker build -t $(DKR_IMG) --cache-from $(DKR_IMG) .
+dkr: .build/compile.info.txt Dockerfile
+	DOCKER_BUILDKIT=1 docker build --build-arg V_BASE=$(V_BASE) -t $(DKR_IMG) --cache-from $(DKR_IMG) -f Dockerfile ..
 
 dkr-no-deps:
-	docker build -t $(DKR_IMG) --cache-from $(DKR_IMG) .
+	DOCKER_BUILDKIT=1 docker build --build-arg V_BASE=$(V_BASE) -t $(DKR_IMG) --cache-from $(DKR_IMG) -f Dockerfile ..
 
 run-test:
-	@docker run --rm -i \
+	@docker run --rm \
     -v $(CODE):/code \
-    $(DKR_IMG) pytest .
+    $(DKR_IMG) pytest --timeout=30 .
 
 clean:
-	rm -f .build/download.info.txt .build/compile.info.txt .build/env.info.txt
-	rm -rf .build/env
+	rm -f .build/download.info.txt .build/compile.info.txt
 	@echo "Keeping wheels and pip cache"
 
-.PHONY: dbg all clean download compile env dkr
+.PHONY: dbg all clean download compile dkr run-test dkr dkr-no-deps bash bash-runner

--- a/docker/rr-odc-tools.in
+++ b/docker/rr-odc-tools.in
@@ -4,6 +4,9 @@ mock
 pytest
 docker
 deepdiff
+pip-tools
+rio-cogeo
+
 
 -e /code/apps/dc_tools[AZURE,THREDDS]
 -e /code/apps/cloud[AZURE,THREDDS,GCP]

--- a/docker/with_bootstrap
+++ b/docker/with_bootstrap
@@ -23,7 +23,7 @@ export PIP_CACHE_DIR=/wk/.cache/pip
 
 case "${1:-help}" in
     help)
-        echo "TODO: help" 
+        echo "TODO: help"
         ;;
     python|python3|pip|pip3|pip-compile|pytest)
         source /env/bin/activate

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -234,6 +234,7 @@ class WorkTokenInterface(ABC):
             return self.extend(seconds)
         return True
 
+
 @dataclass
 class Task:
     product: OutputProduct
@@ -348,7 +349,7 @@ class Task:
             bbox=[bbox.left, bbox.bottom, bbox.right, bbox.top],
             datetime=self.time_range.start.replace(tzinfo=timezone.utc),
             properties=properties,
-            stac_extensions=["projection"]
+            stac_extensions=["projection"],
         )
 
         item.ext.projection.epsg = geobox.crs.epsg
@@ -526,7 +527,7 @@ class TaskRunnerConfig:
 
     # Heartbeat filepath
     heartbeat_filepath: Optional[str] = None
-    
+
     # Terminate task if running longer than this amount (seconds)
     max_processing_time: int = 0
 


### PR DESCRIPTION
- do not build and cache both env and wheels, instead only do wheels
- build env directly in the test runner docker using bind mounts to bring in both wheels and code
