### PR TITLE
Fix fc percentile wofs masking

### DIFF
--- a/libs/algo/odc/algo/_masking.py
+++ b/libs/algo/odc/algo/_masking.py
@@ -727,12 +727,11 @@ def _nodata_fuser(xx, **kw):
     return choose_first_valid(xx, **kw)
 
 
-def fuse_mean_np(*aa, nodata):
+def _fuse_mean_np(*aa, nodata):
     assert len(aa) > 0
     
     out = aa[0].astype(np.float32)
     count = (aa[0] != nodata).astype(np.float32)
-
     for a in aa[1:]:
         out += a.astype(np.float32)
         count += (a != nodata)

--- a/libs/algo/odc/algo/_masking.py
+++ b/libs/algo/odc/algo/_masking.py
@@ -730,14 +730,14 @@ def _nodata_fuser(xx, **kw):
 def fuse_mean_np(*aa, nodata):
     assert len(aa) > 0
     
+    out = aa[0].astype(np.float32)
     count = (aa[0] != nodata).astype(np.float32)
-    out = aa[0].astype(np.float32) * count
 
     for a in aa[1:]:
-        mask = (a != nodata)
-        out += a.astype(np.float32) * mask
-        count += mask
+        out += a.astype(np.float32)
+        count += (a != nodata)
 
+    out -= (len(aa) - count) * nodata
     out = np.round(out / count).astype(aa[0].dtype)
     out[count == 0] = nodata
     return out

--- a/libs/algo/odc/algo/_masking.py
+++ b/libs/algo/odc/algo/_masking.py
@@ -725,3 +725,19 @@ def _nodata_fuser(xx, **kw):
     if xx.shape[0] <= 1:
         return xx
     return choose_first_valid(xx, **kw)
+
+
+def fuse_mean_np(*aa, nodata):
+    assert len(aa) > 0
+    
+    count = (aa[0] != nodata).astype(np.float32)
+    out = aa[0].astype(np.float32) * count
+
+    for a in aa[1:]:
+        mask = (a != nodata)
+        out += a.astype(np.float32) * mask
+        count += mask
+
+    out = np.round(out / count).astype(aa[0].dtype)
+    out[count == 0] = nodata
+    return out

--- a/libs/algo/tests/test_masking.py
+++ b/libs/algo/tests/test_masking.py
@@ -11,6 +11,7 @@ from odc.algo._masking import (
     enum_to_bool,
     _get_enum_values,
     _enum_to_mask_numexpr,
+    _fuse_mean_np,
 )
 
 
@@ -212,3 +213,16 @@ def test_enum_to_mask_numexpr():
         _enum_to_mask_numexpr(mm, elements, dtype="uint8", value_true=255) == 255,
         np.isin(mm, elements),
     )
+
+
+def test_fuse_mean_np():
+    data = np.array([
+        [[255, 255], [255, 50]],
+        [[30, 40], [255, 80]], 
+        [[25, 52], [255, 98]],
+    ]).astype(np.uint8)
+
+    slices = [data[i:i+1] for i in range(data.shape[0])]
+    out = _fuse_mean_np(*slices, nodata=255)
+    assert (out == np.array([[28, 46], [255, 76]])).all()
+

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -60,12 +60,12 @@ class StatsFCP(StatsPluginInterface):
         # are nodata. This causes any pixel that overlaps with the nodata edge region
         # of another scene to always be set to nodata
 
-        water = da.bitwise_and(xx["water"], 0b1110_1110)
-        xx = xx.drop_vars(["water"])
-
+        # water = da.bitwise_and(xx["water"], 0b1110_1110)
+    
         xx["bad"] = (xx.water & 0b0111_1110) > 0
         xx["dry"] = xx.water == 0
         xx["wet"] = xx.water == 128
+        xx = xx.drop_vars(["water"])
         return xx
 
     @staticmethod

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -62,7 +62,13 @@ class StatsFCP(StatsPluginInterface):
 
         wet = xx["wet"]
         xx = _xr_fuse(xx.drop_vars(["wet"]), partial(_first_valid_np, nodata=NODATA), '')
-        xx["wet"] = _xr_fuse(wet, _fuse_or_np, wet.name) & (xx['bs'] == 255)
+
+        band, *bands = xx.data_vars.keys()
+        all_bands_invalid = xx[band] == NODATA
+        for band in bands:
+            all_bands_invalid &= xx[band] == NODATA
+
+        xx["wet"] = _xr_fuse(wet, _fuse_or_np, wet.name) & all_bands_invalid
         return xx
 
     def input_data(self, task: Task) -> xr.Dataset:

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -11,7 +11,7 @@ from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_percentile
-from odc.algo._masking import _xr_fuse, _or_fuser, fuse_mean_np, _fuse_or_np, _fuse_and_np
+from odc.algo._masking import _xr_fuse, _or_fuser, _fuse_mean_np, _fuse_or_np, _fuse_and_np
 from .model import StatsPluginInterface
 from . import _plugins
 
@@ -61,7 +61,7 @@ class StatsFCP(StatsPluginInterface):
     def _fuser(xx):
 
         wet = xx["wet"]
-        xx = _xr_fuse(xx.drop_vars(["wet"]), partial(fuse_mean_np, nodata=NODATA), '')
+        xx = _xr_fuse(xx.drop_vars(["wet"]), partial(_fuse_mean_np, nodata=NODATA), '')
 
         band, *bands = xx.data_vars.keys()
         all_bands_invalid = xx[band] == NODATA

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -60,9 +60,8 @@ class StatsFCP(StatsPluginInterface):
         # are nodata. This causes any pixel that overlaps with the nodata edge region
         # of another scene to always be set to nodata
 
-        # water = da.bitwise_and(xx["water"], 0b1110_1110)
     
-        xx["bad"] = (xx.water & 0b0111_1110) > 0
+        xx["bad"] = (xx.water & 0b0110_1110) > 0
         xx["dry"] = xx.water == 0
         xx["wet"] = xx.water == 128
         xx = xx.drop_vars(["water"])

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -41,25 +41,14 @@ class StatsFCP(StatsPluginInterface):
     @staticmethod
     def _native_tr(xx):
         """
-        Loads in the data in the native projection. It performs the following:
+        Loads data in its native projection. It performs the following:
 
-        1. Loads all the fc and WOfS bands
-        2. Set high slope terrain flag and nodata wofs to 0
-        3. Extracts the clear dry and clear wet flags from WOfS
+        1. Load all the fc and WOfS bands
+        2. Find bad WOfS pixels ignoring the high slope terrain and nodata flags
+        3. Extracts the clear dry and clear wet WoFS pixels
         4. Drops the WOfS band
-        5. Masks out all pixels that are not clear and dry to a nodata value of 255
-        6. Discards the clear dry flags
         """
 
-        # Set terrain and nodata flag to zero
-        #
-        # Leaving the nodata flag causes any pixel that has a nodata value for
-        # one or more wofs scenes on a given day to be set to nodata for that day
-        #
-        # This a particular issue because large areas on the edges of scenes 
-        # are nodata. This causes any pixel that overlaps with the nodata edge region
-        # of another scene to always be set to nodata
-        
         xx["bad"] = (xx.water & 0b0110_1110) > 0
         xx["dry"] = xx.water == 0
         xx["wet"] = xx.water == 128

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -76,12 +76,14 @@ class StatsFCP(StatsPluginInterface):
         bad = xx.bad
 
         xx = _xr_fuse(xx.drop_vars(["wet", "dry", "bad"]), partial(_first_valid_np, nodata=NODATA), '')
-        wet = _xr_fuse(wet, _fuse_or_np, wet.name)
-        dry = _xr_fuse(dry, _fuse_or_np, dry.name)
+        
+        xx["wet"] = _xr_fuse(wet, _fuse_or_np, wet.name)
+        xx["dry"] = _xr_fuse(dry, _fuse_or_np, dry.name)
+        xx["bad"] = _xr_fuse(bad, _fuse_or_np, dry.name)
         
         xx["wet"] = apply_numexpr("wet & (~dry) & (~bad)", xx, dtype="bool")
         xx["dry"] = apply_numexpr("dry & (~wet) & (~bad)", xx, dtype="bool")
-
+        xx = xx.drop_vars(["bad"])
         return xx
 
     def input_data(self, task: Task) -> xr.Dataset:

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -44,15 +44,23 @@ class StatsFCP(StatsPluginInterface):
         Loads in the data in the native projection. It performs the following:
 
         1. Loads all the fc and WOfS bands
-        2. Set high slope terrain flag to 0
+        2. Set high slope terrain flag and nodata wofs to 0
         3. Extracts the clear dry and clear wet flags from WOfS
         4. Drops the WOfS band
         5. Masks out all pixels that are not clear and dry to a nodata value of 255
         6. Discards the clear dry flags
         """
 
-        # set terrain flag to zero
-        water = da.bitwise_and(xx["water"], 0b11101111)
+        # Set terrain and nodata flag to zero
+        #
+        # Leaving the nodata flag causes any pixel that has a nodata value for
+        # one or more wofs scenes on a given day to be set to nodata for that day
+        #
+        # This a particular issue because large areas on the edges of scenes 
+        # are nodata. This causes any pixel that overlaps with the nodata edge region
+        # of another scene to always be set to nodata
+
+        water = da.bitwise_and(xx["water"], 0b1110_1110)
         xx = xx.drop_vars(["water"])
 
         xx["dry"] = water == 0

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -9,9 +9,9 @@ import xarray as xr
 import numpy as np
 from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
-from odc.algo import keep_good_only, apply_numexpr
+from odc.algo import keep_good_only
 from odc.algo._percentile import xr_percentile
-from odc.algo._masking import _xr_fuse, _or_fuser, _first_valid_np, _fuse_or_np, _fuse_and_np
+from odc.algo._masking import _xr_fuse, _or_fuser, fuse_mean_np, _fuse_or_np, _fuse_and_np
 from .model import StatsPluginInterface
 from . import _plugins
 
@@ -61,7 +61,7 @@ class StatsFCP(StatsPluginInterface):
     def _fuser(xx):
 
         wet = xx["wet"]
-        xx = _xr_fuse(xx.drop_vars(["wet"]), partial(_first_valid_np, nodata=NODATA), '')
+        xx = _xr_fuse(xx.drop_vars(["wet"]), partial(fuse_mean_np, nodata=NODATA), '')
 
         band, *bands = xx.data_vars.keys()
         all_bands_invalid = xx[band] == NODATA
@@ -70,7 +70,7 @@ class StatsFCP(StatsPluginInterface):
 
         xx["wet"] = _xr_fuse(wet, _fuse_or_np, wet.name) & all_bands_invalid
         return xx
-
+    
     def input_data(self, task: Task) -> xr.Dataset:
 
         chunks = {"y": -1, "x": -1}

--- a/libs/stats/odc/stats/_fc_percentiles.py
+++ b/libs/stats/odc/stats/_fc_percentiles.py
@@ -62,7 +62,7 @@ class StatsFCP(StatsPluginInterface):
 
         wet = xx["wet"]
         xx = _xr_fuse(xx.drop_vars(["wet"]), partial(_first_valid_np, nodata=NODATA), '')
-        xx["wet"] = _xr_fuse(wet, _fuse_or_np, wet.name)
+        xx["wet"] = _xr_fuse(wet, _fuse_or_np, wet.name) & (xx['bs'] == 255)
         return xx
 
     def input_data(self, task: Task) -> xr.Dataset:

--- a/libs/stats/tests/test_fc_percentiles.py
+++ b/libs/stats/tests/test_fc_percentiles.py
@@ -36,9 +36,12 @@ def dataset():
     return xx
 
 
-def test_native_transform(dataset):
+@pytest.mark.parametrize("bits", [0b0000_0000, 0b0000_0001, 0b0001_0000, 0b0001_0001])
+def test_native_transform(dataset, bits):
     
-    xx = StatsFCP._native_tr(dataset)
+    xx = dataset.copy()
+    xx['water'] = da.bitwise_or(xx['water'], bits)
+    xx = StatsFCP._native_tr(xx)
     
     expected_result = np.array([
         [[255, 57], [20, 50]],

--- a/libs/stats/tests/test_fc_percentiles.py
+++ b/libs/stats/tests/test_fc_percentiles.py
@@ -79,7 +79,7 @@ def test_fusing(dataset):
     assert (result == expected_result).all()
 
     expected_result = np.array(
-        [[False, True], [False, False]],
+        [[False, False], [False, False]],
     )
     result = xx.compute()["wet"].data
     assert (result == expected_result).all()

--- a/libs/stats/tests/test_fc_percentiles.py
+++ b/libs/stats/tests/test_fc_percentiles.py
@@ -65,9 +65,11 @@ def test_fusing(dataset):
     xx = xx.groupby("solar_day").map(StatsFCP._fuser)
 
     expected_result = np.array(
-        [[30, 40], [255, 50]],
+        [[28, 46], [255, 76]],
     )
     result = xx.compute()["band_1"].data
+
+    print(result.shape)
     assert (result == expected_result).all()
 
     expected_result = np.array(

--- a/libs/stats/tests/test_fc_percentiles.py
+++ b/libs/stats/tests/test_fc_percentiles.py
@@ -44,7 +44,7 @@ def test_native_transform(dataset, bits):
     xx = StatsFCP._native_tr(xx)
     
     expected_result = np.array([
-        [[255, 57], [20, 50]],
+        [[255, 255], [20, 50]],
         [[30, 40], [70, 80]], 
         [[25, 52], [73, 98]],
     ])
@@ -59,35 +59,21 @@ def test_native_transform(dataset, bits):
     result = xx.compute()["wet"].data
     assert (result == expected_result).all()
 
-    expected_result = np.array([
-        [[True, False], [True, True]],
-        [[True, True], [True, True]], 
-        [[True, True], [True, True]],
-    ])
-    result = xx.compute()["dry"].data
-    assert (result == expected_result).all()
-
 
 def test_fusing(dataset):
     xx = StatsFCP._native_tr(dataset)
     xx = xx.groupby("solar_day").map(StatsFCP._fuser)
 
     expected_result = np.array(
-        [[30, 57], [20, 50]],
+        [[30, 40], [20, 50]],
     )
     result = xx.compute()["band_1"].data
     assert (result == expected_result).all()
 
     expected_result = np.array(
-        [[False, False], [False, False]],
+        [[False, True], [False, False]],
     )
     result = xx.compute()["wet"].data
-    assert (result == expected_result).all()
-
-    expected_result = np.array(
-        [[True, False], [True, True]],
-    )
-    result = xx.compute()["dry"].data
     assert (result == expected_result).all()
 
 

--- a/libs/stats/tests/test_fc_percentiles.py
+++ b/libs/stats/tests/test_fc_percentiles.py
@@ -36,7 +36,7 @@ def dataset():
     return xx
 
 
-@pytest.mark.parametrize("bits", [0b0000_0000, 0b0000_0001, 0b0001_0000, 0b0001_0001])
+@pytest.mark.parametrize("bits", [0b0000_0000, 0b0001_0000])
 def test_native_transform(dataset, bits):
     
     xx = dataset.copy()


### PR DESCRIPTION
The previous wofs masking assumed that if a pixel was `nodata` in `wofs` then it was `nodata` in `fc`. This turns out not to be true on the edges of scenes for some reason (maybe `fc` scenes are slightly larger?) causing thicks lines to appear in `wofs` masked areas near the edges of scenes.

This PR fixes this and handles the `nodata` pixels properly.

For each day, the fused daily WOfS measurement is considered:
- `bad` if at least one measurement on that day has one of the: cloud; cloud shadow; terrain shadow; low solar angle;  or non contiguous flags set to `True`
- `dry` if at least one measurement on that day is `(~bad) & dry` and there are no `wet` or `bad` measurements
- `wet` if at least one measurement on that day is `(~bad) & wet` and there are no `dry` or `bad` measurements

An `fc` measurement is only included if:
- there is at least one valid `fc` measurement from that day
- the corresponding fused daily `WOfS` measurement is `dry`

How does this sound?