### PR TITLE
Disable the inherit_properties warning msg

### DIFF
--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -22,6 +22,7 @@ from pystac.extensions.projection import ProjectionExtension
 from toolz import dicttoolz
 from toolz import dicttoolz
 from rasterio.crs import CRS
+import warnings
 
 from eodatasets3.assemble import DatasetAssembler, serialise
 from eodatasets3.images import GridSpec
@@ -358,7 +359,9 @@ class Task:
         dataset_assembler = DatasetAssembler(naming_conventions=self.product.naming_conventions_values,
                                              dataset_location=Path(self.product.explorer_path),
                                              allow_absolute_paths=True)
-
+        
+        # ignore the tons of Inheritable property warnings
+        warnings.simplefilter(action='ignore', category=UserWarning)
         platforms = [] # platforms are the concat value in stats
 
         for dataset in self.datasets:
@@ -377,6 +380,9 @@ class Task:
                                                     inherit_skip_properties=self.product.inherit_skip_properties)
                 if 'eo:platform' in source_datasetdoc.properties:
                     platforms.append(source_datasetdoc.properties['eo:platform'])
+
+        # set the warning message back
+        warnings.filterwarnings('default')
 
         if len(platforms) > 0:
             dataset_assembler.platform = ','.join(sorted(set(platforms)))


### PR DESCRIPTION
Before we finish this feature: https://github.com/GeoscienceAustralia/eo-datasets/issues/194. The inherit_properties method will throw tons of warning message. E.g. 

> /env/lib/python3.8/site-packages/eodatasets3/assemble.py:681: UserWarning: Inheritable property 'odc:region_code' is different from current value ("Overriding property 'odc:region_code' (from '31NGE' to '31NHF')",)


Just disable it to save the log system.