### PR TITLE
Make sure dependencies are properly defined in odc-stac

### DIFF
--- a/libs/stac/setup.cfg
+++ b/libs/stac/setup.cfg
@@ -22,11 +22,15 @@ tests_require =
     deepdiff
 
 install_requires =
+    affine
     datacube>=1.8.5 # need hashable GeoBox
     jinja2
-    odc_io
+    numpy
+    odc-io
+    pandas
+    pystac>=1.0.0,<2
     toolz
-    pyproj
+    xarray
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Remove pyproj as it was not used, but add pystac,numpy,affine,pandas,xarray
which are used directly but were not listed in setup.cfg