### PR TITLE
Add rgba tif output as optional

### DIFF
--- a/libs/stats/README.md
+++ b/libs/stats/README.md
@@ -164,6 +164,8 @@ cog_opts:
 
 Note that configurations will vary between different products. See this [sample configuration for Australian Landsat-8](https://bitbucket.org/geoscienceaustralia/datakube-apps/src/develop/workspaces/dea-dev/processing/06_stats.yaml).
 
+If no cog_opts:overrides:rgba in configurations or relative plug-in rgba method return None. There is no rgba.tif in output files.
+
 It is also possible to define custom plugins outside of `odc.stats.*`. To do that, define class deriving from `odc.stats.model.StatsPluginInterface` and implement `.input_data` and `.reduce` methods. You can then specify fully qualified name of your custom plugin in `cfg.yaml`.
 
 ```yaml

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -209,9 +209,12 @@ class TaskRunner:
             ds = client.persist(ds, fifo_timeout="1ms")
 
             aux: Optional[xr.Dataset] = None
-            rgba = proc.rgba(ds)
-            if rgba is not None:
-                aux = xr.Dataset(dict(rgba=rgba))
+
+            # if no rgba setting in cog_ops:overrides, no rgba tif as ouput
+            if 'overrides' in cfg.cog_opts and 'rgba' in cfg.cog_opts['overrides']: 
+                rgba = proc.rgba(ds)
+                if rgba is not None:
+                    aux = xr.Dataset(dict(rgba=rgba))
 
             cog = sink.dump(task, ds, aux, proc, apply_eodatasets3)
             cog = client.compute(cog, fifo_timeout="1ms")


### PR DESCRIPTION
Hi,

How are you. I am changing the rgba output control.

The original rgba.tif output control is:

> if the plug-in rgba method return [is None](https://github.com/opendatacube/odc-tools/blob/develop/libs/stats/odc/stats/_wofs.py#L167), there is no rgba.tif in output files. If the plug-in rgba method return [is not None](https://github.com/opendatacube/odc-tools/blob/develop/libs/stats/odc/stats/_gm.py#L130), there is rgba.tif in output files.

In the new desing, I am adding a new layer. We can also using the [rgba section](https://github.com/GeoscienceAustralia/dea-config/blob/master/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml#L71) in config file to control it. If there is no `rgba` in config file, there is also no rgba.tif in output files.

I am testing two cases and both passed:
1) config file with rgba section
2) config file without rgba section

Cheers

Sai