### PR TITLE
Various cleanups

### DIFF
--- a/libs/algo/odc/algo/_tiff.py
+++ b/libs/algo/odc/algo/_tiff.py
@@ -404,7 +404,7 @@ class COGSink:
         """
 
         When extract=True --> returns bytes (doubles memory requirements!!!)
-        When extract=False -> returns sink after completing everything
+        When extract=False -> returns return_value if supplied, or sink after completing everything
         """
         tk = tokenize(sink, extract, strict)
         delayed_close = dask.delayed(lambda sink, idx, *deps: sink.close(idx))

--- a/libs/algo/odc/algo/_tiff.py
+++ b/libs/algo/odc/algo/_tiff.py
@@ -22,7 +22,7 @@ from ._numeric import roundup16, half_up, roi_shrink2, np_slice_to_idx
 from ._warp import _shrink2
 
 
-_UNSET = object()
+_UNSET = ":unset:-427d8b3f1944"
 
 
 def _adjust_blocksize(block: int, dim: int) -> int:
@@ -415,7 +415,7 @@ class COGSink:
 
         def _copy_cog(sink, extract, strict, return_value, *parts):
             bb = sink._copy_cog(extract=extract, strict=strict)
-            if return_value is _UNSET:
+            if return_value == _UNSET:
                 return bb if extract else sink
             else:
                 return return_value

--- a/libs/algo/odc/algo/io.py
+++ b/libs/algo/odc/algo/io.py
@@ -77,7 +77,7 @@ def dc_load(
 
     # dask_chunks is a backward-compatibility alias for chunks
     if chunks is None:
-        chunks = kw.pop('dask_chunks', None)
+        chunks = kw.pop("dask_chunks", None)
     # group_by is a backward-compatibility alias for groupby
     if groupby is None:
         groupby = kw.pop("group_by", "time")
@@ -107,12 +107,11 @@ def dc_load(
     product = ds.type
 
     if geobox is None:
-        if len(geo_keys) == 0:
-            # TODO: figure out extent to load based on supplied datasets
-            raise NotImplementedError("Have to supply region to load (for now)")
-
         geobox = output_geobox(
-            grid_spec=product.grid_spec, load_hints=product.load_hints(), **geo_keys
+            grid_spec=product.grid_spec,
+            load_hints=product.load_hints(),
+            **geo_keys,
+            datasets=datasets,
         )
     elif len(geo_keys):
         warn(f"Supplied 'geobox=' parameter aliases {list(geo_keys)} inputs")

--- a/libs/stats/docs/example-cfg.yaml
+++ b/libs/stats/docs/example-cfg.yaml
@@ -2,6 +2,9 @@
 #
 #    odc-stats run --config <this-file|content of this file> ...
 
+# local or s3 path, can be supplied/overwritten on a command line
+filedb: 's3://deafrica-services/dbs/s2ab.db'
+
 # It's a template {product} and {version} are replaced at run time
 output_location: 's3://deafrica-services/s2_stats_annual/{product}/{version}/'
 

--- a/libs/stats/odc/stats/_cli_run.py
+++ b/libs/stats/odc/stats/_cli_run.py
@@ -43,7 +43,7 @@ from ._cli_common import main, setup_logging, click_resolution, click_yaml_cfg
 @click_yaml_cfg("--cog-config", help="Configure COG options")
 @click.option("--resampling", type=str, help="Input resampling strategy, e.g. average")
 @click_resolution("--resolution", help="Override output resolution")
-@click.argument("filedb", type=str, nargs=1)
+@click.argument("filedb", type=str, nargs=1, default="")
 @click.argument("tasks", type=str, nargs=-1)
 def run(
     filedb,
@@ -135,6 +135,9 @@ def run(
     if cog_config is not None:
         _cfg["cog_opts"] = cog_config
 
+    if not _cfg.get('filedb'):
+        _log.error("Must supply `filedb` either through config or CLI")
+        sys.exit(1)
     cfg = TaskRunnerConfig(**_cfg)
     _log.info(f"Using this config: {cfg}")
 

--- a/libs/ui/odc/ui/_dc_explore.py
+++ b/libs/ui/odc/ui/_dc_explore.py
@@ -26,6 +26,7 @@ class DcViewer:
         height=None,
         width=None,
         style=None,
+        max_datasets_to_display=2000,
     ):
         """
         :param dc:        Datacube object
@@ -40,6 +41,8 @@ class DcViewer:
             - color/fillColor
             - opacity/fillOpacity
             - full list of options here: https://leafletjs.com/reference-1.5.0.html#path-option
+        :param max_datasets_to_display: If the view contains more than that many datasets don't bother querying DB
+                                        and displaying footprints.
         """
         self._dc = dc
 
@@ -61,6 +64,7 @@ class DcViewer:
         self._last_query_bounds = None
         self._last_query_polygon = None
         self._style = style
+        self._max_datasets_to_display = max_datasets_to_display
 
     def _build_ui(
         self, product_names, time, zoom=None, center=None, height=None, width=None
@@ -225,7 +229,10 @@ class DcViewer:
         else:
             self._clear_footprints()
 
-    def _maybe_show(self, max_dss, clear=False):
+    def _maybe_show(self, max_dss=None, clear=False):
+        if max_dss is None:
+            max_dss = self._max_datasets_to_display
+
         if self._state.count < max_dss:
             self._update_footprints()
         elif clear:
@@ -239,18 +246,18 @@ class DcViewer:
                 skip_refresh = True
 
         if not skip_refresh:
-            self._maybe_show(500, clear=True)
+            self._maybe_show(clear=True)
 
     def on_date(self, time):
         self._update_info_count()
-        self._maybe_show(500, clear=True)
+        self._maybe_show(clear=True)
 
     def on_show(self):
         self._update_footprints()
 
     def on_product(self, prod):
         self._update_info_count()
-        self._maybe_show(500, clear=True)
+        self._maybe_show(clear=True)
 
     def _ipython_display_(self):
         return self._gui.ui._ipython_display_()


### PR DESCRIPTION
- do not demand filedb cli argument as it can come from config file
- fixes in Dask -> COG
   - non-unique keys
   - obtain credentials for writing to S3 at Dask graph construction time and pass it on to workers
- Fixes in DcViewer: bump up number of Datasets in the view before refusing to display them, and also make that configurable
- Fixes in `dc_load` be more like `dc.load`