### PR TITLE
Enhancement/mosaic

### DIFF
--- a/libs/stats/odc/stats/_cli_generate_mosaic.py
+++ b/libs/stats/odc/stats/_cli_generate_mosaic.py
@@ -105,18 +105,8 @@ def generate_mosaic(product, input_prefix, location, bands, verbose):
         print(f"Preparing mosaics for {product.name} product")
 
     dss = s3_fetch_dss(input_prefix, product, glob="*.json")
-#     cache = create_cache(f"{product.name}.db")
-
-    if verbose:
-        print(f"Writing {location}/{product.name}.db")
-
-#     cache = create_cache(f"{location}/{product.name}.db")
-#     cache.bulk_save(dss)
-#     if verbose:
-#         print(f"Found {cache.count:,d} datasets")
 
     dc = Datacube()
-#     dss = list(cache.get_all())
     xx = dc.load(
         datasets=dss,
         dask_chunks={"x": 2048, "y": 2048},
@@ -124,12 +114,17 @@ def generate_mosaic(product, input_prefix, location, bands, verbose):
         measurements=bands,
     )
 
+    if bands is None:
+        suffix = ''
+    else:
+        suffix = '_' + '_'.join(bands)
+
     if verbose:
-        print(f"Writing {location}/{product.name}.tif")
+        print(f"Writing {location}/{product.name}{suffix}.tif")
     xx = xx.squeeze('time').to_stacked_array('bands', ['x', 'y'])
     yy = save_cog(
         xx,
-        f"{location}/{product.name}.tif",
+        f"{location}/{product.name}{suffix}.tif",
         blocksize=1024,
         compress="zstd",
         zstd_level=4,

--- a/libs/stats/odc/stats/_cli_generate_mosaic.py
+++ b/libs/stats/odc/stats/_cli_generate_mosaic.py
@@ -46,7 +46,7 @@ def xr_to_mem(xx, client):
     )
 
 
-def save(xx, location, product_name, verbose):
+def save(xx, location, product_name, verbose, creds=None, rgb_bands=None):
     client = start_local_dask(
         nanny=False,
         n_workers=1,
@@ -61,7 +61,7 @@ def save(xx, location, product_name, verbose):
         aws_unsigned=True, cloud_defaults=True, client=client, **gdal_cfg
     )
 
-    rgba = to_rgba(xx.isel(time=0), clamp=(0, 3000))
+    rgba = to_rgba(xx.isel(time=0), clamp=(0, 3000), bands=rgba_bands)
     rgba = xr_to_mem(rgba, client)
 
     if verbose:
@@ -77,6 +77,7 @@ def save(xx, location, product_name, verbose):
         NUM_THREADS="ALL_CPUS",
         BIGTIFF="YES",
         SPARSE_OK=True,
+        creds=creds,
     )
 
 
@@ -84,8 +85,9 @@ def save(xx, location, product_name, verbose):
 @click.argument("product", type=str)
 @click.argument("input_prefix", type=str)
 @click.argument("location", type=str)
+@click.option("rgb-bands", type=str)
 @click.option("--verbose", "-v", is_flag=True, help="Be verbose")
-def cli(product, input_prefix, location, verbose):
+def cli(product, input_prefix, location, verbose, rgb_bands):
     """
     Generate mosaic overviews of the stats data.
 
@@ -118,7 +120,7 @@ def cli(product, input_prefix, location, verbose):
         measurements=["red", "green", "blue"],
     )
 
-    save(xx, location, product.name, verbose)
+    save(xx, location, product.name, verbose, rgb_bands=rgb_bands)
 
 
 if __name__ == "__main__":

--- a/libs/stats/odc/stats/cli.py
+++ b/libs/stats/odc/stats/cli.py
@@ -3,3 +3,4 @@ from . import _cli_save_tasks
 from . import _cli_run
 from . import _cli_publish_tasks
 from . import _cli_generate_cache
+from . import _cli_generate_mosaic


### PR DESCRIPTION
This PR adds a few changes to CLI mosaic:

- allows the option to specify which bands are used
- allows more complex globs to be used for searching s3
- uses some built in dask functions to stack bands - unsure if this is equivalant to what was there before
- no longer creates a dataset cache file (only to be immediately loaded back into memory?)

For the extra flexibility I removed the clamping that was implemented for rgb stuff - I'm not sure what the best API is here. Maybe an `--rgb` flag? 