### PR TITLE
Make STAC -> ODC conversion more robust to missing extension data

### DIFF
--- a/libs/stac/odc/stac/__init__.py
+++ b/libs/stac/odc/stac/__init__.py
@@ -7,6 +7,7 @@ from ._eo3 import (
     BandMetadata,
     ConversionConfig,
     stac2ds,
+    infer_dc_product,
 )
 
 from ._dcload import dc_load
@@ -16,6 +17,7 @@ __all__ = (
     "BandMetadata",
     "ConversionConfig",
     "stac2ds",
+    "infer_dc_product",
     "dc_load",
     "__version__",
 )

--- a/libs/stac/odc/stac/_eo3.py
+++ b/libs/stac/odc/stac/_eo3.py
@@ -115,7 +115,11 @@ def is_raster_data(asset: pystac.asset.Asset, check_proj: bool = False) -> bool:
        projection data as "raster data" bands.
     """
     if check_proj:
-        if has_proj_ext(asset.owner) and not has_proj_data(asset):
+        if (
+            asset.owner is not None
+            and has_proj_ext(asset.owner)
+            and not has_proj_data(asset)
+        ):
             return False
 
     if asset.roles is not None and len(asset.roles) > 0:

--- a/libs/stac/odc/stac/_eo3.py
+++ b/libs/stac/odc/stac/_eo3.py
@@ -87,7 +87,7 @@ def band_metadata(asset: pystac.asset.Asset, default: BandMetadata) -> BandMetad
 
 def has_proj_ext(item: pystac.Item) -> bool:
     """
-    Check if STAC Item has prjection extension
+    Check if STAC Item has projection extension
     """
     try:
         ProjectionExtension.validate_has_extension(item, add_if_missing=False)
@@ -370,7 +370,7 @@ def mk_product(
 
 @singledispatch
 def infer_dc_product(x: Any, cfg: Optional[ConversionConfig]) -> DatasetType:
-    raise TypeError("Invalid type, must be one of: pystac.Item, pyctac.Collection")
+    raise TypeError("Invalid type, must be one of: pystac.Item, pystac.Collection")
 
 
 @infer_dc_product.register(pystac.Item)

--- a/libs/stac/odc/stac/_eo3.py
+++ b/libs/stac/odc/stac/_eo3.py
@@ -369,7 +369,7 @@ def mk_product(
 
 
 @singledispatch
-def infer_dc_product(x: Any, cfg: Optional[ConversionConfig]) -> DatasetType:
+def infer_dc_product(x: Any, cfg: Optional[ConversionConfig] = None) -> DatasetType:
     raise TypeError("Invalid type, must be one of: pystac.Item, pystac.Collection")
 
 

--- a/libs/stac/tests/conftest.py
+++ b/libs/stac/tests/conftest.py
@@ -11,6 +11,7 @@ from datacube.utils import documents
 TEST_DATA_FOLDER: Path = Path(__file__).parent.joinpath("data")
 LANDSAT_STAC: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
 LANDSAT_ODC: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.odc-metadata.yaml"
+SENTINEL_STAC_COLLECTION: str = "sentinel-2-l2a.collection.json"
 SENTINEL_STAC: str = "S2A_28QCH_20200714_0_L2A.json"
 SENTINEL_STAC_MS: str = "S2B_MSIL2A_20190629T212529_R043_T06VVN_20201006T080531.json"
 SENTINEL_STAC_MS_RASTER_EXT: str = "S2B_MSIL2A_20190629T212529_R043_T06VVN_20201006T080531_raster_ext.json"
@@ -73,6 +74,13 @@ def sentinel_stac_ms_no_ext():
 def sentinel_stac_ms_with_raster_ext():
     return pystac.Item.from_file(
         str(TEST_DATA_FOLDER.joinpath(SENTINEL_STAC_MS_RASTER_EXT))
+    )
+
+
+@pytest.fixture
+def sentinel_stac_collection():
+    return pystac.Collection.from_file(
+        str(TEST_DATA_FOLDER.joinpath(SENTINEL_STAC_COLLECTION))
     )
 
 

--- a/libs/stac/tests/data/sentinel-2-l2a.collection.json
+++ b/libs/stac/tests/data/sentinel-2-l2a.collection.json
@@ -1,0 +1,546 @@
+{
+  "id": "sentinel-2-l2a",
+  "type": "Collection",
+  "links": [
+    {
+      "rel": "items",
+      "type": "application/geo+json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items"
+    },
+    {
+      "rel": "parent",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/"
+    },
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a"
+    },
+    {
+      "rel": "license",
+      "href": "https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf",
+      "title": "Copernicus Sentinel data terms"
+    }
+  ],
+  "title": "Sentinel-2 Level-2A",
+  "assets": {
+    "thumbnail": {
+      "href": "https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/sentinel-2.png",
+      "type": "image/png",
+      "roles": [
+        "thumbnail"
+      ],
+      "title": "Sentinel 2 L2A"
+    }
+  },
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180,
+          -90,
+          180,
+          90
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2015-06-27T10:25:31.456000Z",
+          null
+        ]
+      ]
+    }
+  },
+  "license": "proprietary",
+  "keywords": [
+    "Sentinel",
+    "Copernicus",
+    "ESA",
+    "Satellite",
+    "Global",
+    "Imagery",
+    "Reflectance"
+  ],
+  "providers": [
+    {
+      "url": "https://sentinel.esa.int/web/sentinel/missions/sentinel-2",
+      "name": "ESA",
+      "roles": [
+        "producer",
+        "licensor"
+      ]
+    },
+    {
+      "url": "https://www.esri.com/",
+      "name": "Esri",
+      "roles": [
+        "processor"
+      ]
+    },
+    {
+      "url": "https://planetarycomputer.microsoft.com",
+      "name": "Microsoft",
+      "roles": [
+        "host",
+        "processor"
+      ]
+    }
+  ],
+  "summaries": {
+    "gsd": [
+      10,
+      20,
+      60
+    ],
+    "eo:bands": [
+      {
+        "name": "AOT",
+        "description": "aerosol optical thickness"
+      },
+      {
+        "gsd": 60,
+        "name": "B01",
+        "common_name": "coastal",
+        "description": "coastal aerosol",
+        "center_wavelength": 0.443,
+        "full_width_half_max": 0.027
+      },
+      {
+        "gsd": 10,
+        "name": "B02",
+        "common_name": "blue",
+        "description": "visible blue",
+        "center_wavelength": 0.49,
+        "full_width_half_max": 0.098
+      },
+      {
+        "gsd": 10,
+        "name": "B03",
+        "common_name": "green",
+        "description": "visible green",
+        "center_wavelength": 0.56,
+        "full_width_half_max": 0.045
+      },
+      {
+        "gsd": 10,
+        "name": "B04",
+        "common_name": "red",
+        "description": "visible red",
+        "center_wavelength": 0.665,
+        "full_width_half_max": 0.038
+      },
+      {
+        "gsd": 20,
+        "name": "B05",
+        "common_name": "rededge",
+        "description": "vegetation classification red edge",
+        "center_wavelength": 0.704,
+        "full_width_half_max": 0.019
+      },
+      {
+        "gsd": 20,
+        "name": "B06",
+        "common_name": "rededge",
+        "description": "vegetation classification red edge",
+        "center_wavelength": 0.74,
+        "full_width_half_max": 0.018
+      },
+      {
+        "gsd": 20,
+        "name": "B07",
+        "common_name": "rededge",
+        "description": "vegetation classification red edge",
+        "center_wavelength": 0.783,
+        "full_width_half_max": 0.028
+      },
+      {
+        "gsd": 10,
+        "name": "B08",
+        "common_name": "nir",
+        "description": "near infrared",
+        "center_wavelength": 0.842,
+        "full_width_half_max": 0.145
+      },
+      {
+        "gsd": 20,
+        "name": "B8A",
+        "common_name": "rededge",
+        "description": "vegetation classification red edge",
+        "center_wavelength": 0.865,
+        "full_width_half_max": 0.033
+      },
+      {
+        "gsd": 60,
+        "name": "B09",
+        "description": "water vapor",
+        "center_wavelength": 0.945,
+        "full_width_half_max": 0.026
+      },
+      {
+        "gsd": 20,
+        "name": "B11",
+        "common_name": "swir16",
+        "description": "short-wave infrared, snow/ice/cloud classification",
+        "center_wavelength": 1.61,
+        "full_width_half_max": 0.143
+      },
+      {
+        "gsd": 20,
+        "name": "B12",
+        "common_name": "swir22",
+        "description": "short-wave infrared, snow/ice/cloud classification",
+        "center_wavelength": 2.19,
+        "full_width_half_max": 0.242
+      }
+    ],
+    "platform": [
+      "Sentinel-2A",
+      "Sentinel-2B"
+    ],
+    "instruments": [
+      "msi"
+    ],
+    "constellation": [
+      "sentinel-2"
+    ],
+    "view:off_nadir": [
+      0
+    ]
+  },
+  "description": "The [Sentinel-2](https://sentinel.esa.int/web/sentinel/missions/sentinel-2) program provides global imagery in thirteen spectral bands at 10m-60m resolution and a revisit time of approximately five days.  This dataset represents the global Sentinel-2 archive, from 2016 to the present, processed to L2A (bottom-of-atmosphere) using [Sen2Cor](https://step.esa.int/main/snap-supported-plugins/sen2cor/) and converted to [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.",
+  "item_assets": {
+    "AOT": {
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Aerosol optical thickness (AOT)"
+    },
+    "B01": {
+      "gsd": 60,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 1 - Coastal aerosol - 60m",
+      "eo:bands": [
+        {
+          "name": "B01",
+          "common_name": "coastal",
+          "description": "Band 1 - Coastal aerosol",
+          "center_wavelength": 0.443,
+          "full_width_half_max": 0.027
+        }
+      ]
+    },
+    "B02": {
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 2 - Blue - 10m",
+      "eo:bands": [
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "description": "Band 2 - Blue",
+          "center_wavelength": 0.49,
+          "full_width_half_max": 0.098
+        }
+      ]
+    },
+    "B03": {
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 3 - Green - 10m",
+      "eo:bands": [
+        {
+          "name": "B03",
+          "common_name": "green",
+          "description": "Band 3 - Green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        }
+      ]
+    },
+    "B04": {
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 4 - Red - 10m",
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "description": "Band 4 - Red",
+          "center_wavelength": 0.665,
+          "full_width_half_max": 0.038
+        }
+      ]
+    },
+    "B05": {
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 5 - Vegetation red edge 1 - 20m",
+      "eo:bands": [
+        {
+          "name": "B05",
+          "common_name": "rededge",
+          "description": "Band 5 - Vegetation red edge 1",
+          "center_wavelength": 0.704,
+          "full_width_half_max": 0.019
+        }
+      ]
+    },
+    "B06": {
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 6 - Vegetation red edge 2 - 20m",
+      "eo:bands": [
+        {
+          "name": "B06",
+          "common_name": "rededge",
+          "description": "Band 6 - Vegetation red edge 2",
+          "center_wavelength": 0.74,
+          "full_width_half_max": 0.018
+        }
+      ]
+    },
+    "B07": {
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 7 - Vegetation red edge 3 - 20m",
+      "eo:bands": [
+        {
+          "name": "B07",
+          "common_name": "rededge",
+          "description": "Band 7 - Vegetation red edge 3",
+          "center_wavelength": 0.783,
+          "full_width_half_max": 0.028
+        }
+      ]
+    },
+    "B08": {
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 8 - NIR - 10m",
+      "eo:bands": [
+        {
+          "name": "B08",
+          "common_name": "nir",
+          "description": "Band 8 - NIR",
+          "center_wavelength": 0.842,
+          "full_width_half_max": 0.145
+        }
+      ]
+    },
+    "B09": {
+      "gsd": 60,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 9 - Water vapor - 60m",
+      "eo:bands": [
+        {
+          "name": "B09",
+          "description": "Band 9 - Water vapor",
+          "center_wavelength": 0.945,
+          "full_width_half_max": 0.026
+        }
+      ]
+    },
+    "B11": {
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 11 - SWIR (1.6) - 20m",
+      "eo:bands": [
+        {
+          "name": "B11",
+          "common_name": "swir16",
+          "description": "Band 11 - SWIR (1.6)",
+          "center_wavelength": 1.61,
+          "full_width_half_max": 0.143
+        }
+      ]
+    },
+    "B12": {
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 12 - SWIR (2.2) - 20m",
+      "eo:bands": [
+        {
+          "name": "B12",
+          "common_name": "swir22",
+          "description": "Band 12 - SWIR (2.2)",
+          "center_wavelength": 2.19,
+          "full_width_half_max": 0.242
+        }
+      ]
+    },
+    "B8A": {
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Band 8A - Vegetation red edge 4 - 20m",
+      "eo:bands": [
+        {
+          "name": "B8A",
+          "common_name": "rededge",
+          "description": "Band 8A - Vegetation red edge 4",
+          "center_wavelength": 0.865,
+          "full_width_half_max": 0.033
+        }
+      ]
+    },
+    "SCL": {
+      "gsd": 20,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint8"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Scene classfication map (SCL)"
+    },
+    "WVP": {
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"nodata": 0, "data_type": "uint16"}],
+      "roles": [
+        "data"
+      ],
+      "title": "Water vapour (WVP)"
+    },
+    "visual": {
+      "gsd": 10,
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "raster:bands": [{"data_type": "uint8"},{"data_type": "uint8"},{"data_type": "uint8"}],
+      "roles": [
+        "data"
+      ],
+      "title": "True color image",
+      "eo:bands": [
+        {
+          "name": "B04",
+          "common_name": "red",
+          "description": "Band 4 - Red",
+          "center_wavelength": 0.665,
+          "full_width_half_max": 0.038
+        },
+        {
+          "name": "B03",
+          "common_name": "green",
+          "description": "Band 3 - Green",
+          "center_wavelength": 0.56,
+          "full_width_half_max": 0.045
+        },
+        {
+          "name": "B02",
+          "common_name": "blue",
+          "description": "Band 2 - Blue",
+          "center_wavelength": 0.49,
+          "full_width_half_max": 0.098
+        }
+      ]
+    },
+    "preview": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "roles": [
+        "thumbnail"
+      ],
+      "title": "Thumbnail"
+    },
+    "safe-manifest": {
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "SAFE manifest"
+    },
+    "granule-metadata": {
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "Granule metadata"
+    },
+    "inspire-metadata": {
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "INSPIRE metadata"
+    },
+    "product-metadata": {
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "Product metadata"
+    },
+    "datastrip-metadata": {
+      "type": "application/xml",
+      "roles": [
+        "metadata"
+      ],
+      "title": "Datastrip metadata"
+    }
+  },
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
+  ],
+  "msft:container": "sentinel2-l2",
+  "msft:storage_account": "sentinel2l2a01",
+  "msft:short_description": "The Sentinel-2 program provides global imagery in thirteen spectral bands at 10m-60m resolution and a revisit time of approximately five days.  This dataset contains the global Sentinel-2 archive, from 2016 to the present, processed to L2A (bottom-of-atmosphere)."
+}


### PR DESCRIPTION
### Support for Collection -> Product

- If you have STAC `Collection` that includes "Item Assets" extension then you can create Datacube product from that. 
- If Item Assets include EO extension then common_name will be used to generate aliases
- If Item Assets include Raster extension then `dtype,nodata` will be read from that

### Support for STAC Items without Projection extension

For more information see #297, essentially if there is no projection extension found on an item, then we create Dataset object with "faked" grid, Dataset's `.extent` is still valid and so data can be loaded from that Dataset, one just can't know what native resolution and projections are. But so long as user supplies desired resolution and projection for loaded data it's not a problem.

