### PR TITLE
Remove dependency on stac_transform in odc-stats #415

### DIFF
--- a/libs/stac/README.rst
+++ b/libs/stac/README.rst
@@ -40,9 +40,12 @@ Using pip
 Using Conda
 ~~~~~~~~~~~
 
+This will be available on ``conda-forge`` channel soon, but in the meantime it
+can be installed like this:
+
 .. code-block:: bash
 
-   conda -c conda-forge install odc-stac
+   conda install -c kirill-odc odc-stac
 
 To use development version of ``odc-stac`` install dependencies from conda, then
 install ``odc-stac`` with ``pip``.

--- a/libs/stac/odc/stac/_eo3.py
+++ b/libs/stac/odc/stac/_eo3.py
@@ -436,6 +436,10 @@ def infer_dc_product_from_item(
         cfg = {}
 
     collection_id = item.collection_id
+    if collection_id is None:
+        # workaround for some early ODC data
+        collection_id = item.properties.get("odc:product", "_")
+
     _cfg = cfg.get("*", {})
     _cfg.update(cfg.get(collection_id, {}))
 

--- a/libs/stac/tests/test_stac_eo3.py
+++ b/libs/stac/tests/test_stac_eo3.py
@@ -1,6 +1,7 @@
 import uuid
 import pystac
 import pytest
+from toolz import dicttoolz
 from datacube.testutils.io import native_geobox
 from datacube.utils.geometry import Geometry
 from odc.stac._eo3 import (
@@ -173,6 +174,14 @@ def test_infer_product_item(sentinel_stac_ms):
     assert product.canonical_measurement("rededge3") == "B07"
 
     assert set(product._stac_cfg["band2grid"]) == set(product.measurements)
+
+    _stac = dicttoolz.dissoc(sentinel_stac_ms, "collection")
+    item_no_collection = pystac.Item.from_dict(_stac)
+    assert item_no_collection.collection_id is None
+
+    with pytest.warns(UserWarning, match="Common name `rededge` is repeated, skipping"):
+        product = infer_dc_product(item_no_collection)
+    print(product)
 
 
 def test_infer_product_raster_ext(sentinel_stac_ms_with_raster_ext: pystac.Item):

--- a/libs/stats/odc/stats/_cli_generate_cache.py
+++ b/libs/stats/odc/stats/_cli_generate_cache.py
@@ -1,52 +1,28 @@
 import click
-import json
-
+import itertools
 from ._cli_common import main
 
-from odc.aio import S3Fetcher
-from datacube.index.eo3 import prep_eo3
-from odc.stac.transform import stac_transform
-from odc.index import product_from_yaml
 from odc.dscache import create_cache
-from datacube.model import Dataset
-
-
-def bytes2ds_doc(data):
-    if isinstance(data, bytes):
-        data = data.decode("utf-8")
-    stac_doc = json.loads(data)
-    eo3_doc = stac_transform(stac_doc)
-    ds_doc = prep_eo3(eo3_doc)
-    return ds_doc
-
-
-def blob2ds(blob, product):
-    doc = bytes2ds_doc(blob.data)
-    return Dataset(product, doc, uris=[blob.url])
-
-
-def s3_fetch_dss(base, product, glob="*.json", s3=None):
-    if s3 is None:
-        s3 = S3Fetcher(aws_unsigned=True)
-    blobs = s3(o.url for o in s3.find(base, glob=glob))
-    dss = (blob2ds(b, product) for b in blobs)
-    return dss
+from ._stac_fetch import s3_fetch_dss
 
 
 @main.command("generate-cache")
-@click.argument("product", type=str)
-@click.argument("input_prefix", type=str)
+@click.argument("input_glob", type=str)
 @click.argument("location", type=str)
 @click.option("--verbose", "-v", is_flag=True, help="Be verbose")
-def cli(product, input_prefix, location, verbose):
+def cli(input_glob, location, verbose):
     """
     Dump stats data into a cache file.
 
     Note: The input bucket must be public otherwise the data can not be listed.
     """
 
-    product = product_from_yaml(product)
-    dss = s3_fetch_dss(input_prefix, product, glob="*.json")
+    # Look ahead to get product
+    dss = s3_fetch_dss(input_glob)
+    ds0 = next(dss)
+    product = ds0.type
+    dss = itertools.chain(iter([ds0]), dss)
+
     cache = create_cache(f"{product.name}.db")
 
     if verbose:

--- a/libs/stats/odc/stats/_cli_generate_mosaic.py
+++ b/libs/stats/odc/stats/_cli_generate_mosaic.py
@@ -1,68 +1,29 @@
 import click
-import json
+from datacube import Datacube
+from odc.algo import save_cog
 
 from ._cli_common import main
-
-import xarray as xr
-
-from odc.aio import S3Fetcher, s3_find_glob
-from datacube.index.eo3 import prep_eo3
-from odc.stac.transform import stac_transform
-from odc.index import product_from_yaml
-from odc.dscache import create_cache
-from datacube.model import Dataset
-from datacube import Datacube
-from odc.algo import store_to_mem, to_rgba
-from datacube.utils.cog import write_cog
-from odc.algo import save_cog
-from datacube.utils.dask import start_local_dask
-from datacube.utils.rio import configure_s3_access
-
-
-def bytes2ds_doc(data):
-    if isinstance(data, bytes):
-        data = data.decode("utf-8")
-    stac_doc = json.loads(data)
-    eo3_doc = stac_transform(stac_doc)
-    ds_doc = prep_eo3(eo3_doc)
-    return ds_doc
-
-
-def blob2ds(blob, product):
-    doc = bytes2ds_doc(blob.data)
-    return Dataset(product, doc, uris=[blob.url])
-
-
-def s3_fetch_dss(glob, product, s3=None):
-    if s3 is None:
-        s3 = S3Fetcher(aws_unsigned=True)
-    
-    blobs = s3(o.url for o in s3_find_glob(glob, skip_check=True, s3=s3))
-    dss = (blob2ds(b, product) for b in blobs)
-    return dss
+from ._stac_fetch import s3_fetch_dss
 
 
 @main.command("generate-mosaic")
-@click.argument("product", type=str)
-@click.argument("input_prefix", type=str)
-@click.argument("location", type=str)
+@click.argument("input_glob", type=str)
+@click.argument("output", type=str)
 @click.option("--bands", type=str)
 @click.option("--resampling", type=str, default="average")
 @click.option("--verbose", "-v", is_flag=True, help="Be verbose")
-def generate_mosaic(product, input_glob, location, bands, resampling, verbose):
+def generate_mosaic(input_glob, output, bands, resampling, verbose):
     """
     Generate mosaic overviews of the stats data.
 
-    An intermediate cache file is generated and stored in the output location
-    during this process.
     Note: The input bucket must be public otherwise the data can not be listed.
     """
     bands = bands.split(",")
-    product = product_from_yaml(product)
-    if verbose:
-        print(f"Preparing mosaics for {product.name} product")
 
-    dss = s3_fetch_dss(input_glob, product)
+    if verbose:
+        print(f"Preparing mosaics from: '{input_glob}'")
+
+    dss = s3_fetch_dss(input_glob)
 
     dc = Datacube()
     xx = dc.load(
@@ -72,17 +33,13 @@ def generate_mosaic(product, input_glob, location, bands, resampling, verbose):
         measurements=bands,
     )
 
-    if bands is None:
-        suffix = ''
-    else:
-        suffix = '_' + '_'.join(bands)
-
     if verbose:
-        print(f"Writing {location}/{product.name}{suffix}.tif")
-    xx = xx.squeeze('time').to_stacked_array('bands', ['x', 'y'])
+        print(f"Writing {output}")
+
+    xx = xx.squeeze("time").to_stacked_array("bands", ["x", "y"])
     yy = save_cog(
         xx,
-        f"{location}/{product.name}{suffix}.tif",
+        output,
         blocksize=1024,
         compress="zstd",
         zstd_level=4,
@@ -91,9 +48,9 @@ def generate_mosaic(product, input_glob, location, bands, resampling, verbose):
         bigtiff="YES",
         SPARSE_OK=True,
     )
-    
+
     yy.compute()
 
 
 if __name__ == "__main__":
-    cli()
+    main()

--- a/libs/stats/odc/stats/_stac_fetch.py
+++ b/libs/stats/odc/stats/_stac_fetch.py
@@ -1,0 +1,22 @@
+import json
+
+from odc.aio import S3Fetcher, s3_find_glob
+from odc.stac import stac2ds
+from pystac.item import Item
+
+
+def bytes2stac(data):
+    if isinstance(data, bytes):
+        data = data.decode("utf-8")
+    stac_doc = json.loads(data)
+    return Item.from_dict(stac_doc)
+
+
+def s3_fetch_dss(glob, s3=None):
+    if s3 is None:
+        s3 = S3Fetcher(aws_unsigned=True)
+
+    blobs = s3(o.url for o in s3_find_glob(glob, skip_check=True, s3=s3))
+    stacs = (bytes2stac(b.data) for b in blobs)
+
+    return stac2ds(stacs)


### PR DESCRIPTION
Needed to support extraction of `odc-stac` into a stand alone repository see discussion in #415.

- includes other cleanups
- no longer need to supply product yaml on input

not sure about mosaics, but this worked fine

```bash
odc-stats generate-cache 's3://dea-dev-stats-processing/gm-ls-27-09-2021-sample-run/ga_ls8c_nbart_gm_cyear_3/3-0-0/**/*stac-item.json' .
```
