### PR TITLE
Dilate nodata and non-contiguity bita

### DIFF
--- a/libs/stats/odc/stats/_wofs.py
+++ b/libs/stats/odc/stats/_wofs.py
@@ -45,7 +45,7 @@ class StatsWofs(StatsPluginInterface):
     PRODUCT_FAMILY = "wo_summary"
 
     # these get padded out if dilation was requested
-    BAD_BITS_MASK = 0b0111_1110  # Cloud/Shadow + Terrain Shadow
+    BAD_BITS_MASK = 0b0111_1111  # Cloud/Shadow + Terrain Shadow
 
     def __init__(
         self,

--- a/libs/stats/odc/stats/_wofs.py
+++ b/libs/stats/odc/stats/_wofs.py
@@ -45,7 +45,7 @@ class StatsWofs(StatsPluginInterface):
     PRODUCT_FAMILY = "wo_summary"
 
     # these get padded out if dilation was requested
-    BAD_BITS_MASK = 0b0110_1000  # Cloud/Shadow + Terrain Shadow
+    BAD_BITS_MASK = 0b0111_1110  # Cloud/Shadow + Terrain Shadow
 
     def __init__(
         self,

--- a/libs/stats/odc/stats/_wofs.py
+++ b/libs/stats/odc/stats/_wofs.py
@@ -45,7 +45,7 @@ class StatsWofs(StatsPluginInterface):
     PRODUCT_FAMILY = "wo_summary"
 
     # these get padded out if dilation was requested
-    BAD_BITS_MASK = 0b0111_1111  # Cloud/Shadow + Terrain Shadow
+    BAD_BITS_MASK = 0b0110_1011  # Cloud/Shadow, Terrain Shadow, non-contiguous, and nodata
 
     def __init__(
         self,


### PR DESCRIPTION
This branch dilates the nodata and non-contiguity bits when calculating a wofs summary. This more aggressively masks out regions in wofs to hopefully yield a cleaner summary.

This branch is mostly here for testing, this may lead to unacceptable level of data loss.

@omad I won't be merging this but I'm creating a review just to check if this is right