### PR TITLE
Only run publishing jobs on appropriate branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,6 +240,11 @@ jobs:
         DATACUBE_DB_URL: postgresql:///datacube
 
   publish-s3:
+    if: |
+        github.event_name == 'push'
+        && github.repository == 'opendatacube/odc-tools'
+        && github.ref == 'refs/heads/develop'
+
     needs:
       - build-wheels
       - test-wheels
@@ -284,6 +289,11 @@ jobs:
 
 
   publish-pypi:
+    if: |
+        github.event_name == 'push'
+        && github.repository == 'opendatacube/odc-tools'
+        && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/pypi/publish')
+
     strategy:
       matrix:
         pkg:
@@ -307,7 +317,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Config
-      if:
+      if: |
         github.event_name == 'push'
         && github.repository == 'opendatacube/odc-tools'
         && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/pypi/publish')
@@ -358,6 +368,8 @@ jobs:
       run: |
         ls pips/${PKG}
         twine upload --non-interactive --skip-existing pips/${PKG}/*
+
+
   check-docs:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -252,3 +252,21 @@ integration tests that require datacube database to work. From here on you can
 run specific tests you are developing with `py.test ./path/to/test_file.py`. Any
 changes you make to code outside of the docker environment are available without
 any further action from you for testing.
+
+
+Release Process
+===============
+
+Development versions of packages are pushed to [DEA packages
+repo](https://packages.dea.ga.gov.au/) on every push to `develop` branch,
+version is automatically increased by a script that runs before creating wheels
+and source distribution tar balls. Right now new dev version is pushed for all
+the packages even the ones that have not changed since last push.
+
+To publish to [PyPi](https://pypi.org/) there are more steps involved.
+
+1. Manually edit `{lib,app}/{pkg}/odc/{pkg}/_version.py` file to increase version number
+2. Merge it to `develop` branch
+3. Create PR from `develop` to `pypi/publish` or `stable` branch
+4. Once PR is merged packages with updated versions will be published to PyPI,
+   assuming all the checks have passed


### PR DESCRIPTION
I was disabling at `job.step` level previously, but turns out you can disable entire job within a workflow, so I'm changing to that.

- Only run `publish-s3` job on `develop` branch and only on push event
- Only run `publish-pypi` job on `stable` or `pypi/publish` branches also only on push event

It's a much better UX that way and a bit faster to run.

closes #309 
