### PR TITLE
Fix test docker builds

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -49,10 +49,20 @@ dbg: .build/prepared.txt
 	@$(dkr) python3 --version
 
 dkr: .build/compile.info.txt Dockerfile
-	DOCKER_BUILDKIT=1 docker build --build-arg V_BASE=$(V_BASE) -t $(DKR_IMG) --cache-from $(DKR_IMG) -f Dockerfile ..
+	DOCKER_BUILDKIT=1 docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg V_BASE=$(V_BASE) \
+  --cache-from $(DKR_IMG) \
+  -t $(DKR_IMG) \
+  -f Dockerfile ..
 
 dkr-no-deps:
-	DOCKER_BUILDKIT=1 docker build --build-arg V_BASE=$(V_BASE) -t $(DKR_IMG) --cache-from $(DKR_IMG) -f Dockerfile ..
+	DOCKER_BUILDKIT=1 docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg V_BASE=$(V_BASE) \
+  --cache-from $(DKR_IMG) \
+  -t $(DKR_IMG) \
+  -f Dockerfile ..
 
 run-test:
 	@docker run --rm \

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -42,3 +42,7 @@ toolz
 tqdm
 xarray
 zstandard
+
+wheel
+setuptools
+pip


### PR DESCRIPTION
work around limitations of geobase, need to include libs for new environment bootstrap for new_no_index to work.