### PR TITLE
add input dataset product info to proc-info

### DIFF
--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -344,6 +344,8 @@ class S3COGSink:
         proc_info_url = task.metadata_path("absolute", ext=self._proc_info_ext)
         dataset_assembler = task.render_assembler_metadata(ext=self._band_ext, output_dataset=ds)
 
+        dataset_assembler.extend_user_metadata("input-products", sorted(set([e.type.name for e in task.datasets])))
+
         dataset_assembler.extend_user_metadata("odc-stats-config", vars(task.product))
 
         dataset_assembler.note_software_version("eodatasets3",


### PR DESCRIPTION
With the [help](https://github.com/opendatacube/odc-tools/issues/419) from Krill. Add the input datasets product name to `proc-info.yaml`.

I test the WO summary and FC percentile. They both can work and dump the expected information.

The WO summary is: 
```
input-products:
- ga_ls_wo_3
```

The FC percentile is:

```
input-products:
- fused__ga_ls_fc_3__ga_ls_wo_3
```