### PR TITLE
update masking to support third argument

### DIFF
--- a/libs/algo/odc/algo/_masking.py
+++ b/libs/algo/odc/algo/_masking.py
@@ -385,7 +385,7 @@ def binary_closing(xx: xr.DataArray, radius: int = 1, **kw) -> xr.DataArray:
 
 def mask_cleanup_np(mask: np.ndarray, filter: Dict = dict(closing=0, opening=2, dilation=5)) -> np.ndarray:
     """
-    Given binary mask and apply morphological closing(>0) then opening(>0) followed by dilation(>0).
+    Apply morphological closing(>0) then opening(>0) followed by dilation(>0) on given binary mask.
 
     :param mask: Binary image to process
     :param filter: dict of integer (closing=int, opening=int, dilation=int), order of operation
@@ -418,14 +418,13 @@ def _compute_overlap_depth(r: Tuple[int, int, int], ndim: int) -> Tuple[int, ...
 
 
 def mask_cleanup(
-        mask: xr.DataArray, filter: Dict = dict(closing=0, opening=2, dilation=5), name: Optional[str] = None
+    mask: xr.DataArray, filter: Dict = dict(closing=0, opening=2, dilation=5), name: Optional[str] = None
 ) -> xr.DataArray:
     """
-    Given binary mask and apply morphological closing(>0) then opening(>0) followed by dilation(>0).
+    Apply morphological closing(>0) then opening(>0) followed by dilation(>0) on given binary mask.
 
-    This is bit-equivalent to ``mask |> morphological closing(r3) |> opening(r1) |> dilation(r2)``, but
-    could be faster when using Dask, as we fuse those operations into single
-    Dask task.
+    This is bit-equivalent to ``mask |> morphological closing |> opening |> dilation``, but
+    could be faster when using Dask, as we fuse those operations into single Dask task.
 
     :param mask: Binary image to process
     :param filter: dict of integer (closing=int, opening=int, dilation=int), order of operation

--- a/libs/algo/odc/algo/io.py
+++ b/libs/algo/odc/algo/io.py
@@ -307,7 +307,7 @@ def load_enum_filtered(
     band: str,
     geobox: GeoBox,
     categories: Iterable[Union[str, int]],
-    filters: Optional[Tuple[int, int]] = None,
+    filters: Optional[Dict[str, int]] = None,
     groupby: Optional[str] = None,
     resampling: str = "nearest",
     chunks: Optional[Dict[str, int]] = None,
@@ -331,9 +331,11 @@ def load_enum_filtered(
     :param geobox: GeoBox of the final output
     :param categories: Enum values or names
 
-    :param filters: Optional Tuple of (r1, r2), here r1 shrinks away small
-                    areas of the mask, and r2 adds padding. Units are in native
-                    pixels of the mask. Use ``0`` to skip filter step.
+    :param filters: dict(closing=int, opening=int, dilation=int), where
+                    closing(optional = remove small holes in cloud - morphological closing,
+                    opening = shrinks away small areas of the mask,
+                    dilation = adds padding to the mask.
+                    Use ``0`` to skip filter step.
     :param groupby: One of 'solar_day'|'time'|'idx'|None
     :param resampling: Any resampling mode supported by GDAL as a string:
                        nearest, bilinear, average, mode, cubic, etc...
@@ -378,7 +380,7 @@ def load_enum_filtered(
     pad = kw.pop("pad", None)
     if pad is None:
         if filters is not None:
-            pad = max(*filters)
+            pad = max(*filters.values())
 
     xx = load_with_native_transform(
         dss,

--- a/libs/algo/tests/test_masking.py
+++ b/libs/algo/tests/test_masking.py
@@ -12,6 +12,7 @@ from odc.algo._masking import (
     _get_enum_values,
     _enum_to_mask_numexpr,
     _fuse_mean_np,
+    mask_cleanup_np
 )
 
 
@@ -218,7 +219,7 @@ def test_enum_to_mask_numexpr():
 def test_fuse_mean_np():
     data = np.array([
         [[255, 255], [255, 50]],
-        [[30, 40], [255, 80]], 
+        [[30, 40], [255, 80]],
         [[25, 52], [255, 98]],
     ]).astype(np.uint8)
 
@@ -226,3 +227,12 @@ def test_fuse_mean_np():
     out = _fuse_mean_np(*slices, nodata=255)
     assert (out == np.array([[28, 46], [255, 76]])).all()
 
+def test_mask_cleanup_np():
+    mask = np.ndarray(shape=(2,2), dtype=bool, buffer=np.array([[True, False], [False, True]]))
+    r = (1, 2, 1)
+
+    result = mask_cleanup_np(mask, r)
+    expected_result = np.array(
+        [[True, True], [True, True]],
+    )
+    assert (result == expected_result).all()

--- a/libs/algo/tests/test_masking.py
+++ b/libs/algo/tests/test_masking.py
@@ -12,7 +12,6 @@ from odc.algo._masking import (
     _get_enum_values,
     _enum_to_mask_numexpr,
     _fuse_mean_np,
-    mask_cleanup,
     mask_cleanup_np
 )
 

--- a/libs/algo/tests/test_masking.py
+++ b/libs/algo/tests/test_masking.py
@@ -12,6 +12,7 @@ from odc.algo._masking import (
     _get_enum_values,
     _enum_to_mask_numexpr,
     _fuse_mean_np,
+    mask_cleanup,
     mask_cleanup_np
 )
 
@@ -229,10 +230,38 @@ def test_fuse_mean_np():
 
 def test_mask_cleanup_np():
     mask = np.ndarray(shape=(2,2), dtype=bool, buffer=np.array([[True, False], [False, True]]))
-    r = (1, 2, 1)
 
-    result = mask_cleanup_np(mask, r)
+    mask_filter_with_opening_dilation = dict(opening=1, dilation=1)
+    result = mask_cleanup_np(mask, mask_filter_with_opening_dilation)
+    expected_result = np.array(
+        [[False, False], [False, False]],
+    )
+    assert (result == expected_result).all()
+
+    mask_filter_opening = dict(opening=1, dilation=0)
+    result = mask_cleanup_np(mask, mask_filter_opening)
+    expected_result = np.array(
+        [[False, False], [False, False]],
+    )
+    assert (result == expected_result).all()
+
+    mask_filter_with_dilation = dict(opening=0, dilation=1)
+    result = mask_cleanup_np(mask, mask_filter_with_dilation)
     expected_result = np.array(
         [[True, True], [True, True]],
+    )
+    assert (result == expected_result).all()
+
+    mask_filter_with_closing = dict(closing=1, opening=1, dilation=1)
+    result = mask_cleanup_np(mask, mask_filter_with_closing)
+    expected_result = np.array(
+        [[True, True], [True, True]],
+    )
+    assert (result == expected_result).all()
+
+    mask_filter_with_all_zero = dict(closing=0, opening=0, dilation=0)
+    result = mask_cleanup_np(mask, mask_filter_with_all_zero)
+    expected_result = np.array(
+        [[True, False], [False, True]],
     )
     assert (result == expected_result).all()

--- a/libs/stats/odc/stats/_gm.py
+++ b/libs/stats/odc/stats/_gm.py
@@ -1,7 +1,7 @@
 """
 Geomedian
 """
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 import xarray as xr
 from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
@@ -23,7 +23,7 @@ class StatsGM(StatsPluginInterface):
         mask_band: str,
         cloud_classes: Tuple[str, ...],
         nodata_classes: Optional[Tuple[str, ...]] = None,
-        filters: Optional[Tuple[int, int]] = (0, 0),
+        filters: Optional[Dict[str, int]] = dict(opening=0, dilation=0),
         basis_band=None,
         aux_names=dict(smad="smad", emad="emad", bcmad="bcmad", count="count"),
         rgb_bands=None,
@@ -153,7 +153,7 @@ class StatsGMS2(StatsGM):
             "thin cirrus",
         ),
         nodata_classes: Optional[Tuple[str, ...]] = None,
-        filters: Optional[Tuple[int, int]] = (2, 5),
+        filters: Optional[Dict[str, int]] = dict(opening=2, dilation=5),
         basis_band: Optional[str] = None,
         aux_names=dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT"),
         rgb_bands=None,
@@ -209,7 +209,7 @@ class StatsGMLS(StatsGM):
         mask_band: str = "fmask",
         cloud_classes: Tuple[str, ...] = ("cloud", "shadow"),
         nodata_classes: Optional[Tuple[str, ...]] = ("nodata",),
-        filters: Optional[Tuple[int, int]] = (0, 0),
+        filters: Optional[Dict[str, int]] = dict(opening=0, dilation=0),
         basis_band: Optional[str] = None,
         aux_names=dict(smad="sdev", emad="edev", bcmad="bcdev", count="count"),
         rgb_bands=None,

--- a/libs/stats/odc/stats/_gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/_gm_ls_bitmask.py
@@ -25,7 +25,7 @@ class StatsGMLSBitmask(StatsPluginInterface):
             self,
             bands: Optional[Tuple[str, ...]] = None,
             mask_band: str = "QA_PIXEL",
-            filter: Optional[Tuple[int, int]] = None,
+            filter: Optional[Tuple[int, int, int]] = None,
             aux_names=dict(smad="sdev", emad="edev", bcmad="bcdev", count="count"),
             resampling: str = "nearest",
             work_chunks: Tuple[int, int] = (400, 400),
@@ -133,7 +133,8 @@ class StatsGMLSBitmask(StatsPluginInterface):
             compute_mads=True,
         )
 
-        # apply filter - [r1, r2]
+        # apply filter in this order - [r1, r2, r3]
+        # r3 = remove small holes in cloud - morphological closing
         # r1 = shrinks away small areas of the mask
         # r2 = adds padding to the mask
         if self.filter is not None:

--- a/libs/stats/odc/stats/_pq.py
+++ b/libs/stats/odc/stats/_pq.py
@@ -2,7 +2,7 @@
 Sentinel 2 pixel quality stats
 """
 from functools import partial
-from typing import List, Optional, Tuple, cast
+from typing import List, Dict, Optional, Tuple, cast
 
 import xarray as xr
 
@@ -21,16 +21,14 @@ cloud_classes = (
     "thin cirrus",
 )
 
-# Filters are a list of (r1: int, r2: int, r3: int) tuples, where
+# Filters are a list of dict(closing=int, opening=int, dilation=int), where
+# closing(Optional) = remove small holes in cloud - morphological closing
+# opening = shrinks away small areas of the mask
+# dilation = adds padding to the mask
 #
-#  ``r3=N`` - The morphological closing allows to close gaps in clouds
-#  ``r1=N`` - Shrink away clouds smaller than N pixels radius (0 -- do not shrink)
-#  ``r2=N`` - For clouds that remain after shrinking add that much padding in pixels
-#
-# For each entry in the list an extra ``.clear_{r1}_{r2}_{r3}`` band will be added to the output in addition to
+# For each entry in the list an extra ``.clear_{r1}_{r2}`` band will be added to the output in addition to
 # ``.total`` and ``.clear`` bands that are always computed.
-default_filters = [(2, 5, 0), (0, 5, 0)]
-
+default_filters = [dict(opening=2,dilation=5), dict(opening=0,dilation=5)]
 
 class StatsPQ(StatsPluginInterface):
     NAME = "pc_s2_annual"
@@ -40,7 +38,7 @@ class StatsPQ(StatsPluginInterface):
 
     def __init__(
         self,
-        filters: Optional[List[Tuple[int, int, int]]] = None,
+        filters: Optional[List[Dict[str, int]]] = None,
         resampling: str = "nearest",
     ):
         if filters is None:
@@ -50,11 +48,14 @@ class StatsPQ(StatsPluginInterface):
 
     @property
     def measurements(self) -> Tuple[str, ...]:
-        return (
-            "total",
-            "clear",
-            *[f"clear_{r1:d}_{r2:d}_{r3:d}" for (r1, r2, r3) in self.filters],
-        )
+        measurements = ["total", "clear"]
+        for filter in self.filters:
+            if "closing" in filter:
+                measurements.append(f"clear_{filter['closing']:d}_{filter['opening']:d}_{filter['dilation']:d}")
+            else:
+                measurements.append(f"clear_{filter['opening']:d}_{filter['dilation']:d}")
+
+        return tuple(measurements)
 
     def input_data(self, task: Task) -> xr.Dataset:
         """
@@ -114,7 +115,7 @@ def _pq_native_transform(xx: xr.Dataset) -> xr.Dataset:
 
 
 def _pq_fuser(
-    xx: xr.Dataset, filters: Optional[List[Tuple[int, int]]] = None
+    xx: xr.Dataset, filters: Optional[List[Dict]] = None
 ) -> xr.Dataset:
     """
     Native:
@@ -130,9 +131,12 @@ def _pq_fuser(
     xx.attrs.pop("native", None)
 
     if is_native:
-        if filters is not None:
-            for r1, r2, r3 in filters:
-                xx[f"erased_{r1:d}_{r2:d}"] = mask_cleanup(xx.erased, (r1, r2, r3))
+        for filter in filters:
+            if "closing" in filter:
+                erased_band_name = f"erased_{filter['closing']:d}_{filter['opening']:d}_{filter['dilation']:d}"
+            else:
+                erased_band_name = f"erased_{filter['opening']:d}_{filter['dilation']:d}"
+            xx[erased_band_name] = mask_cleanup(xx.erased, filter)
 
     return xx
 
@@ -143,7 +147,7 @@ _plugins.register("pq", StatsPQ)
 def test_pq_product():
     location = "file:///tmp"
     product = StatsPQ().product(location)
-    assert product.measurements == ("total", "clear", "clear_2_5_0", "clear_0_5_0")
+    assert product.measurements == ("total", "clear", "clear_2_5", "clear_0_5")
 
     product = StatsPQ(filters=[]).product(location)
     assert product.measurements == ("total", "clear")
@@ -154,7 +158,7 @@ def test_plugin():
     pq = _plugins.resolve("pq")()
     product = pq.product(location)
 
-    assert product.measurements == ("total", "clear", "clear_2_5_0", "clear_0_5_0")
+    assert product.measurements == ("total", "clear", "clear_2_5", "clear_0_5")
     assert pq.filters == default_filters
 
     pq = _plugins.resolve("pq")(filters=[], resampling="cubic")

--- a/libs/stats/odc/stats/_pq.py
+++ b/libs/stats/odc/stats/_pq.py
@@ -115,7 +115,7 @@ def _pq_native_transform(xx: xr.Dataset) -> xr.Dataset:
 
 
 def _pq_fuser(
-    xx: xr.Dataset, filters: Optional[List[Dict]] = None
+    xx: xr.Dataset, filters: Optional[List[Dict[str, int]]] = None
 ) -> xr.Dataset:
     """
     Native:

--- a/libs/stats/odc/stats/_pq_bitmask.py
+++ b/libs/stats/odc/stats/_pq_bitmask.py
@@ -12,22 +12,22 @@ aerosol_band = input band for aerosol masking; provide one of the band as an inp
 | SR_ATMOS_OPACITY | Unitless | 0.001 * DN | Atmospheric opacity; < 0.1 = clear; 0.1 - 0.3 = average; > 0.3 = hazy |
 | SR_QA_AEROSOL    | Bit Index | NA | Aerosol level; Bit(6-7): 00 = climatology; 01 = low; 10 = medium; 11 = high |
 
-filters = filters to apply on cloud mask - [[r1, r2, r3], ...]
-    r1 = shrinks away small areas of the mask
-    r2 = adds padding to the mask
-    r3 = remove small holes in cloud - morphological closing
-aerosol_filters = filters to apply on cloud mask - [[r1, r2, r3], ...] and then calculate clear_aerosol
+filters = filters to apply on cloud mask - dict(closing=int, opening=int, dilation=int), where
+    closing(optional = remove small holes in cloud - morphological closing
+    opening = shrinks away small areas of the mask
+    dilation = adds padding to the mask
+aerosol_filters = filters to apply on cloud mask - dict(closing=int, opening=int, dilation=int) and then calculate clear_aerosol
 resampling = "nearest"
 """
 
 from functools import partial
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import dask.array as da
 import xarray as xr
 
 from odc.algo import mask_cleanup, keep_good_only
-from odc.algo._masking import _xr_fuse, _first_valid_np, _fuse_or_np, _fuse_and_np, binary_closing
+from odc.algo._masking import _xr_fuse, _first_valid_np, _fuse_or_np
 from odc.algo.io import load_with_native_transform
 from odc.stats.model import Task
 
@@ -45,8 +45,8 @@ class StatsPQLSBitmask(StatsPluginInterface):
             self,
             pq_band: str = "QA_PIXEL",
             aerosol_band: Optional[str] = None,
-            filters: Optional[List[Tuple[int, int, int]]] = [],
-            aerosol_filters: Optional[List[Tuple[int, int, int]]] = [],
+            filters: Optional[List[Dict[str, int]]] = None,
+            aerosol_filters: Optional[List[Dict[str, int]]] = None,
             resampling: str = "nearest",
     ):
         self.pq_band = pq_band
@@ -60,20 +60,23 @@ class StatsPQLSBitmask(StatsPluginInterface):
         """
         Output product measurements
         """
-        _measurements = [
-            "total",
-            "clear",
-            *[f"clear_{r1:d}_{r2:d}_{r3:d}" for (r1, r2, r3) in self.filters],
-        ]
-        if self.aerosol_band:
-            aerosol_measurements = [
-                "clear_aerosol",
-                *[f"clear_{r1:d}_{r2:d}_{r3:d}_aerosol" for (r1, r2, r3) in self.aerosol_filters if
-                  self.aerosol_band == "SR_QA_AEROSOL" and self.aerosol_filters],
-            ]
-            _measurements.extend(aerosol_measurements)
+        measurements = ["total", "clear"]
+        for filter in self.filters or []:
+            if "closing" in filter:
+                measurements.append(f"clear_{filter['closing']:d}_{filter['opening']:d}_{filter['dilation']:d}")
+            else:
+                measurements.append(f"clear_{filter['opening']:d}_{filter['dilation']:d}")
 
-        return tuple(_measurements)
+        if self.aerosol_band:
+            measurements.append("clear_aerosol")
+            if self.aerosol_band == "SR_QA_AEROSOL":
+                for aerosol_filter in self.aerosol_filters or []:
+                    if "closing" in aerosol_filter:
+                        measurements.append(f"clear_{aerosol_filter['closing']:d}_{aerosol_filter['opening']:d}_{aerosol_filter['dilation']:d}_aerosol")
+                    else:
+                        measurements.append(f"clear_{aerosol_filter['opening']:d}_{aerosol_filter['dilation']:d}_aerosol")
+
+        return tuple(measurements)
 
     def input_data(self, task: Task) -> xr.Dataset:
         bands = [self.pq_band]
@@ -103,8 +106,12 @@ class StatsPQLSBitmask(StatsPluginInterface):
         """
         pq = xr.Dataset()
 
-        for r1, r2, r3 in self.filters or []:
-            xx[f"erased_{r1:d}_{r2:d}_{r3:d}"] = mask_cleanup(xx["erased"], (r1, r2, r3))
+        for filter in self.filters or []:
+            if "closing" in filter:
+                erased_band_name = f"erased_{filter['closing']:d}_{filter['opening']:d}_{filter['dilation']:d}"
+            else:
+                erased_band_name = f"erased_{filter['opening']:d}_{filter['dilation']:d}"
+            xx[erased_band_name] = mask_cleanup(xx["erased"], filter)
 
         erased_bands = [str(n) for n in xx.data_vars if str(n).startswith("erased")]
         valid = xx["keeps"]
@@ -117,14 +124,19 @@ class StatsPQLSBitmask(StatsPluginInterface):
                 pq[clear_name] = (valid & (~xx[band])).sum(axis=0, dtype="uint16")
 
         if self.aerosol_band and self.aerosol_band == "SR_QA_AEROSOL":
-            for r1, r2, r3 in self.aerosol_filters or []:
-                # apply filter on cloud_mask if not exists
-                if f"erased_{r1:d}_{r2:d}_{r3:d}" not in xx:
-                    xx[f"erased_{r1:d}_{r2:d}_{r3:d}"] = mask_cleanup(xx["erased"], (r1, r2, r3))
+            for aerosol_filter in self.aerosol_filters or []:
+                if "closing" in aerosol_filter:
+                    erased_band_name = f"erased_{aerosol_filter['closing']:d}_{aerosol_filter['opening']:d}_{aerosol_filter['dilation']:d}"
+                    aerosol_band_name = f"clear_{aerosol_filter['closing']:d}_{aerosol_filter['opening']:d}_{aerosol_filter['dilation']:d}_aerosol"
+                else:
+                    erased_band_name = f"erased_{aerosol_filter['opening']:d}_{aerosol_filter['dilation']:d}"
+                    aerosol_band_name = f"clear_{aerosol_filter['opening']:d}_{aerosol_filter['dilation']:d}_aerosol"
 
-                pq[f"clear_{r1:d}_{r2:d}_{r3:d}_aerosol"] = (
-                        valid & (~xx[f"erased_{r1:d}_{r2:d}_{r3:d}"] & ~xx["erased_aerosol"])) \
-                            .sum(axis=0, dtype="uint16")
+                # apply filter on cloud_mask if not exists
+                if erased_band_name not in xx:
+                    xx[erased_band_name] = mask_cleanup(xx["erased"], aerosol_filter)
+
+                pq[aerosol_band_name] = (valid & (~xx[erased_band_name] & ~xx["erased_aerosol"])).sum(axis=0, dtype="uint16")
 
         return pq
 

--- a/libs/stats/odc/stats/_pq_bitmask.py
+++ b/libs/stats/odc/stats/_pq_bitmask.py
@@ -104,8 +104,7 @@ class StatsPQLSBitmask(StatsPluginInterface):
         pq = xr.Dataset()
 
         for r1, r2, r3 in self.filters or []:
-            cloud_mask = binary_closing(xx["erased"], r3)
-            xx[f"erased_{r1:d}_{r2:d}_{r3:d}"] = mask_cleanup(cloud_mask, (r1, r2))
+            xx[f"erased_{r1:d}_{r2:d}_{r3:d}"] = mask_cleanup(xx["erased"], (r1, r2, r3))
 
         erased_bands = [str(n) for n in xx.data_vars if str(n).startswith("erased")]
         valid = xx["keeps"]
@@ -121,8 +120,7 @@ class StatsPQLSBitmask(StatsPluginInterface):
             for r1, r2, r3 in self.aerosol_filters or []:
                 # apply filter on cloud_mask if not exists
                 if f"erased_{r1:d}_{r2:d}_{r3:d}" not in xx:
-                    cloud_mask = binary_closing(xx["erased"], r3)
-                    xx[f"erased_{r1:d}_{r2:d}_{r3:d}"] = mask_cleanup(cloud_mask, (r1, r2))
+                    xx[f"erased_{r1:d}_{r2:d}_{r3:d}"] = mask_cleanup(xx["erased"], (r1, r2, r3))
 
                 pq[f"clear_{r1:d}_{r2:d}_{r3:d}_aerosol"] = (
                         valid & (~xx[f"erased_{r1:d}_{r2:d}_{r3:d}"] & ~xx["erased_aerosol"])) \

--- a/libs/stats/tests/test_pq_bitmask.py
+++ b/libs/stats/tests/test_pq_bitmask.py
@@ -101,15 +101,19 @@ def test_fuser(dataset):
     erased_cloud = fuser_result["erased"].data
     assert (erased_cloud == expected_result).all()
 
+def test_meaurements(dataset):
+    pq = StatsPQLSBitmask(filters=[dict(closing=0,opening=1,dilation=1)])
+    meaurements = pq.measurements
+
 def test_reduce(dataset):
-    pq = StatsPQLSBitmask(filters=[[1,1,0]])
+    pq = StatsPQLSBitmask(filters=[dict(closing=0,opening=1,dilation=1)])
 
     xx = pq._native_tr(dataset)
     xx = pq.reduce(xx)
     reduce_result = xx.compute()
 
     assert set(reduce_result.data_vars.keys()) == set(
-        ["total", "clear", "clear_1_1_0"]
+        ["total", "clear", "clear_0_1_1"]
     )
 
     expected_result = np.array(
@@ -127,7 +131,7 @@ def test_reduce(dataset):
     expected_result = np.array(
         [[2, 3], [3, 2]]
     )
-    clear_1_1_0 = reduce_result["clear_1_1_0"].data
+    clear_1_1_0 = reduce_result["clear_0_1_1"].data
     assert (clear_1_1_0 == expected_result).all()
 
 def test_native_transform_for_aerosol(dataset_with_aerosol_band):
@@ -181,26 +185,28 @@ def test_reduce_for_aerosol(dataset_with_aerosol_band):
     assert (clear_aerosol == expected_result).all()
 
 def test_reduce_for_aerosol_with_filter(dataset_with_aerosol_band):
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL", filters=[[1,1,0]], aerosol_filters=[[1,1,0]])
+    filters = [dict(closing=0,opening=1,dilation=1)]
+    aerosol_filters = [dict(closing=0,opening=1,dilation=1)]
+    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL", filters=filters, aerosol_filters=aerosol_filters)
 
     xx = pq._native_tr(dataset_with_aerosol_band)
     xx = pq.reduce(xx)
     reduce_result = xx.compute()
 
     assert set(reduce_result.data_vars.keys()) == set(
-        ["total", "clear", "clear_1_1_0", "clear_aerosol", "clear_1_1_0_aerosol"]
+        ["total", "clear", "clear_0_1_1", "clear_aerosol", "clear_0_1_1_aerosol"]
     )
 
     expected_result = np.array(
         [[2, 3], [3, 2]]
     )
-    clear_1_1_0 = reduce_result["clear_1_1_0"].data
+    clear_1_1_0 = reduce_result["clear_0_1_1"].data
     assert (clear_1_1_0 == expected_result).all()
 
     expected_result = np.array(
         [[1, 3], [2, 2]]
     )
-    clear_aerosol = reduce_result["clear_1_1_0_aerosol"].data
+    clear_aerosol = reduce_result["clear_0_1_1_aerosol"].data
     assert (clear_aerosol == expected_result).all()
 
 def test_native_transform_for_atmos_opacity(dataset_with_atmos_opacity_band):


### PR DESCRIPTION
 update masking lib to support third argument so the operation can be performed in this order:
- morphological closing with r3 (>0)
- then opening with r1 (>0)
- followed by dilation with r2 (>0)

Doing this will fixes:
- overlap issue as the whole masking operation is performed using single dask task