### PR TITLE
some more adjustments to geomad code

### DIFF
--- a/libs/stats/odc/stats/_gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/_gm_ls_bitmask.py
@@ -52,7 +52,7 @@ class StatsGMLSBitmask(StatsPluginInterface):
         self.aux_bands = list(aux_names.values())
         self.scale = scale
         self.offset = offset
-        self.masking_scale = (-1.0 * self.offset)/self.scale
+        self.masking_scale = -1.0 * (self.offset/self.scale)
         self.output_scale = output_scale
         self.output_dtype = np.dtype(output_dtype)
         self.output_nodata = self.offset * self.output_scale

--- a/libs/stats/tests/test_gm_ls_bitmask.py
+++ b/libs/stats/tests/test_gm_ls_bitmask.py
@@ -85,7 +85,7 @@ def test_fuser(dataset):
 
 def test_reduce(dataset):
     _ = pytest.importorskip("hdstats")
-    gm = StatsGMLSBitmask(bands=["band_red"], masking_scale=20.7)
+    gm = StatsGMLSBitmask(bands=["band_red"], offset=-0.2, scale=0.00975)
 
     xx = gm._native_tr(dataset)
     xx = gm.reduce(xx)
@@ -105,7 +105,7 @@ def test_reduce(dataset):
 def test_reduce_with_filters(dataset):
     _ = pytest.importorskip("hdstats")
     mask_filters = [("closing", 2), ("dilation",1)]
-    gm = StatsGMLSBitmask(bands=["band_red"], filters=mask_filters, masking_scale=20.7)
+    gm = StatsGMLSBitmask(bands=["band_red"], filters=mask_filters, offset=-0.2, scale=0.00975)
 
     xx = gm._native_tr(dataset)
     xx = gm.reduce(xx)

--- a/libs/stats/tests/test_gm_ls_bitmask.py
+++ b/libs/stats/tests/test_gm_ls_bitmask.py
@@ -45,13 +45,13 @@ def dataset(usgs_ls8_sr_definition):
 
 
 def test_native_transform(dataset):
-    gm = StatsGMLSBitmask(bands=["band_red"], masking_scale=25.7)
+    gm = StatsGMLSBitmask(bands=["band_red"], offset=-0.2, scale=0.00975)
 
     xx = gm._native_tr(dataset)
     expected_result = np.array([
         [[255, 57], [0, 0]],
         [[0, 0], [70, 80]],
-        [[0, 52], [0, 0]],
+        [[25, 52], [0, 0]],
     ])
     result = xx.compute()["band_red"].data
     assert (result == expected_result).all()
@@ -66,7 +66,7 @@ def test_native_transform(dataset):
 
 
 def test_fuser(dataset):
-    gm = StatsGMLSBitmask(bands=["band_red"], masking_scale=20.7)
+    gm = StatsGMLSBitmask(bands=["band_red"], offset=-0.2, scale=0.00975)
 
     xx = gm._native_tr(dataset)
     xx = xx.groupby("solar_day").map(gm._fuser)


### PR DESCRIPTION
- kept NODATA constant so can be reference it during the process - instead of hard coded 0
- calculate `masking_scale` using - `masking_scale = -1.0 * (self.offset/self.scale)` - to filter negative pixels
- calculate `output_nodata` using - `output_nodata = self.offset * self.output_scale` - to reset nodata on gm rescaling