### PR TITLE
Handle issue #348. disable the useless test

### DIFF
--- a/libs/stats/tests/test_utils.py
+++ b/libs/stats/tests/test_utils.py
@@ -8,7 +8,6 @@ from datacube import Datacube
 from datacube.model import Dataset, DatasetType, metadata_from_doc
 from datacube.index.eo3 import prep_eo3
 from datacube.index.index import default_metadata_type_docs
-from eodatasets3.assemble import DatasetAssembler
 from odc.stac.transform import stac_transform
 from odc.stats.model import DateTimeRange
 from odc.stats.tasks import TaskReader
@@ -41,10 +40,6 @@ def test_stac(test_db_path):
 
     stac_item = pystac.Item.from_dict(stac_meta)
     stac_item.validate()
-
-    # check eodatasets3 integration
-    datasetassembler = task.render_assembler_metadata()
-    assert isinstance(datasetassembler, DatasetAssembler)
 
 
 def test_binning():


### PR DESCRIPTION
To the [issue](https://github.com/opendatacube/odc-tools/issues/348)

This unit test return tons of warning messages, but does not do any useful test. Disable it right now.