### PR TITLE
Integrate OWS to odc-stats and odc-tool

### DIFF
--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -36,6 +36,7 @@ click-plugins==1.1.1
 cligj==0.7.2
 cloudpickle==1.6.0
 colorama==0.4.3
+colour==0.1.5
 commonmark==0.9.1
 coverage==5.5
 cryptography==3.4.7
@@ -44,6 +45,7 @@ dask==2021.8.1
 dask-image==0.6.0
 dataclasses==0.6
 datacube==1.8.5
+datacube_ows==1.8.19
 debugpy==1.4.1
 decorator==5.0.9
 deepdiff==5.5.0
@@ -53,8 +55,12 @@ docker==5.0.0
 docutils==0.15.2
 entrypoints==0.3
 eodatasets3==0.22.0
+flask==2.0.1
+flask-babel==2.0.0
+flask-log-request-id==0.10.1
 fsspec==2021.7.0
 future-fstrings==1.2.0
+geoalchemy2==0.9.4
 google-api-core==2.0.0
 google-auth==2.0.1
 google-cloud-core==2.0.0
@@ -70,12 +76,14 @@ idna==2.10
 imageio==2.9.0
 imagesize==1.2.0
 importlib-metadata==4.6.4
+importlib-resources==5.2.2
 iniconfig==1.1.1
 ipykernel==6.2.0
 ipyleaflet==0.14.0
 ipython==7.26.0
 ipython-genutils==0.2.0
 ipywidgets==7.6.3
+iso8601==0.1.16
 isodate==0.6.0
 isort==5.9.3
 itsdangerous==2.0.1
@@ -130,6 +138,7 @@ pip-tools==6.2.0
 platformdirs==2.2.0
 pluggy==0.13.1
 prometheus-client==0.11.0
+prometheus-flask-exporter==0.18.2
 prompt-toolkit==3.0.20
 protobuf==3.17.3
 psutil==5.8.0
@@ -142,6 +151,7 @@ pycodestyle==2.7.0
 pycparser==2.20
 pygments==2.10.0
 pylint==2.10.2
+pyows==0.2.4
 pyparsing==2.4.7
 pyproj==3.1.0
 pyrsistent==0.18.0
@@ -154,12 +164,14 @@ pytest-httpserver==1.0.1
 pytest-timeout==1.4.2
 python-dateutil==2.8.2
 python-rapidjson==1.4
+python-slugify==5.0.2
 pytz==2021.1
 pywavelets==1.1.1
 pyyaml==5.4.1
 pyzmq==22.2.1
 rasterio==1.2.6
 recommonmark==0.7.1
+regex==2021.8.28
 requests==2.25.1
 requests-cache==0.7.4
 requests-oauthlib==1.3.0
@@ -167,6 +179,7 @@ responses==0.13.4
 rsa==4.7.2
 ruamel.yaml==0.17.13
 ruamel.yaml.clib==0.2.6
+s3fs==2021.07.0
 s3transfer==0.4.2
 scikit-image==0.18.2
 scipy==1.7.1
@@ -193,8 +206,10 @@ structlog==21.1.0
 tblib==1.7.0
 terminado==0.11.1
 testpath==0.5.0
+text-unidecode==1.3
 thredds-crawler==1.5.4
 tifffile==2021.8.8
+timezonefinderl==4.0.2
 toml==0.10.2
 tomli==1.2.1
 toolz==0.11.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -31,6 +31,7 @@ aiobotocore[boto3,awscli]==1.3.3
 dask[complete]
 
 eodatasets3
+datacube_ows==1.8.19
 
 # not needed for python 3.8 and up, and are not installed,
 # but `pip check` doesn't know better

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -36,6 +36,8 @@ from eodatasets3.images import FileWrite, GridSpec
 import eodatasets3.stac as eo3stac
 import eodatasets3
 
+import datacube_ows
+
 WriteResult = namedtuple("WriteResult", ["path", "sha1", "error"])
 
 _log = logging.getLogger(__name__)

--- a/libs/stats/setup.cfg
+++ b/libs/stats/setup.cfg
@@ -36,6 +36,9 @@ install_requires =
     toolz
     tqdm
     xarray
+    datacube_ows==1.8.19
+    sentry_sdk
+    blinker
 
 [options.entry_points]
 console_scripts =

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -48,6 +48,9 @@ dependencies:
   - structlog
   - url-normalize
 
+  # datacube_ows (for odc-stats)
+  - datacube_ows==1.8.19
+
   # For tests
   - pytest
   - pytest-httpserver

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -48,9 +48,6 @@ dependencies:
   - structlog
   - url-normalize
 
-  # datacube_ows (for odc-stats)
-  - datacube_ows==1.8.19
-
   # For tests
   - pytest
   - pytest-httpserver
@@ -87,3 +84,6 @@ dependencies:
 
       # tests
       - pytest-depends
+
+      # datacube_ows (for odc-stats)
+      - datacube_ows==1.8.19


### PR DESCRIPTION
We are using the [OWS](https://github.com/opendatacube/datacube-ows) to generate odc-stats thumbnail now. 

Because the feature branch always load the develop branch docker to run the test. So add the OWS library to develop branch firstly.

Note: I did the same changes in the feature branch, and run local docker test. It can generate the output without dependency issue.