### PR TITLE
[odc-stac] Allow 3x3 proj:transforms in `asset_geobox`

### DIFF
--- a/libs/stac/odc/stac/_eo3.py
+++ b/libs/stac/odc/stac/_eo3.py
@@ -77,7 +77,14 @@ def asset_geobox(asset: pystac.asset.Asset) -> GeoBox:
     assert _proj.crs_string is not None
 
     h, w = _proj.shape
-    affine = Affine(*_proj.transform)
+    if len(_proj.transform) == 9:
+        if _proj.transform[6:] != [0, 0, 1]:
+            raise ValueError(
+                f"Asset transform is not affine: {_proj.transform}")
+        transform = _proj.transform[0:6]
+    else:
+        transform = _proj.transform
+    affine = Affine(*transform)
     return GeoBox(w, h, affine, _proj.crs_string)
 
 

--- a/libs/stac/tests/data/S2A_28QCH_20200714_0_L2A.json
+++ b/libs/stac/tests/data/S2A_28QCH_20200714_0_L2A.json
@@ -2,9 +2,9 @@
   "type": "Feature",
   "stac_version": "1.0.0-beta.1",
   "stac_extensions": [
-    "eo",
-    "view",
-    "proj"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
   ],
   "id": "S2A_28QCH_20200714_0_L2A",
   "bbox": [

--- a/libs/stac/tests/test_stac_eo3.py
+++ b/libs/stac/tests/test_stac_eo3.py
@@ -1,12 +1,6 @@
-from odc.stac._eo3 import (
-    mk_product,
-    BandMetadata,
-    compute_eo3_grids,
-    infer_dc_product,
-    is_raster_data,
-    item_to_ds,
-    stac2ds,
-)
+from odc.stac._eo3 import (mk_product, BandMetadata, compute_eo3_grids,
+                           infer_dc_product, is_raster_data, item_to_ds,
+                           stac2ds, asset_geobox)
 import pystac
 
 STAC_CFG = {
@@ -95,3 +89,9 @@ def test_item_to_ds(sentinel_stac_ms):
     dss = list(stac2ds(iter([item, item, item]), STAC_CFG))
     assert len(dss) == 3
     assert len(set(id(ds.type) for ds in dss)) == 1
+
+
+def test_asset_geobox(sentinel_stac):
+    item = pystac.Item.from_dict(sentinel_stac)
+    asset = item.assets["B01"]
+    asset_geobox(asset)


### PR DESCRIPTION
As demonstrated in https://github.com/gadomski/chalkboard/blob/062dd84c7d7323066c0a2af238bc123e29aaf88f/odc-stac.ipynb, 3x3 matrices are not allowed in `odc.stac._eo3.asset_geobox`. This patch adds 3x3 support to `asset_geobox` while checking to ensure the matrix is an affine transform. Includes a unit test.

Sidecar changes:
- Update the stac_extensions list to be urls, which is required to use `ProjectionExtension` in `asset_geobox`.