### PR TITLE
Use load_documents from odc to handle remote file

### DIFF
--- a/libs/stats/odc/stats/_cli_common.py
+++ b/libs/stats/odc/stats/_cli_common.py
@@ -92,15 +92,16 @@ def click_yaml_cfg(*args, **kw):
     """
     def _parse(ctx, param, value):
         if value is not None:
-            import urllib
             from urllib.parse import urlparse
             r = urlparse(value)
 
-            # if referece to file, use documents.load_documents to process
             if all([r.scheme, r.netloc]):
-                from datacube.utils import documents
+                import urllib
+                import fsspec
+                import yaml
                 try:
-                    return dict(next(documents.load_documents(value)))
+                    with fsspec.open(value, mode="r") as f:
+                        return next(yaml.safe_load_all(f))
                 except urllib.error.URLError as e:
                     raise click.ClickException(str(e) + f". Cannot access file {value}") from None 
                 except Exception as e:


### PR DESCRIPTION
Based on the talk here: https://github.com/opendatacube/odc-tools/issues/403.

The new/expected config YAML loading piepline:

1) if value meet filename pattern (based on urllib), we will use the similar remoate yaml load [approach](https://github.com/opendatacube/odc-tools/blob/develop/apps/dc_tools/odc/apps/dc_tools/add_update_products.py#L24) to load it. Consider we only have `one` file, so only one next() is enough.
2) if value is not filename, we assume it is the dict string, and still use old approach `parse_yaml_file_or_inline()` to process it.

I am using three filename patterns to test and all good:

1) https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml
2) ga_ls8c_nbart_gm_cyear_3.yaml
3) /home/ubuntu/odc-stats-test-data/ga_ls8c_nbart_gm_cyear_3.yaml

Cheers

Sai