### PR TITLE
Improve eodatasets3 performance

### DIFF
--- a/libs/stats/odc/stats/_cli_run.py
+++ b/libs/stats/odc/stats/_cli_run.py
@@ -36,7 +36,7 @@ from ._sqs import SQSWorkToken
     help="Mark outputs for public access (default: no)",
 )
 @click.option(
-    "--apply_eodatasets3/--not_apply_eodatasets3",
+    "--apply_eodatasets3",
     is_flag=True,
     default=False,
     help="Apply eodatasets3 plugin to generate metadata files (default: use PySTAC to generate metadata files)",

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -240,7 +240,7 @@ class S3COGSink:
         thumbnail_bytes = FileWrite().create_thumbnail_from_numpy(rgb=tuning_pixels,
                                                                   static_stretch=stretch,
                                                                   input_geobox=input_geobox,
-                                                                  nodata=task.product.nodata[band])
+                                                                  nodata=ds[band].nodata if 'nodata' in ds[band].attrs else None)
                                                                   
         return self._write_blob(thumbnail_bytes, thumbnail_path, ContentType="image/jpeg")
 
@@ -256,7 +256,8 @@ class S3COGSink:
         
         for display_band in ['red', 'green', 'blue']:
             display_pixels.append(ds[multi_band[display_band]].values.reshape([task.geobox.shape[0], task.geobox.shape[1]])) if display_band in multi_band else display_pixels.append(zero_band)
-            nodata_val = task.product.nodata[multi_band[display_band]] if display_band in multi_band else 0
+            if display_band in multi_band:
+                nodata_val = ds[multi_band[display_band]].nodata if 'nodata' in ds[multi_band[display_band]].attrs else None
 
         thumbnail_name = multi_band['thumbnail_name']
         thumbnail_path = odc_file_path.split('.')[0] + f"_{thumbnail_name}_thumbnail.jpg"

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -277,11 +277,6 @@ class S3COGSink:
                                 transform=task.geobox.transform, 
                                 crs=CRS.from_epsg(task.geobox.crs.to_epsg()))
 
-        # if we do not define the r/g/b values, we will grab the first avaialble variable shape to 
-        # generate full zero numpy
-        zero_band = numpy.zeros_like(ds[list(ds.keys())[0]].values.reshape([task.geobox.shape[0], 
-                                                                            task.geobox.shape[1]]))
-
         if task.product.preview_image_singleband:
             for single_band in task.product.preview_image_singleband:
                 thumbnail_cog = self._get_single_band_thumbnail(ds, task, single_band, input_geobox, odc_file_path)

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import json
 import pandas as pd
+import numpy
 import pystac
 import xarray as xr
 from datacube.model import Dataset
@@ -400,7 +401,7 @@ class Task:
                 # when we pass grid, the eodatasets will not load file from path
                 dataset_assembler.note_measurement(band,
                                                     path,
-                                                    pixels=output_dataset[band].values.reshape([self.geobox.shape[0], self.geobox.shape[1]]),
+                                                    pixels=numpy.zeros((self.geobox.shape[0], self.geobox.shape[1])),
                                                     grid=GridSpec(shape=self.geobox.shape,
                                                                     transform=self.geobox.transform,
                                                                     crs=CRS.from_epsg(self.geobox.crs.to_epsg())),

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -405,7 +405,7 @@ class Task:
                                                     grid=GridSpec(shape=self.geobox.shape,
                                                                     transform=self.geobox.transform,
                                                                     crs=CRS.from_epsg(self.geobox.crs.to_epsg())),
-                                                    nodata=self.product.nodata[band])
+                                                    nodata=output_dataset[band].nodata if 'nodata' in output_dataset[band].attrs else 'None')
 
         return dataset_assembler
 


### PR DESCRIPTION
In this PR, we are doing:
1. Remove the nodata values from Config file. The metadata will extract them from output dataset nodata field
2. Avoid the actually data loading from XArray.Dataset (e.g. dataset[band]. values). Then the eodatasets3 metadata files section can be lightweight.