### PR TITLE
Support proj:transform and proj:shape in properties + null datetime

### DIFF
--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -93,22 +93,13 @@ def _get_stac_bands(
         ]:
             continue
 
-        transform = asset.get("proj:transform")
-        if transform and proj_transform and proj_transform != transform:
-            raise ValueError(
-                'Conflicting proj:transform specified: {} and {}'.format(
-                    transform, proj_transform,
-                ))
-        transform = transform if transform else proj_transform
+        # If transform specified here in the asset it should override
+        # the properties-specified transform.
+        transform = asset.get("proj:transform") or proj_transform
         grid = f"g{transform[0]:g}m"
 
-        shape = asset.get("proj:shape")
-        if shape and proj_shape and shape != proj_shape:
-            raise ValueError(
-                'Conflicting proj:shape specified: {} and {}'.format(
-                    shape, proj_shape,
-                ))
-        shape = shape if shape else proj_shape
+        # As per transform, shape here overrides properties
+        shape = asset.get("proj:shape") or proj_shape
 
         if grid not in grids:
             grids[grid] = {

--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -172,7 +172,7 @@ def _get_stac_properties_lineage(input_stac: Document) -> Tuple[Document, Any]:
         MAPPING_STAC_TO_EO3.get(key, key): _convert_value_to_eo3_type(key, val)
         for key, val in properties.items()
     }
-    if prop.get("odc:processing_datetime") is None:
+    if prop.get("odc:processing_datetime") is None and properties["datetime"] is not None:
         prop["odc:processing_datetime"] = properties["datetime"].replace(
             "000+00:00", "Z"
         )

--- a/libs/index/tests/data/lidar_dem.json
+++ b/libs/index/tests/data/lidar_dem.json
@@ -1,0 +1,103 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-beta.2",
+    "id": "lidar_id",
+    "properties": {
+        "start_datetime": "2012-01-01T00:00:00Z",
+        "end_datetime": "2012-01-01T00:00:00Z",
+        "resolution": 1.0,
+        "data_type": "float32",
+        "derived_from": "Category 1 Lidar",
+        "platform": "Aircraft",
+        "interpolation_type": "TIN",
+        "horizontal_datum": "GDA94",
+        "vertical_datum": "AHD71 - using local Geoid model",
+        "model_type": "DEM",
+        "horizontal_accuracy": "+/-0.80 @95% Confidence Interval",
+        "vertical_accuracy": "+/-0.30 @95% Confidence Interval",
+        "sensor": "ALS50 (SN101)",
+        "proj:epsg": 28355,
+        "proj:shape": [
+            2000,
+            2000
+        ],
+        "proj:transform": [
+            1.0,
+            0.0,
+            766000.0,
+            0.0,
+            -1.0,
+            6732000.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "datetime": null
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    149.74413486135487,
+                    -29.513331085946845
+                ],
+                [
+                    149.74462179934187,
+                    -29.531360829758146
+                ],
+                [
+                    149.76523815043552,
+                    -29.53093320024493
+                ],
+                [
+                    149.7647475661126,
+                    -29.512903768601603
+                ],
+                [
+                    149.74413486135487,
+                    -29.513331085946845
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "s3://example-bucket/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "collection",
+            "href": "s3://example-bucket/lidar_collection/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "s3://example-bucket/lidar_collection/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "self",
+            "href": "s3://example-bucket/lidar_collection/lidar_id.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "dem": {
+            "href": "s3://example-bucket/lidar_id.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Cloud-Optimized Geotiff"
+        }
+    },
+    "bbox": [
+        149.74413486135487,
+        -29.531360829758146,
+        149.76523815043552,
+        -29.512903768601603
+    ],
+    "stac_extensions": [
+        "projection"
+    ],
+    "collection": "lidar_collection"
+}

--- a/libs/index/tests/test_stac.py
+++ b/libs/index/tests/test_stac.py
@@ -17,6 +17,7 @@ LANDSAT_ODC: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
 SENTINEL_STAC: str = "S2A_28QCH_20200714_0_L2A.json"
 SENTINEL_ODC: str = "S2A_28QCH_20200714_0_L2A.odc-metadata.json"
 USGS_LANDSAT_STAC: str = "LC08_L2SR_081119_20200101_20200823_02_T2.json"
+LIDAR_STAC: str = "lidar_dem.json"
 
 deep_diff = partial(
     DeepDiff, significant_digits=6, ignore_type_in_groups=[(tuple, list)]
@@ -35,6 +36,10 @@ def test_sentinel_stac_transform(sentinel_stac, sentinel_odc):
 
 def test_usgs_landsat_stac_transform(usgs_landsat_stac):
     transformed = stac_transform(usgs_landsat_stac)
+
+
+def test_lidar_stac_transform(lidar_stac):
+    transformed = stac_transform(lidar_stac)
 
 
 def do_diff(actual_doc, expected_doc):
@@ -83,6 +88,13 @@ def usgs_landsat_stac():
 @pytest.fixture
 def landsat_stac():
     with TEST_DATA_FOLDER.joinpath(LANDSAT_STAC).open("r") as f:
+        metadata = json.load(f)
+    return metadata
+
+
+@pytest.fixture
+def lidar_stac():
+    with TEST_DATA_FOLDER.joinpath(LIDAR_STAC).open("r") as f:
         metadata = json.load(f)
     return metadata
 


### PR DESCRIPTION
Resolves #217 and also a bug where datetime: null was unsupported [despite being allowed](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#properties-object).