### PR TITLE
Minor Stac conversion improvements

### DIFF
--- a/libs/index/odc/index/stac.py
+++ b/libs/index/odc/index/stac.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict, Tuple, Any, Optional
 from uuid import UUID
 
+import dateutil.parser
 from datacube.utils.geometry import Geometry
 from odc.index import odc_uuid
 from toolz import get_in
@@ -194,13 +195,15 @@ def _get_stac_properties_lineage(input_stac: Document) -> Tuple[Document, Any]:
         MAPPING_STAC_TO_EO3.get(key, key): _convert_value_to_eo3_type(key, val)
         for key, val in properties.items()
     }
-    if (
-        prop.get("odc:processing_datetime") is None
-        and properties.get("datetime") is not None
-    ):
-        prop["odc:processing_datetime"] = properties["datetime"].replace(
-            "000+00:00", "Z"
-        )
+
+    creation_time = (
+        properties.get("odc:processing_datetime")
+        or properties.get("created")
+        or properties.get("datetime")
+    )
+    if prop.get("odc:processing_datetime") is None and creation_time:
+        prop["odc:processing_datetime"] = creation_time
+
     if prop.get("odc:file_format") is None:
         prop["odc:file_format"] = "GeoTIFF"
 


### PR DESCRIPTION
- Don't include an eo3 `label` field when it's just an (unreadable by humans) UUID. 
     - Including the field disables the more-useful fallbacks that tools like Explorer have, such as showing the filename. We're better off not having a label if it's the same as the document uuid.
- Also fallback to the Stac 'title' field if available as the label.
- Fallback to Stac 'created' field if available for processing time.

(I ran the tests this time -- stac+esri)