### PR TITLE
Rework CI test runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,12 +97,85 @@ jobs:
         mamba env export -p tests/env
 
 
-  run-tests:
+  test-with-coverage:
     runs-on: ubuntu-latest
 
     needs:
-      - build-wheels
       - build-test-env-base
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get Conda Environment from Cache
+      uses: actions/cache@v2
+      id: conda_cache
+      with:
+        path: |
+          tests/env
+
+        key: ${{ runner.os }}-test-env-py38-${{ hashFiles('tests/test-env-py38.yml') }}
+
+    - name: Update PATH
+      shell: bash
+      run: |
+        echo "$(pwd)/tests/env/bin" >> $GITHUB_PATH
+
+    - name: Install in Edit mode
+      shell: bash
+      run: |
+        which python
+        which createdb
+        which datacube
+
+        ./scripts/dev-install.sh --no-deps
+
+
+    - name: Start Test DB
+      shell: bash
+      run: |
+        echo "Launching test db"
+        pgdata=$(pwd)/.dbdata
+        initdb -D ${pgdata} --auth-host=md5 --encoding=UTF8
+        pg_ctl -D ${pgdata} -l "${pgdata}/pg.log" start
+        createdb datacube
+        datacube system init
+
+      env:
+        DATACUBE_DB_URL: postgresql:///datacube
+
+    - name: Run Tests
+      shell: bash
+      run: |
+        datacube system check
+
+        echo "Running Tests"
+        pytest --cov=. \
+        --cov-report=html \
+        --cov-report=xml:coverage.xml \
+        --timeout=30 \
+        libs apps
+
+      env:
+        AWS_DEFAULT_REGION: us-west-2
+        DASK_TEMPORARY_DIRECTORY: /tmp/dask
+        DATACUBE_DB_URL: postgresql:///datacube
+
+    - name: Upload Coverage
+      if: |
+        github.repository == 'opendatacube/odc-tools'
+
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: false
+        verbose: false
+
+
+  test-wheels:
+    runs-on: ubuntu-latest
+
+    needs:
+      - build-test-env-base
+      - build-wheels
 
     steps:
     - uses: actions/checkout@v2
@@ -158,31 +231,17 @@ jobs:
         datacube system check
 
         echo "Running Tests"
-        ./tests/env/bin/pytest --cov=. \
-        --cov-report=html \
-        --cov-report=xml:coverage.xml \
-        --timeout=30 \
-        libs apps
+        pytest --timeout=30 libs apps
 
       env:
         AWS_DEFAULT_REGION: us-west-2
         DASK_TEMPORARY_DIRECTORY: /tmp/dask
         DATACUBE_DB_URL: postgresql:///datacube
 
-    - name: Upload Coverage
-      if: |
-        github.repository == 'opendatacube/odc-tools'
-
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: false
-        verbose: false
-
-
   publish-wheels:
     needs:
       - build-wheels
-      - run-tests
+      - test-wheels
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,9 @@ on:
       - '!docs/**'
       - '!old/**'
       - '!README.md'
-env:
-  ORG: opendatacube
-  IMAGE: odc-test-runner
 
 jobs:
-  build:
+  build-wheels:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,15 +22,25 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Install dependencies
+    - uses: actions/cache@v2
+      id: wheels_cache
+      with:
+        path: ./wheels
+        key: wheels-${{ github.sha }}
+
+    - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade 'setuptools>51'
-        python -m pip install \
+        python -m pip install --upgrade setuptools
+        python -m pip install --upgrade \
+         toml \
          wheel \
          twine
+        python -m pip freeze
 
     - name: Patch Package Versions
+      if: |
+        github.ref != 'refs/heads/stable'
       run: |
         find . -name _version.py | xargs python ./scripts/patch_version.py ${GITHUB_RUN_NUMBER:-0}
 
@@ -42,6 +49,151 @@ jobs:
         mkdir -p ./wheels
         ./scripts/build-wheels.sh ./wheels
         find ./wheels -type f
+
+  build-test-env-base:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      id: conda_cache
+      with:
+        path: |
+          tests/env
+
+        key: ${{ runner.os }}-test-env-py38-${{ hashFiles('tests/test-env-py38.yml') }}
+
+    - uses: conda-incubator/setup-miniconda@v2
+      if: steps.conda_cache.outputs.cache-hit != 'true'
+      with:
+        channels: conda-forge,defaults
+        channel-priority: true
+        activate-environment: ""
+        mamba-version: "*"
+        use-mamba: true
+
+    - name: Dump Conda Environment Info
+      shell: bash -l {0}
+      if: steps.conda_cache.outputs.cache-hit != 'true'
+      run: |
+          conda info
+          conda list
+          mamba -V
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+
+    - name: Build Python Environment for Testing
+      shell: bash -l {0}
+      if: steps.conda_cache.outputs.cache-hit != 'true'
+      run: |
+        mamba env create -f tests/test-env-py38.yml -p tests/env
+
+    - name: Check Python Env
+      shell: bash -l {0}
+      if: steps.conda_cache.outputs.cache-hit != 'true'
+      run: |
+        mamba env export -p tests/env
+
+
+  run-tests:
+    runs-on: ubuntu-latest
+
+    needs:
+      - build-wheels
+      - build-test-env-base
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get Wheels from Cache
+      uses: actions/cache@v2
+      id: wheels_cache
+      with:
+        path: ./wheels
+        key: wheels-${{ github.sha }}
+
+    - name: Get Conda Environment from Cache
+      uses: actions/cache@v2
+      id: conda_cache
+      with:
+        path: |
+          tests/env
+
+        key: ${{ runner.os }}-test-env-py38-${{ hashFiles('tests/test-env-py38.yml') }}
+
+    - name: Update PATH
+      shell: bash
+      run: |
+        echo "$(pwd)/tests/env/bin" >> $GITHUB_PATH
+
+    - name: Install wheels for testing
+      shell: bash
+      run: |
+        which python
+        which createdb
+        which datacube
+
+        ls -lh wheels/
+        python -m pip install --no-deps wheels/*whl
+        python -m pip check || true
+
+    - name: Start Test DB
+      shell: bash
+      run: |
+        echo "Launching test db"
+        pgdata=$(pwd)/.dbdata
+        initdb -D ${pgdata} --auth-host=md5 --encoding=UTF8
+        pg_ctl -D ${pgdata} -l "${pgdata}/pg.log" start
+        createdb datacube
+        datacube system init
+
+      env:
+        DATACUBE_DB_URL: postgresql:///datacube
+
+    - name: Run Tests
+      shell: bash
+      run: |
+        datacube system check
+
+        echo "Running Tests"
+        ./tests/env/bin/pytest --cov=. \
+        --cov-report=html \
+        --cov-report=xml:coverage.xml \
+        --timeout=30 \
+        libs apps
+
+      env:
+        AWS_DEFAULT_REGION: us-west-2
+        DASK_TEMPORARY_DIRECTORY: /tmp/dask
+        DATACUBE_DB_URL: postgresql:///datacube
+
+    - name: Upload Coverage
+      if: |
+        github.repository == 'opendatacube/odc-tools'
+
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: false
+        verbose: false
+
+
+  publish-wheels:
+    needs:
+      - build-wheels
+      - run-tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      id: wheels_cache
+      with:
+        path: ./wheels
+        key: wheels-${{ github.sha }}
 
     - name: Prepare for upload to S3
       run: |
@@ -66,91 +218,3 @@ jobs:
         AWS_DEFAULT_REGION: 'ap-southeast-2'
         AWS_REGION: 'ap-southeast-2'
         S3_DST: 's3://datacube-core-deployment/'
-
-
-  run-tests:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Config
-      id: cfg
-      run: |
-        echo ::set-output name=docker_image::${ORG}/${IMAGE}:latest
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Cache Docker layers
-      uses: pat-s/always-upload-cache@v2.1.5
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
-    - name: Build Test Docker
-      uses: docker/build-push-action@v2
-      with:
-        file: docker/Dockerfile
-        context: docker
-        tags: ${{ steps.cfg.outputs.docker_image }}
-        outputs: type=docker
-        build-args: |
-          V_BASE=3.3.0
-          V_PG=12
-        cache-from: |
-          type=local,src=/tmp/.buildx-cache
-        cache-to: |
-          type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-    # This ugly bit is necessary if you don't want your cache to grow forever
-    # till it hits GitHub's limit of 5GB.
-    # Temp fix
-    # https://github.com/docker/build-push-action/issues/252
-    # https://github.com/moby/buildkit/issues/1896
-    - name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-
-    - name: Run Dockerized Tests
-      timeout-minutes: 20
-      shell: bash
-      run: |
-        make -C docker run-test
-
-    - name: Upload Coverage
-      if: |
-        github.repository == 'opendatacube/odc-tools'
-
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: false
-        verbose: false
-
-    - name: DockerHub Login
-      id: dkr
-      if: |
-        github.event_name == 'push'
-        && github.ref == 'refs/heads/develop'
-        && github.repository == 'opendatacube/odc-tools'
-
-      run: |
-        if [ -n "${{ secrets.DOCKER_USER }}" ]; then
-           echo "Login to DockerHub as ${{ secrets.DOCKER_USER }}"
-           echo "${{ secrets.DOCKER_PASS }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
-           echo "::set-output name=logged_in::yes"
-        else
-           echo "Set DOCKER_{PASS,USER} secrets to push to docker"
-           echo "::set-output name=logged_in::no"
-        fi
-
-    - name: DockerHub Push
-      if: |
-        steps.dkr.outputs.logged_in == 'yes'
-
-      run: |
-        docker push "${{ steps.cfg.outputs.docker_image }}"

--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -117,7 +117,7 @@ limit = click.option(
 
 
 def get_esri_list():
-    stream = pkg_resources.resource_stream(__name__, "./esri-lc-tiles-list.txt")
+    stream = pkg_resources.resource_stream(__name__, "esri-lc-tiles-list.txt")
     with stream as f:
         for tile in f.readlines():
             id = tile.decode().rstrip('\n')

--- a/apps/dc_tools/setup.cfg
+++ b/apps/dc_tools/setup.cfg
@@ -61,3 +61,8 @@ console_scripts =
 [options.packages.find]
 include =
   odc*
+
+[options.package_data]
+* =
+  *.txt
+  *.sh

--- a/libs/stac/setup.cfg
+++ b/libs/stac/setup.cfg
@@ -35,3 +35,8 @@ install_requires =
 [options.packages.find]
 include =
   odc*
+
+[options.package_data]
+* =
+  *.yaml
+  *.yml

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -1,0 +1,83 @@
+# Conda environment for running tests in odc-tools
+#   conda env create -f test-env-py38.yml
+#   conda activate odc-tests-py38
+
+name: odc-tests-py38
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+
+  # Datacube
+  - datacube>=1.8.5
+
+  # odc.dscache
+  - python-lmdb
+  - zstandard
+
+  # odc.algo
+  - dask-image
+  - numexpr
+  - scikit-image
+  - scipy
+  - toolz
+
+  # odc.ui
+  - ipywidgets
+  - ipyleaflet
+  - tqdm
+
+  # odc-apps-dc-tools
+  - pystac>=1.1.0
+  - pystac-client>=0.2.0
+  - azure-storage-blob
+  - fsspec
+  - lxml  # needed for thredds-crawler
+
+  # odc.{aws,aio}: aiobotocore/boto3
+  #  pin aiobotocore for easier resolution of dependencies
+  - aiobotocore==1.3.3
+  - boto3
+
+  # eodatasets3 (for odc-stats)
+  - boltons
+  - ciso8601
+  - python-rapidjson
+  - requests-cache==0.7.4  # 0.8.0 broke eodatasets3
+  - ruamel.yaml
+  - structlog
+  - url-normalize
+
+  # For tests
+  - pytest
+  - pytest-httpserver
+  - pytest-cov
+  - pytest-timeout
+  - moto
+  - mock
+  - deepdiff
+
+  # for pytest-depends
+  - future_fstrings
+  - networkx
+  - colorama
+
+  # for docs
+  - sphinx
+
+  - pip=20
+  - pip:
+      # odc.apps.dc-tools
+      - thredds-crawler
+
+      # odc.stats
+      - eodatasets3
+
+      # odc.algo optional dependency
+      - hdstats
+
+      # odc.ui
+      - jupyter-ui-poll>=0.2.0a
+
+      # tests
+      - pytest-depends

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -64,6 +64,8 @@ dependencies:
 
   # for docs
   - sphinx
+  - sphinx_rtd_theme
+  - sphinx-autodoc-typehints
 
   - pip=20
   - pip:


### PR DESCRIPTION
- Use conda environment (cached and only gets rebuilt when environment definition changes)
- Use multiple Jobs with dependencies
- Only upload wheels after testing them
- Tests run on actual wheels rather than with editable installs
   - This found a packaging bug in `odc-apps-dc_tools` (fixed in this PR)
- This change is meant to make publishing to PyPI and documentation building  easier to implement.
- Paves the way for adding more checks like pylint/black/mypy
- Faster run time while still maintaining relatively stable test environment
![image](https://user-images.githubusercontent.com/1428024/132432916-3d29062c-6648-4862-9dc6-019cc6366083.png)
