### PR TITLE
Float 16 frequency

### DIFF
--- a/libs/stats/odc/stats/_wofs.py
+++ b/libs/stats/odc/stats/_wofs.py
@@ -147,7 +147,7 @@ class StatsWofs(StatsPluginInterface):
         count_wet = xx.wet.sum(axis=0, dtype="int16")
         count_dry = xx.dry.sum(axis=0, dtype="int16")
         count_clear = count_wet + count_dry
-        frequency = safe_div(count_wet, count_clear, dtype="float32")
+        frequency = safe_div(count_wet, count_clear, dtype="float16")
 
         count_wet.attrs["nodata"] = nodata
         count_clear.attrs["nodata"] = nodata


### PR DESCRIPTION
Following a short discussion on Slack:

Kieran Ricardo 15 Sep at 11:36:
> on a side note I noticed that frequency uses float64 and  64 bits of precision might be overkill for representing a fraction in 0-1 with a denominator of <365. Maybe its worth storing this as float 16 ?

daveg
> make it so!

Paul Haesler
> Yeah even if you cared about the difference between once per solar day and once per sidereal day, that's excessive.