### PR TITLE
Add better wild card support

### DIFF
--- a/libs/aws/odc/aws/_find.py
+++ b/libs/aws/odc/aws/_find.py
@@ -62,7 +62,7 @@ def parse_query(url_query):
             depth = 0
         elif qq_set == {"**"}:
             depth = -1
-        elif qq_set == {"*"}:
+        elif "**" not in qq_set:
             depth = len(qq)
         else:
             raise ValueError("Bad query: %s" % url_query)
@@ -94,6 +94,9 @@ def test_parse_query():
     assert parse_query(base + "**/*txt") == E(
         base=base, depth=-1, glob="*txt", file=None
     )
+    assert parse_query(base + "*/*/something/*yaml") == E(
+        base=base, depth=3, glob="*yaml", file=None
+    )
 
     with pytest.raises(ValueError):
-        parse_query(base + "*/*/something/*yaml")
+        parse_query(base + "**/*/something/*yaml")


### PR DESCRIPTION
This PR adds support for handling arbitrary directory wild cards for depth specified query url. For e.g. queries like the below are now allowed:

- `s3://dea-public-data/baseline/s2a_ard_granule/*-02/*A*/*.yaml`
- `s3://dea-public-data/baseline/s2a_ard_granule/*-02/*A*/eo3-ARD-METADATA.yaml`
- `s3://dea-public-data/baseline/s2a_ard_granule/*-02/*A*/

This works by dynamically cropping the prefix glob (`baseline/s2a_ard_granule/*-02/*A*` in the first example) to match the depth currently being searched in `s3_dir_dir`.