### PR TITLE
Add description of STAC best practices (#395)

### DIFF
--- a/libs/stac/docs/index.rst
+++ b/libs/stac/docs/index.rst
@@ -19,6 +19,13 @@ odc-stac
    examples.rst
 
 .. toctree::
+   :caption: STAC
+   :hidden:
+   :maxdepth: 2
+
+   stac-best-practice.rst
+
+.. toctree::
    :caption: Index
    :hidden:
    :maxdepth: 2

--- a/libs/stac/docs/stac-best-practice.rst
+++ b/libs/stac/docs/stac-best-practice.rst
@@ -1,0 +1,54 @@
+Best Practices
+##############
+
+:mod:`odc.stac` can operate on STAC items with only minimal information present,
+however user experience is best when following information is included
+
+.. list-table::
+
+   * - `Raster Extension`_
+     -
+   * - ``nodata``
+     - used when combining multiple items into one raster plane
+   * - ``data_type``
+     - used to determine output pixel type
+   * - ``unit``
+     - passed on as an attribute
+       (can be useful for further processing)
+   * - ``scale``
+     - currently ignored, but will be supported in the future
+   * - ``offset``
+     - currently ignored, but will be supported in the future
+
+   * - `Projection Extension`_
+     -
+   * - ``proj:shape``
+     - contains image size per asset
+   * - ``proj:transform``
+     - contains geo-registration per asset
+   * - ``proj:epsg``
+     - contains native CRS
+   * - ``proj:wkt2``
+     - can be used instead of ``proj:epsg`` for CRS without EPSG code
+   * - ``proj:projjson``
+     - yet another way to specify projection
+
+   * - `Electro Optical Extension`_
+     -
+   * - ``eo:bands.common_name``
+     - used to assign an alias for a band
+       (use ``red`` instead of ``B04``).
+
+
+Assumptions
+###########
+
+Items from the same collection are assumed to have the same number and names of
+bands, and bands are assumed to use the same ``data_type`` across the
+collection.
+
+It is assumed that Assets within a single Item share common native projection.
+
+.. _`Raster Extension`: https://github.com/stac-extensions/eo
+.. _`Projection Extension`: https://github.com/stac-extensions/eo
+.. _`Electro Optical Extension`: https://github.com/stac-extensions/eo

--- a/libs/stac/docs/stac-best-practice.rst
+++ b/libs/stac/docs/stac-best-practice.rst
@@ -2,22 +2,24 @@ Best Practices
 ##############
 
 :mod:`odc.stac` can operate on STAC items with only minimal information present,
-however user experience is best when following information is included
+however user experience is best when following information is included:
+``data_type`` and ``nodata`` from `Raster Extension`_, ``proj:{shape,transform,epsg}``
+from `Projection Extension`_.
+
+For a full list of understood extension elements see table below.
 
 .. list-table::
 
    * - `Raster Extension`_
      -
-   * - ``nodata``
-     - used when combining multiple items into one raster plane
    * - ``data_type``
      - used to determine output pixel type
+   * - ``nodata``
+     - used when combining multiple items into one raster plane
    * - ``unit``
      - passed on as an attribute
        (can be useful for further processing)
-   * - ``scale``
-     - currently ignored, but will be supported in the future
-   * - ``offset``
+   * - *[planned]* ``scale``, ``offset``
      - currently ignored, but will be supported in the future
 
    * - `Projection Extension`_
@@ -28,11 +30,8 @@ however user experience is best when following information is included
      - contains geo-registration per asset
    * - ``proj:epsg``
      - contains native CRS
-   * - ``proj:wkt2``
+   * - ``proj:wkt2``, ``proj:projjson``
      - can be used instead of ``proj:epsg`` for CRS without EPSG code
-   * - ``proj:projjson``
-     - yet another way to specify projection
-
    * - `Electro Optical Extension`_
      -
    * - ``eo:bands.common_name``


### PR DESCRIPTION
For now I have pointed default `latest` version of read the docs to this branch.

https://odc-stac.readthedocs.io/en/latest/stac-best-practice.html#

Closes #395