### PR TITLE
Stac.load

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,61 @@ dependencies:
   - aiobotocore==1.3.3
   - boto3
 
+  # eodatasets3 (used by odc-stats)
+  - boltons
+  - ciso8601
+  - python-rapidjson
+  - requests-cache
+  - ruamel.yaml
+  - structlog
+  - url-normalize
+
+  # for dev
+  - pylint
+  - autopep8
+  - flake8
+  - isort
+  - black
+  - mypy
+
+  # For tests
+  - pytest
+  - pytest-httpserver
+  - pytest-cov
+  - pytest-timeout
+  - moto
+  - mock
+  - deepdiff
+
+  # for pytest-depends
+  - future_fstrings
+  - networkx
+  - colorama
+
   - pip=20
   - pip:
       # odc.apps.dc-tools
       - thredds-crawler
 
+      # odc.stats
+      - eodatasets3
+
+      # tests
+      - pytest-depends
+
       # odc.ui
       - jupyter-ui-poll
+
+      # odc-tools libs
+      - odc-stac
+      - odc-algo
+      - odc-ui
+      - odc-dscache
+      - odc-stats
+
+      # odc-tools CLI apps
+      - odc-apps-cloud
+      - odc-apps-dc-tools
 ```
 </div></details>
 

--- a/libs/stac/odc/index/__init__.py
+++ b/libs/stac/odc/index/__init__.py
@@ -1,7 +1,5 @@
 """ Indexing related helper methods.
 """
-from ..stac._version import __version__
-
 from ._index import (
     from_metadata_stream,
     from_yaml_doc_stream,
@@ -19,6 +17,7 @@ from ._index import (
     chopped_dss,
     all_datasets,
     product_from_yaml,
+    patch_urls,
 )
 
 from ._uuid import (
@@ -58,6 +57,7 @@ __all__ = (
     "chopped_dss",
     "all_datasets",
     "product_from_yaml",
+    "patch_urls",
     "odc_uuid",
     "utm_region_code",
     "utm_zone_to_epsg",

--- a/libs/stac/odc/stac/__init__.py
+++ b/libs/stac/odc/stac/__init__.py
@@ -11,6 +11,8 @@ from ._eo3 import (
 )
 
 from ._dcload import dc_load
+from ._load import load
+stac_load = load
 
 
 __all__ = (
@@ -19,5 +21,7 @@ __all__ = (
     "stac2ds",
     "infer_dc_product",
     "dc_load",
+    "load",
+    "stac_load",
     "__version__",
 )

--- a/libs/stac/odc/stac/_dcload.py
+++ b/libs/stac/odc/stac/_dcload.py
@@ -34,6 +34,7 @@ def dc_load(
     """
     Load data given a collection of datacube.Dataset objects.
     """
+    datasets = list(datasets)
     assert len(datasets) > 0
 
     # dask_chunks is a backward-compatibility alias for chunks

--- a/libs/stac/odc/stac/_eo3.py
+++ b/libs/stac/odc/stac/_eo3.py
@@ -511,7 +511,9 @@ def item_to_ds(item: pystac.Item, product: DatasetType) -> Dataset:
     return Dataset(product, prep_eo3(ds_doc), uris=[ds_doc.get("location", "")])
 
 
-def stac2ds(items: Iterable[pystac.Item], cfg: ConversionConfig) -> Iterator[Dataset]:
+def stac2ds(
+    items: Iterable[pystac.Item], cfg: Optional[ConversionConfig] = None
+) -> Iterator[Dataset]:
     """
     Given a lazy sequence of STAC Items turn it into a lazy sequence of ``Dataset`` objects
     """

--- a/libs/stac/odc/stac/_eo3.py
+++ b/libs/stac/odc/stac/_eo3.py
@@ -42,6 +42,23 @@ ConversionConfig = Dict[str, Any]
 
 EPSG4326 = CRS("EPSG:4326")
 
+# Mapping between EO3 field names and STAC properties object field names
+# EO3 metadata was defined before STAC 1.0, so we used some extensions
+# that are now part of the standard instead
+STAC_TO_EO3_RENAMES = {
+    "end_datetime": "dtr:end_datetime",
+    "start_datetime": "dtr:start_datetime",
+    "gsd": "eo:gsd",
+    "instruments": "eo:instrument",
+    "platform": "eo:platform",
+    "constellation": "eo:constellation",
+    "view:off_nadir": "eo:off_nadir",
+    "view:azimuth": "eo:azimuth",
+    "view:sun_azimuth": "eo:sun_azimuth",
+    "view:sun_elevation": "eo:sun_elevation",
+}
+
+
 (_eo3,) = [
     metadata_from_doc(d) for d in default_metadata_type_docs() if d.get("name") == "eo3"
 ]
@@ -540,7 +557,9 @@ def item_to_ds(item: pystac.Item, product: DatasetType) -> Dataset:
         "grids": grids,
         "location": "",
         "measurements": measurements,
-        "properties": deepcopy(item.properties),
+        "properties": dicttoolz.keymap(
+            lambda k: STAC_TO_EO3_RENAMES.get(k, k), item.properties
+        ),
         "lineage": {},
     }
 

--- a/libs/stac/odc/stac/_load.py
+++ b/libs/stac/odc/stac/_load.py
@@ -1,0 +1,88 @@
+"""
+stac.load - dc.load from STAC Items
+"""
+from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Union
+
+import pystac
+import xarray as xr
+from datacube.utils.geometry import GeoBox
+
+from ._dcload import dc_load
+from ._eo3 import ConversionConfig, stac2ds
+
+
+def load(
+    items: Iterable[pystac.Item],
+    bands: Optional[Union[str, Sequence[str]]] = None,
+    geobox: Optional[GeoBox] = None,
+    groupby: Optional[str] = None,
+    resampling: Optional[Union[str, Dict[str, str]]] = None,
+    skip_broken_datasets: bool = False,
+    chunks: Optional[Dict[str, int]] = None,
+    progress_cbk: Optional[Callable[[int, int], Any]] = None,
+    fuse_func=None,
+    stac_cfg: Optional[ConversionConfig] = None,
+    **kw,
+) -> xr.Dataset:
+    """
+    Load STAC Items (from the same or similar collections) as an
+    xarray Dataset.
+
+    :param items:
+       STAC Items to load
+
+    :param bands:
+        List of band names to load, defaults to All. Also accepts
+        single band name as input.
+
+    :param geobox:
+       Allows to specify exact region/resolution/projection
+
+    :param groupby:
+       Controls what items get placed in to the same pixel plane,
+       supported values are "time" or "solar_day", default is "time"
+
+    :param resampling:
+       Controls resampling strategy, can be specified per band.
+
+    :param skip_broken_datasets:
+       Continue processing when IO errors are encountered
+
+    :param chunks:
+       Rather than loading pixel data directly construct
+       a Dask backed arrays. ``chunks={'x': 2048, 'y': 2048}``
+
+    :param progress_cbk:
+       Get data loading progress via callback, ignored when
+       constructing Dask arrays.
+
+    :param fuse_func:
+       Provide custom function for fusing pixels from different
+       sources into one pixel plane. The default behaviour is to
+       use first observed valid pixel (Item timestamp is used to
+       determine "first", ``nodata`` is used to determine "valid")
+
+    :param stac_cfg:
+       Controls STAC -> Dataset conversion, mostly used to specify
+       "missing" metadata like pixel data types. see ``stac_to_ds``.
+
+    :return:
+       ``xr.Dataset`` with requested bands populated
+    """
+    if bands is None:
+        # dc.load name for bands is measurements
+        bands = kw.pop("measurements", None)
+
+    dss = list(stac2ds(items, stac_cfg))
+    return dc_load(
+        dss,
+        measurements=bands,
+        geobox=geobox,
+        groupby=groupby,
+        resampling=resampling,
+        skip_broken_datasets=skip_broken_datasets,
+        chunks=chunks,
+        progress_cbk=progress_cbk,
+        fuse_func=fuse_func,
+        **kw,
+    )

--- a/libs/stac/odc/stac/_load.py
+++ b/libs/stac/odc/stac/_load.py
@@ -55,7 +55,7 @@ def load(
 
     :param chunks:
        Rather than loading pixel data directly construct
-       a Dask backed arrays. ``chunks={'x': 2048, 'y': 2048}``
+       Dask backed arrays. ``chunks={'x': 2048, 'y': 2048}``
 
     :param progress_cbk:
        Get data loading progress via callback, ignored when

--- a/libs/stac/odc/stac/_load.py
+++ b/libs/stac/odc/stac/_load.py
@@ -1,16 +1,20 @@
 """
 stac.load - dc.load from STAC Items
 """
+from functools import partial
 from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Union
+import numpy as np
 
 import pystac
 import xarray as xr
+from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
+from odc.index import patch_urls
 
 from ._dcload import dc_load
 from ._eo3 import ConversionConfig, stac2ds
 
-
+# pylint: disable=too-many-arguments
 def load(
     items: Iterable[pystac.Item],
     bands: Optional[Union[str, Sequence[str]]] = None,
@@ -20,8 +24,9 @@ def load(
     skip_broken_datasets: bool = False,
     chunks: Optional[Dict[str, int]] = None,
     progress_cbk: Optional[Callable[[int, int], Any]] = None,
-    fuse_func=None,
+    fuse_func: Optional[Callable[[np.ndarray, np.ndarray], np.ndarray]] = None,
     stac_cfg: Optional[ConversionConfig] = None,
+    patch_url: Optional[Callable[[str], str]] = None,
     **kw,
 ) -> xr.Dataset:
     """
@@ -66,6 +71,9 @@ def load(
        Controls STAC -> Dataset conversion, mostly used to specify
        "missing" metadata like pixel data types. see ``stac_to_ds``.
 
+    :param patch_url:
+       Optionally transform url of every band before loading
+
     :return:
        ``xr.Dataset`` with requested bands populated
     """
@@ -73,7 +81,11 @@ def load(
         # dc.load name for bands is measurements
         bands = kw.pop("measurements", None)
 
-    dss = list(stac2ds(items, stac_cfg))
+    dss = stac2ds(items, stac_cfg)
+
+    if patch_url is not None:
+        dss = map(partial(patch_urls, edit=patch_url, bands=bands), dss)
+
     return dc_load(
         dss,
         measurements=bands,

--- a/libs/stac/tests/common/__init__.py
+++ b/libs/stac/tests/common/__init__.py
@@ -1,0 +1,21 @@
+from pystac import Item
+
+
+def mk_stac_item(
+    _id, datetime="2012-12-12T00:00:00Z", geometry=None, stac_extensions=None, **props
+):
+    if stac_extensions is None:
+        stac_extensions = []
+
+    return Item.from_dict(
+        {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "id": str(_id),
+            "properties": {"datetime": datetime, **props,},
+            "geometry": geometry,
+            "links": [],
+            "assets": {},
+            "stac_extensions": stac_extensions,
+        }
+    )

--- a/libs/stac/tests/test_dc_load.py
+++ b/libs/stac/tests/test_dc_load.py
@@ -1,3 +1,4 @@
+from mock import MagicMock
 import pytest
 import pystac
 
@@ -46,3 +47,12 @@ def test_stac_load_smoketest(sentinel_stac_ms_with_raster_ext: pystac.Item):
     assert "red" in xx.data_vars
     assert "green" in xx.data_vars
     assert xx.red.shape == xx.green.shape
+
+    # Test dc.load name for bands, and alias support
+    patch_url = MagicMock(return_value="https://example.com/f.tif")
+    with pytest.warns(UserWarning, match="`rededge`"):
+        xx = stac_load(
+            [item], measurements=["red", "green"], patch_url=patch_url, **params
+        )
+    # expect patch_url to be called 2 times, 1 for red and 1 for green band
+    assert patch_url.call_count == 2

--- a/libs/stac/tests/test_dc_load.py
+++ b/libs/stac/tests/test_dc_load.py
@@ -50,9 +50,12 @@ def test_stac_load_smoketest(sentinel_stac_ms_with_raster_ext: pystac.Item):
 
     # Test dc.load name for bands, and alias support
     patch_url = MagicMock(return_value="https://example.com/f.tif")
-    with pytest.warns(UserWarning, match="`rededge`"):
-        xx = stac_load(
-            [item], measurements=["red", "green"], patch_url=patch_url, **params
-        )
+    xx = stac_load(
+        [item],
+        measurements=["red", "green"],
+        patch_url=patch_url,
+        stac_cfg={"*": {"warnings": "ignore"}},
+        **params
+    )
     # expect patch_url to be called 2 times, 1 for red and 1 for green band
     assert patch_url.call_count == 2

--- a/libs/stac/tests/test_stac_eo3.py
+++ b/libs/stac/tests/test_stac_eo3.py
@@ -206,6 +206,10 @@ def test_item_to_ds(sentinel_stac_ms):
     assert ds.metadata.lon is not None
     assert ds.center_time is not None
 
+    # this checks property remap, without changing
+    # key names .platform would be None
+    assert ds.metadata.platform == "Sentinel-2B"
+
     with pytest.warns(UserWarning, match="`rededge`"):
         dss = list(stac2ds(iter([item, item, item]), STAC_CFG))
     assert len(dss) == 3


### PR DESCRIPTION
Adding a more direct `odc.stac.load([Item], ...) -> xr.Dataset`

Also generating deterministic UUIDs now, this is actually needed for deterministic pixel loading. When multiple Items share the same timestamp and have overlapping pixels which Item's pixels end up in the output currently depends on UUIDs of those items. This is unfortunate, but it's the behaviour of `dc.load` (see https://github.com/opendatacube/datacube-core/issues/671), it used to be random which is even worse, now it's still arbitrary but at least it's deterministic.

Some other fixes include:
- renaming some STAC properties that EO3 expects to be named differently (because it was finalised before STAC 1.0)
- more tests
- warnings can be disabled via configuration
- introducing `*` config section that applies to all collections, useful for configuration of `warning` and `uuid` strategies
- Credentialization with `pc.sign` is supported by supplying `patch_url=pc.sign`, this same mechanism can be used for remapping urls from http to s3/azure or filesystem to thredds.


Closes #354 