### PR TITLE
Workaround redrive_to_queue cli function

### DIFF
--- a/apps/cloud/odc/apps/cloud/redrive_to_queue.py
+++ b/apps/cloud/odc/apps/cloud/redrive_to_queue.py
@@ -32,7 +32,7 @@ def cli(queue, to_queue, dryrun, limit):
     _log = logging.getLogger(__name__)
 
     # In case of sending just the flag without parameters this must be applied
-    if limit is "default":
+    if limit == "default":
         limit = None
 
     if limit is not None:

--- a/apps/cloud/odc/apps/cloud/redrive_to_queue.py
+++ b/apps/cloud/odc/apps/cloud/redrive_to_queue.py
@@ -8,15 +8,17 @@ from odc.aws.queue import redrive_queue
 @click.argument("queue", required=True)
 @click.argument("to-queue", required=False)
 @click.option(
-    "--limit",
-    "-l",
-    help="Limit the number of messages to transfer.",
-    default=None,
-)
-@click.option(
     "--dryrun", is_flag=True, default=False, help="Don't actually do real work"
 )
-def cli(queue, to_queue, limit, dryrun):
+@click.option(
+    "--limit",
+    "-l",
+    is_flag=False,
+    flag_value="default",
+    default=None,
+    help="Limit the number of messages to transfer.",
+)
+def cli(queue, to_queue, dryrun, limit):
     """
     Redrives all the messages from the given sqs queue to the destination
     """
@@ -28,6 +30,10 @@ def cli(queue, to_queue, limit, dryrun):
     )
 
     _log = logging.getLogger(__name__)
+
+    # In case of sending just the flag without parameters this must be applied
+    if limit is "default":
+        limit = None
 
     if limit is not None:
         try:

--- a/libs/cloud/tests/test_aws.py
+++ b/libs/cloud/tests/test_aws.py
@@ -121,6 +121,7 @@ def test_redrive_to_queue_cli(aws_env):
     assert returned.exit_code == 0
     assert int(get_queue(DEAD_QUEUE_NAME).attributes.get('ApproximateNumberOfMessages')) == 0
 
+    dead_queue.send_message(MessageBody=json.dumps({"content": f"Last test"}))
     # test cli with limit flag without value
     returned = CliRunner().invoke(
         redrive_to_queue.cli,

--- a/libs/cloud/tests/test_aws.py
+++ b/libs/cloud/tests/test_aws.py
@@ -121,6 +121,14 @@ def test_redrive_to_queue_cli(aws_env):
     assert returned.exit_code == 0
     assert int(get_queue(DEAD_QUEUE_NAME).attributes.get('ApproximateNumberOfMessages')) == 0
 
+    # test cli with limit flag without value
+    returned = CliRunner().invoke(
+        redrive_to_queue.cli,
+        [str(DEAD_QUEUE_NAME), str(ALIVE_QUEUE_NAME), "--dryrun", "--limit"],
+    )
+
+    assert returned.exit_code == 0
+
 
 @mock_sqs
 def test_get_queues(aws_env):


### PR DESCRIPTION
- To be able to use the flag --limit parameterless, it must have to receive a default parameter to replace the missing one.

For more information read:
https://click.palletsprojects.com/en/8.0.x/options/#optional-value

PS=> For <flag_value> is not allowed None, "", [], {}, False, True ...