### PR TITLE
Limit 0 not allowed for redrive to queue and None is accepted as all

### DIFF
--- a/apps/cloud/odc/apps/cloud/redrive_to_queue.py
+++ b/apps/cloud/odc/apps/cloud/redrive_to_queue.py
@@ -10,7 +10,6 @@ from odc.aws.queue import redrive_queue
 @click.option(
     "--limit",
     "-l",
-    type=int,
     help="Limit the number of messages to transfer.",
     default=None,
 )
@@ -29,6 +28,15 @@ def cli(queue, to_queue, limit, dryrun):
     )
 
     _log = logging.getLogger(__name__)
+
+    if limit is not None:
+        try:
+            limit = int(limit)
+        except ValueError:
+            raise ValueError(f"Limit {limit} is not valid")
+
+        if limit < 1:
+            raise ValueError(f"Limit {limit} is not valid.")
 
     count = redrive_queue(queue, to_queue, limit, dryrun, max_wait=1)
 


### PR DESCRIPTION
- Limit 0 or lower, now raises an exception informing that value isn't valid.
- None is the default value, which will redrive the whole queue
- get_messages was changed to not allow 0 as limit and raise an exception in case of limit lower than 1.
- added tests to test all possibilities