### PR TITLE
Limit 0 not allowed for redrive to queue:

### DIFF
--- a/apps/cloud/odc/apps/cloud/redrive_to_queue.py
+++ b/apps/cloud/odc/apps/cloud/redrive_to_queue.py
@@ -15,10 +15,7 @@ from odc.aws.queue import redrive_queue
     default=None,
 )
 @click.option(
-    "--dryrun",
-    is_flag=True,
-    default=False,
-    help="Don't actually do real work"
+    "--dryrun", is_flag=True, default=False, help="Don't actually do real work"
 )
 def cli(queue, to_queue, limit, dryrun):
     """

--- a/libs/cloud/odc/aws/queue.py
+++ b/libs/cloud/odc/aws/queue.py
@@ -27,9 +27,6 @@ def redrive_queue(
             message.delete()
         return []
 
-    if limit < 1:
-        raise Exception(f"Limit {limit} is not valid.")
-
     dead_queue = get_queue(queue_name)
 
     if to_queue_name is not None:

--- a/libs/cloud/odc/aws/queue.py
+++ b/libs/cloud/odc/aws/queue.py
@@ -6,7 +6,7 @@ from typing import Mapping, Any, Iterable, Optional
 def redrive_queue(
     queue_name: str,
     to_queue_name: Optional[str] = None,
-    limit: Optional[int] = 0,
+    limit: Optional[int] = None,
     dryrun: bool = False,
     max_wait: int = 5,
     messages_per_request: int = 10,
@@ -27,8 +27,10 @@ def redrive_queue(
             message.delete()
         return []
 
+    if limit < 1:
+        raise Exception(f"Limit {limit} is not valid.")
+
     dead_queue = get_queue(queue_name)
-    alive_queue = None
 
     if to_queue_name is not None:
         alive_queue = get_queue(to_queue_name)
@@ -102,13 +104,15 @@ def get_queues(prefix: str = None, contains: str = None):
 
     if contains is not None:
         for queue in queues:
-            if contains in queue.attributes.get('QueueArn').split(':')[-1]:
+            if contains in queue.attributes.get("QueueArn").split(":")[-1]:
                 yield queue
     else:
         yield from queues
 
 
-def publish_message(queue, message: str, message_attributes: Optional[Mapping[str, Any]] = None):
+def publish_message(
+    queue, message: str, message_attributes: Optional[Mapping[str, Any]] = None
+):
     """
     Publish a message to a queue resource. Message should be a JSON object dumped as a
     string.
@@ -144,7 +148,7 @@ def get_messages(
     message_attributes: Optional[Iterable[str]] = None,
     max_wait: int = 1,
     messages_per_request: int = 1,
-    **kw
+    **kw,
 ):
     """
     Get messages from SQS queue resource. Returns a lazy sequence of message objects.
@@ -169,9 +173,13 @@ def get_messages(
         MaxNumberOfMessages=messages_per_request,
         WaitTimeSeconds=max_wait,
         MessageAttributeNames=message_attributes,
-        **kw
+        **kw,
     )
-    if limit is None or limit == 0:
+
+    if limit is None:
         return messages
+
+    if limit < 1:
+        raise Exception(f"Limit {limit} is not valid.")
 
     return itertools.islice(messages, limit)


### PR DESCRIPTION
- Limit 0 or lower, now raises an exception informing that value isn't valid.
- None is the default value, which will redrive the whole queue
- get_messages was changed to not allow 0 as limit and raise an exception in case of limit lower than 1.