### PR TITLE
Add STAC vs ODC section to odc.stac docs

### DIFF
--- a/libs/stac/docs/index.rst
+++ b/libs/stac/docs/index.rst
@@ -23,8 +23,8 @@ odc-stac
    :hidden:
    :maxdepth: 2
 
-   stac-best-practice.rst
    stac-vs-odc.rst
+   stac-best-practice.rst
 
 .. toctree::
    :caption: Index

--- a/libs/stac/docs/index.rst
+++ b/libs/stac/docs/index.rst
@@ -24,6 +24,7 @@ odc-stac
    :maxdepth: 2
 
    stac-best-practice.rst
+   stac-vs-odc.rst
 
 .. toctree::
    :caption: Index

--- a/libs/stac/docs/stac-best-practice.rst
+++ b/libs/stac/docs/stac-best-practice.rst
@@ -40,7 +40,7 @@ For a full list of understood extension elements see table below.
 
 
 Assumptions
-###########
+===========
 
 Items from the same collection are assumed to have the same number and names of
 bands, and bands are assumed to use the same ``data_type`` across the

--- a/libs/stac/docs/stac-vs-odc.rst
+++ b/libs/stac/docs/stac-vs-odc.rst
@@ -24,7 +24,7 @@ similar concepts.
    * - Band_
      - :class:`~datacube.model.Measurement`
      - Pixel plane within a multi-plane asset
-   * - Common Name
+   * - `Common Name`_
      - Alias
      - Refer to the same band by different names
 
@@ -87,3 +87,4 @@ contained within.
 .. _`Raster Extension`: https://github.com/stac-extensions/eo
 .. _`Item Assets`: https://github.com/stac-extensions/item-assets
 .. _Band: https://github.com/stac-extensions/eo#band-object
+.. _`Common Name`: https://github.com/stac-extensions/eo#common-band-names

--- a/libs/stac/docs/stac-vs-odc.rst
+++ b/libs/stac/docs/stac-vs-odc.rst
@@ -1,7 +1,7 @@
 STAC vs Open Datacube
 #####################
 
-`Open Datacube`_ project on which this library is based started before `STAC`_
+The `Open Datacube`_ (ODC) project, on which this library is based, started before `STAC`_
 spec existed. As a result ODC uses different terminology for otherwise very
 similar concepts.
 
@@ -40,22 +40,22 @@ Multiple Bands per File
 
 Multiple bands in a single file are supported by both ODC and STAC, but
 representation differs. In STAC another level of hierarchy is added below an
-*Asset*. Resource pointed by an *Asset* may contain more than one band of
-pixels, and *Asset* contains description of those bands. In ODC, *Asset* is not
+*Asset* via the [bands attribute of the EO extension](https://github.com/stac-extensions/eo#band-object). Resources pointed to by an *Asset* may contain more than one band of
+pixels, and an *Asset* contains descriptions of those bands. In ODC, *Asset* is not
 modelled explicitly, instead resource path and potential location within this
-resource is just a property of a *Measurement* object. It is common in STAC to
-have one to one mapping between band and asset, in that scenario ODC
+resource are properties of a *Measurement* object. It is common in STAC to
+have one to one mapping between band and asset, and in that scenario ODC
 *Measurement* and STAC *Asset* can be seen as equivalent.
 
 Geo Referencing Metadata
 ========================
 
-Precise geo referencing metadata is stored within a file pointed by
+Precise geo referencing metadata is stored within a file pointed to by
 *Asset*/*Measurement*, but it can also be recorded within a STAC *Item*/ODC
 *Dataset* document. Having geo-referencing information at this level can enable
-more efficient data access.
+more efficient data access by providing spatial information without needing to access the source (data file) itself.
 
-In STAC `Projection Extension`_ is used to bring this metadata from file to
+In STAC, the `Projection Extension`_ is used to bring this metadata from file to
 *Item* document. In STAC each band might have different projection, but in ODC
 projection is a *Dataset* level property and has to be shared across all
 *Measurements*. In ODC individual bands can be of different resolution and have

--- a/libs/stac/docs/stac-vs-odc.rst
+++ b/libs/stac/docs/stac-vs-odc.rst
@@ -21,7 +21,7 @@ similar concepts.
    * - :class:`~pystac.Asset`
      - :class:`~datacube.model.Measurement`
      - Component of a single observation
-   * - Band
+   * - Band_
      - :class:`~datacube.model.Measurement`
      - Pixel plane within a multi-plane asset
    * - Common Name
@@ -40,12 +40,14 @@ Multiple Bands per File
 
 Multiple bands in a single file are supported by both ODC and STAC, but
 representation differs. In STAC another level of hierarchy is added below an
-*Asset* via the [bands attribute of the EO extension](https://github.com/stac-extensions/eo#band-object). Resources pointed to by an *Asset* may contain more than one band of
-pixels, and an *Asset* contains descriptions of those bands. In ODC, *Asset* is not
-modelled explicitly, instead resource path and potential location within this
-resource are properties of a *Measurement* object. It is common in STAC to
-have one to one mapping between band and asset, and in that scenario ODC
-*Measurement* and STAC *Asset* can be seen as equivalent.
+*Asset* via the [bands attribute of the EO
+extension](https://github.com/stac-extensions/eo#band-object). Resources pointed
+to by an *Asset* may contain more than one band of pixels, and an *Asset*
+contains descriptions of those bands. In ODC, *Asset* is not modelled
+explicitly, instead resource path and potential location within this resource
+are properties of a *Measurement* object. It is common in STAC to have one to
+one mapping between band and asset, and in that scenario ODC *Measurement* and
+STAC *Asset* can be seen as equivalent.
 
 Geo Referencing Metadata
 ========================
@@ -53,7 +55,8 @@ Geo Referencing Metadata
 Precise geo referencing metadata is stored within a file pointed to by
 *Asset*/*Measurement*, but it can also be recorded within a STAC *Item*/ODC
 *Dataset* document. Having geo-referencing information at this level can enable
-more efficient data access by providing spatial information without needing to access the source (data file) itself.
+more efficient data access by providing spatial information without needing to
+access the source (data file) itself.
 
 In STAC, the `Projection Extension`_ is used to bring this metadata from file to
 *Item* document. In STAC each band might have different projection, but in ODC
@@ -83,3 +86,4 @@ contained within.
 .. _`Projection Extension`: https://github.com/stac-extensions/projection
 .. _`Raster Extension`: https://github.com/stac-extensions/eo
 .. _`Item Assets`: https://github.com/stac-extensions/item-assets
+.. _Band: https://github.com/stac-extensions/eo#band-object

--- a/libs/stac/docs/stac-vs-odc.rst
+++ b/libs/stac/docs/stac-vs-odc.rst
@@ -1,0 +1,85 @@
+STAC vs Open Datacube
+#####################
+
+`Open Datacube`_ project on which this library is based started before `STAC`_
+spec existed. As a result ODC uses different terminology for otherwise very
+similar concepts.
+
+
+.. list-table::
+   :header-rows: 1
+
+   * - STAC
+     - ODC
+     - Description
+   * - :class:`~pystac.Collection`
+     - Product or :class:`~datacube.model.DatasetType`
+     - Collection of observations across space and time
+   * - :class:`~pystac.Item`
+     - :class:`~datacube.model.Dataset`
+     - Single observation (specific time and place), multi-channel
+   * - :class:`~pystac.Asset`
+     - :class:`~datacube.model.Measurement`
+     - Component of a single observation
+   * - Band
+     - :class:`~datacube.model.Measurement`
+     - Pixel plane within a multi-plane asset
+   * - Common Name
+     - Alias
+     - Refer to the same band by different names
+
+Similarly to STAC, ODC uses several levels of hierarchy to model metadata. At
+the highest level there is *Product* which is a collection of *Datasets*. Each
+*Dataset* contains a set of *Measurements* and related metadata. Finally
+*Measurement* describes a single plane of pixels captured at roughly the same
+time. Metadata includes location of the "file" and possibly location within a
+file.
+
+Multiple Bands per File
+=======================
+
+Multiple bands in a single file are supported by both ODC and STAC, but
+representation differs. In STAC another level of hierarchy is added below an
+*Asset*. Resource pointed by an *Asset* may contain more than one band of
+pixels, and *Asset* contains description of those bands. In ODC, *Asset* is not
+modelled explicitly, instead resource path and potential location within this
+resource is just a property of a *Measurement* object. It is common in STAC to
+have one to one mapping between band and asset, in that scenario ODC
+*Measurement* and STAC *Asset* can be seen as equivalent.
+
+Geo Referencing Metadata
+========================
+
+Precise geo referencing metadata is stored within a file pointed by
+*Asset*/*Measurement*, but it can also be recorded within a STAC *Item*/ODC
+*Dataset* document. Having geo-referencing information at this level can enable
+more efficient data access.
+
+In STAC `Projection Extension`_ is used to bring this metadata from file to
+*Item* document. In STAC each band might have different projection, but in ODC
+projection is a *Dataset* level property and has to be shared across all
+*Measurements*. In ODC individual bands can be of different resolution and have
+different footprints (usually with a lot of overlap), but **must** be in the
+same projection.
+
+Consistency Assumptions
+=======================
+
+In STAC, *Collection* is a very loose term, in theory it can point to very
+heterogeneous set of *Items*. In practice *Items* are typically very similar in
+structure, most contain the same set of *Assets* and bands. ODC is more strict
+in that regard. ODC *Product* contains expected set of *Measurements* per
+*Dataset* as well as some basic common metadata per *Measurement*, specifically
+pixel data type, which is assumed to stay the same across all *Datasets* for a
+given *Measurement*.
+
+STAC equivalent would be `Item Assets`_ extension with `Raster Extension`_
+inside. It describes at the *Collection* level, expected structure of *Items*
+contained within.
+
+
+.. _`Open Datacube`: https://www.opendatacube.org/
+.. _`STAC`: https://stacspec.org/
+.. _`Projection Extension`: https://github.com/stac-extensions/projection
+.. _`Raster Extension`: https://github.com/stac-extensions/eo
+.. _`Item Assets`: https://github.com/stac-extensions/item-assets

--- a/libs/stac/odc/stac/_eo3.py
+++ b/libs/stac/odc/stac/_eo3.py
@@ -418,7 +418,7 @@ def infer_dc_product_from_item(
            rededge1: B05
            rededge2: B06
            rededge3: B07
-         uuid:   # Rules for constructing UUID for Datasets (PLANNED, not implemented yet)
+         uuid:          # Rules for constructing UUID for Datasets
            mode: auto   # auto|random|native(expect .id to contain valid UUID string)
            extras:      # List of extra keys from properties to include (mode=auto)
            - "s2:generation_time"
@@ -592,40 +592,42 @@ def stac2ds(
     :param cfg:
        Supply metadata missing from STAC, configure aliases, control warnings
 
-       .. code-block:: yaml
-
-           sentinel-2-l2a:  # < name of the collection, i.e. ``.collection_id``
-             assets:
-               "*":  # Band named "*" contains band info for "most" bands
-                 data_type: uint16
-                 nodata: 0
-                 unit: "1"
-               SCL:  # Those bands that are different than "most"
-                 data_type: uint8
-                 nodata: 0
-                 unit: "1"
-             aliases:  #< unique alias -> canonical map
-               rededge: B05
-               rededge1: B05
-               rededge2: B06
-               rededge3: B07
-             uuid:   # Rules for constructing UUID for Datasets (PLANNED, not implemented yet)
-               mode: auto   # auto|random|native(expect .id to contain valid UUID string)
-               extras:      # List of extra keys from properties to include (mode=auto)
-               - "s2:generation_time"
-
-             warnings: ignore  # ignore|all  (default all)
-
-           some-other-collection:
-             assets:
-             #...
-
-           "*": # Applies to all collections if not defined on a collection
-             warnings: ignore
-
     :param product_cache:
        Input/Output parameter, contains mapping from collection name to deduced product definition,
        i.e. :py:class:`datacube.model.DatasetType` object.
+
+    .. rubric: Sample Configuration
+
+    .. code-block:: yaml
+
+       sentinel-2-l2a:  # < name of the collection, i.e. `.collection_id`
+         assets:
+           "*":  # Band named "*" contains band info for "most" bands
+             data_type: uint16
+             nodata: 0
+             unit: "1"
+           SCL:  # Those bands that are different than "most"
+             data_type: uint8
+             nodata: 0
+             unit: "1"
+         aliases:  #< unique alias -> canonical map
+           rededge: B05
+           rededge1: B05
+           rededge2: B06
+           rededge3: B07
+         uuid:          # Rules for constructing UUID for Datasets
+           mode: auto   # auto|random|native(expect .id to contain valid UUID string)
+           extras:      # List of extra keys from properties to include (mode=auto)
+           - "s2:generation_time"
+
+         warnings: ignore  # ignore|all  (default all)
+
+       some-other-collection:
+         assets:
+         #...
+
+       "*": # Applies to all collections if not defined on a collection
+         warnings: ignore
 
     """
     products: Dict[str, DatasetType] = {} if product_cache is None else product_cache

--- a/libs/stac/odc/stac/_load.py
+++ b/libs/stac/odc/stac/_load.py
@@ -37,7 +37,6 @@ def load(
     x: Optional[Tuple[float, float]] = None,
     y: Optional[Tuple[float, float]] = None,
     align: Optional[Union[float, int, Tuple[float, float]]] = None,
-    output_crs: MaybeCRS = None,
     like: Optional[Any] = None,
     geopolygon: Optional[datacube.utils.geometry.Geometry] = None,
     # stac related
@@ -132,10 +131,6 @@ def load(
 
     :param crs:
        Load data in a given CRS
-
-    :param output_crs:
-       Same as ``crs``, name used by the underlying
-       :py:meth:`~datacube.Datacube.load` method.
 
     :param resolution:
        Set resolution of output in ``Y, X`` order, it is common for ``Y`` to be negative,
@@ -252,10 +247,6 @@ def load(
            rededge1: B05
            rededge2: B06
            rededge3: B07
-         uuid:   # Rules for constructing UUID for Datasets (PLANNED, not implemented yet)
-           mode: auto   # auto|random|native(expect .id to contain valid UUID string)
-           extras:      # List of extra keys from properties to include (mode=auto)
-           - "s2:generation_time"
 
          warnings: ignore  # ignore|all  (default all)
 
@@ -296,6 +287,7 @@ def load(
     # dc.load has distinction between query crs and output_crs
     # but output_crs name can be confusing, especially that resolution is not output_resolution,
     # so we treat crs same as output_crs
+    output_crs: MaybeCRS = kw.pop("output_crs", None)
     if output_crs is None and crs is not None:
         output_crs, crs = crs, None
 


### PR DESCRIPTION
Document notation differences and similarities between STAC and ODC.

Remove `output_crs=` parameter `crs=` is used instead, `output_crs` is still understood but is not included in docs or named in a argument list (extracted from `**kw` if present to keep consistency with `dc.load`)

Fix docs about UUID generation (were marked as planned, but are in fact done)

Review doc changes here:
https://odc-stac.readthedocs.io/en/stac-docs/stac-vs-odc.html