### PR TITLE
Add eodataset3 to odc-tools

### DIFF
--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -143,6 +143,7 @@ pyparsing==2.4.7
 pyproj==3.1.0
 pyrsistent==0.18.0
 pystac==1.1.0
+eodatasets3==0.22.0
 pystac-client==0.2.0
 pytest==6.2.4
 pytest-cov==2.12.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -33,6 +33,7 @@ aiobotocore[boto3,awscli]==1.3.3
 
 # Make sure dask has all the features enabled
 dask[complete]
+eodatasets3==0.22.0
 
 # not needed for python 3.8 and up, and are not installed,
 # but `pip check` doesn't know better


### PR DESCRIPTION
We need the eodatasets3 in develop branch firstly. 

The feature branch always grab the test-image from develop branch to run test. So I cannot add new library to test-image in feature branch.

All test passed, only the code codecov fail.