### PR TITLE
Switch between JSON and YAML loading better

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/fs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/fs_to_dc.py
@@ -62,10 +62,10 @@ def cli(input_directory, update_if_exists, allow_unsafe, stac, glob):
     for in_file in files_to_process:
         with in_file.open() as f:
             try:
-                if "json" in glob:
-                    metadata = json.load(f)
-                elif "yaml" in glob:
+                if in_file.endswith(".yml") or in_file.endswith(".yaml"):
                     metadata = yaml.safe_load(f, Loader=Loader)
+                else:
+                    metadata = json.load(f)
                 # Do the STAC Transform if it's flagged
                 if stac:
                     metadata = stac_transform(metadata)


### PR DESCRIPTION
* There was a bug where if the glob didn't include json or yaml it wouldn't load the metadata
* Do the switching of loader based on "endswith" instead of glob content