### PR TITLE
Set nodata flag to zero

### DIFF
--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -44,15 +44,23 @@ class StatsFCP(StatsPluginInterface):
         Loads in the data in the native projection. It performs the following:
 
         1. Loads all the fc and WOfS bands
-        2. Set high slope terrain flag to 0
+        2. Set high slope terrain flag and nodata wofs to 0
         3. Extracts the clear dry and clear wet flags from WOfS
         4. Drops the WOfS band
         5. Masks out all pixels that are not clear and dry to a nodata value of 255
         6. Discards the clear dry flags
         """
 
-        # set terrain flag to zero
-        water = da.bitwise_and(xx["water"], 0b11101111)
+        # Set terrain and nodata flag to zero
+        #
+        # Leaving the nodata flag causes any pixel that has a nodata value for
+        # one or more wofs scenes on a given day to be set to nodata for that day
+        #
+        # This a particular issue because large areas on the edges of scenes 
+        # are nodata. This causes any pixel that overlaps with the nodata edge region
+        # of another scene to always be set to nodata
+
+        water = da.bitwise_and(xx["water"], 0b1110_1110)
         xx = xx.drop_vars(["water"])
 
         xx["dry"] = water == 0

--- a/libs/stats/tests/test_fc_percentiles.py
+++ b/libs/stats/tests/test_fc_percentiles.py
@@ -36,9 +36,12 @@ def dataset():
     return xx
 
 
-def test_native_transform(dataset):
+@pytest.mark.parametrize("bits", [0b0000_0000, 0b0000_0001, 0b0001_0000, 0b0001_0001])
+def test_native_transform(dataset, bits):
     
-    xx = StatsFCP._native_tr(dataset)
+    xx = dataset.copy()
+    xx['water'] = da.bitwise_or(xx['water'], bits)
+    xx = StatsFCP._native_tr(xx)
     
     expected_result = np.array([
         [[255, 57], [20, 50]],


### PR DESCRIPTION
This PR fixes an issue where a large portion of pixels are always set to `nodata`. This issue occurs because prior to this PR any pixel that overlapped with a wofs pixel (from the same day) that was not a dry and valid was set to nodata. Due their alignment, the triangular edge regions of tiles are always set to nodata causing any valid data from other scenes that overlaps with these regions to be set to nodata.

<img width="237" alt="image" src="https://user-images.githubusercontent.com/23410124/126740557-e3a795e2-29c3-4f66-80c1-9014fb7dad4d.png">
