### PR TITLE
Add a multi-threaded flag

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -2,7 +2,6 @@
 """Build S3 iterators using odc-tools
 and index datasets found into RDS
 """
-from functools import partial
 import logging
 import sys
 from typing import Tuple
@@ -29,25 +28,6 @@ def stream_docs(documents):
         yield (document.url, document.data)
 
 
-def thread_function(doc_uri, dc, doc2ds, update, update_if_exists, allow_unsafe):
-    print(doc_uri[0])
-    print(doc_uri[1])
-    try:
-        index_update_dataset(
-            doc_uri[0],
-            doc_uri[1],
-            dc,
-            doc2ds,
-            update,
-            update_if_exists,
-            allow_unsafe,
-        )
-        return True
-    except Exception as e:
-        logging.error(f"Failed to index dataset {doc_uri[1]} with error {e}")
-        return False
-
-
 def dump_to_odc(
     document_stream,
     dc: Datacube,
@@ -69,7 +49,7 @@ def dump_to_odc(
     )
 
     if n_threads:
-        print("Starting threaded")
+        logging.info("Starting with {n_threads} threads")
         with concurrent.futures.ThreadPoolExecutor(max_workers=n_threads) as executor:
             future_to_index = {
                 executor.submit(
@@ -93,7 +73,7 @@ def dump_to_odc(
                 else:
                     ds_added += 1
     else:
-        print("Starting without threading")
+        logging.info("Starting without threading")
         for uri, metadata in uris_docs:
             try:
                 index_update_dataset(


### PR DESCRIPTION
Adds a multi-threading approach.

Needs some benchmarking...
* Non-threaded: 13.46 minutes
* Threaded: 15.25 minutes

Benchmarks:
non-threaded:
```
AWS_DEFAULT_REGION=af-south-1 time s3-to-dc "s3://deafrica-data-dev-af/wofs_ls/**/*.json" --no-sign-request --skip-lineage --stac wofs_ls
/env/lib/python3.6/site-packages/datacube/drivers/postgres/_connections.py:84: SADeprecationWarning: Calling URL() directly is deprecated and will be disabled in a future release.  The public constructor for URL is now the URL.create() method.
  username=username, password=password,
 Added 91423 Datasets, Failed 0 Datasets
808.36user 116.95system 33:55.94elapsed 45%CPU (0avgtext+0avgdata 205536maxresident)k
0inputs+0outputs (0major+67353minor)pagefaults 0swaps
```

threaded:
```
AWS_DEFAULT_REGION=af-south-1 time s3-to-dc "s3://deafrica-data-dev-af/wofs_ls/**/*.json" --no-sign-request --skip-lineage --stac wofs_ls --n-threads=100
/env/lib/python3.6/site-packages/datacube/drivers/postgres/_connections.py:84: SADeprecationWarning: Calling URL() directly is deprecated and will be disabled in a future release.  The public constructor for URL is now the URL.create() method.
  username=username, password=password,
Added 91423 Datasets, Failed 0 Datasets
915.78user 213.62system 38:00.92elapsed 49%CPU (0avgtext+0avgdata 466648maxresident)k
0inputs+0outputs (0major+143704minor)pagefaults 0swaps
```