### PR TITLE
Remove io dependencies

### DIFF
--- a/libs/stats/odc/stats/_cli_common.py
+++ b/libs/stats/odc/stats/_cli_common.py
@@ -1,6 +1,7 @@
-from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import List, Tuple
 import click
+
+from ._text import parse_yaml_file_or_inline, parse_range2d_int
 
 TileIdx_txy = Tuple[str, int, int]
 
@@ -117,18 +118,6 @@ def setup_logging(level: int = -1):
     )
 
 
-def parse_range2d_int(s: str) -> Tuple[Tuple[int, int], Tuple[int, int]]:
-    """Parse string like "0:3,4:5" -> ((0,3), (4,5))"""
-    from ._text import split_and_check
-    try:
-        return ((int(x) for x in split_and_check(p, ":", 2)) for p in split_and_check(s, ",", 2))
-    except ValueError:
-        raise ValueError(
-            'Expect <int>:<int>,<int>:<int> syntax, got "{}"'.format(s)
-        ) from None
-
-
-# pylint: disable=import-outside-toplevel,inconsistent-return-statements
 def click_range2d(ctx, param, value):
     """
     @click.option('--range', callback=click_range2d)
@@ -140,29 +129,7 @@ def click_range2d(ctx, param, value):
             raise click.ClickException(str(e)) from None
 
 
-def parse_yaml(s: str) -> Dict[str, Any]:
-    # pylint: disable=import-outside-toplevel
-    import yaml
-
-    return yaml.load(s, Loader=getattr(yaml, "CSafeLoader", yaml.SafeLoader))
-
-
-def parse_yaml_file_or_inline(s: str) -> Dict[str, Any]:
-    """
-    Accept on input either a path to yaml file or yaml text, return parsed yaml document.
-    """
-    try:
-        # if file
-        path = Path(s)
-        with open(path, "rt") as f:
-            txt = f.read()
-            assert isinstance(txt, str)
-    except (FileNotFoundError, IOError, ValueError):
-        txt = s
-    result = parse_yaml(txt)
-    if isinstance(result, str):
-        raise IOError(f"No such file: {s}")
-    return result
+# pylint: disable=import-outside-toplevel,inconsistent-return-statements
 
 
 @click.group(help="Stats command line interface")

--- a/libs/stats/odc/stats/_cli_common.py
+++ b/libs/stats/odc/stats/_cli_common.py
@@ -8,7 +8,7 @@ def parse_task(s: str) -> TileIdx_txy:
     """
     Intentional copy of tasks.parse_task only for CLI parsing
     """
-    from odc.io.text import split_and_check
+    from .io import split_and_check
 
     sep = "/" if "/" in s else ","
     t, x, y = split_and_check(s, sep, 3)
@@ -61,7 +61,7 @@ def parse_all_tasks(
 
 
 def parse_resolution(s: str, separator: str = ",") -> Tuple[float, float]:
-    from odc.io.text import split_and_check
+    from .io import split_and_check
 
     parts = [float(v) for v in split_and_check(s, separator, (1, 2))]
 

--- a/libs/stats/odc/stats/_cli_common.py
+++ b/libs/stats/odc/stats/_cli_common.py
@@ -33,7 +33,7 @@ def parse_all_tasks(
        2019--P1Y,10,-3
        x+10/y-3/2019--P1Y
     """
-    from odc.io.text import parse_slice
+    from .io import parse_slice
 
     out: List[TileIdx_txy] = []
     full_set = set(all_possible_tasks)
@@ -116,6 +116,29 @@ def setup_logging(level: int = -1):
         format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
         stream=sys.stdout,
     )
+
+
+def parse_range2d_int(s: str) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+    """Parse string like "0:3,4:5" -> ((0,3), (4,5))"""
+    from .io import split_and_check
+    try:
+        return ((int(x) for x in split_and_check(p, ":", 2)) for p in split_and_check(s, ",", 2))
+    except ValueError:
+        raise ValueError(
+            'Expect <int>:<int>,<int>:<int> syntax, got "{}"'.format(s)
+        ) from None
+
+
+# pylint: disable=import-outside-toplevel,inconsistent-return-statements
+def click_range2d(ctx, param, value):
+    """
+    @click.option('--range', callback=click_range2d)
+    """
+    if value is not None:
+        try:
+            return parse_range2d_int(value)
+        except ValueError as e:
+            raise click.ClickException(str(e)) from None
 
 
 @click.group(help="Stats command line interface")

--- a/libs/stats/odc/stats/_cli_common.py
+++ b/libs/stats/odc/stats/_cli_common.py
@@ -9,7 +9,7 @@ def parse_task(s: str) -> TileIdx_txy:
     """
     Intentional copy of tasks.parse_task only for CLI parsing
     """
-    from .io import split_and_check
+    from ._text import split_and_check
 
     sep = "/" if "/" in s else ","
     t, x, y = split_and_check(s, sep, 3)
@@ -34,7 +34,7 @@ def parse_all_tasks(
        2019--P1Y,10,-3
        x+10/y-3/2019--P1Y
     """
-    from .io import parse_slice
+    from ._text import parse_slice
 
     out: List[TileIdx_txy] = []
     full_set = set(all_possible_tasks)
@@ -62,7 +62,7 @@ def parse_all_tasks(
 
 
 def parse_resolution(s: str, separator: str = ",") -> Tuple[float, float]:
-    from .io import split_and_check
+    from ._text import split_and_check
 
     parts = [float(v) for v in split_and_check(s, separator, (1, 2))]
 
@@ -119,7 +119,7 @@ def setup_logging(level: int = -1):
 
 def parse_range2d_int(s: str) -> Tuple[Tuple[int, int], Tuple[int, int]]:
     """Parse string like "0:3,4:5" -> ((0,3), (4,5))"""
-    from .io import split_and_check
+    from ._text import split_and_check
     try:
         return ((int(x) for x in split_and_check(p, ":", 2)) for p in split_and_check(s, ",", 2))
     except ValueError:

--- a/libs/stats/odc/stats/_cli_save_tasks.py
+++ b/libs/stats/odc/stats/_cli_save_tasks.py
@@ -2,8 +2,7 @@ import json
 
 import click
 import sys
-from odc.io.text import click_range2d
-from ._cli_common import main
+from ._cli_common import click_range2d, main
 from .utils import fuse_products, fuse_ds
 from odc.index import ordered_dss, dataset_count
 from itertools import groupby

--- a/libs/stats/odc/stats/_cli_save_tasks.py
+++ b/libs/stats/odc/stats/_cli_save_tasks.py
@@ -2,7 +2,7 @@ import json
 
 import click
 import sys
-from ._cli_common import click_range2d, main
+from ._cli_common import main, click_range2d
 from .utils import fuse_products, fuse_ds
 from odc.index import ordered_dss, dataset_count
 from itertools import groupby

--- a/libs/stats/odc/stats/_text.py
+++ b/libs/stats/odc/stats/_text.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from typing import Union, Optional, Tuple
+
+PathLike = Union[str, Path]
+
+
+# Copied from odc.io.text
+
+def read_int(path: PathLike, default=None, base=10) -> Optional[int]:
+    """
+    Read single integer from a text file.
+
+    Useful for things like parsing content of /sys/ or /proc.
+    """
+    try:
+        with open(path, "rt") as f:
+            return int(f.read(), base)
+    except (FileNotFoundError, ValueError):
+        return default
+
+
+def split_and_check(
+        s: str, separator: str, n: Union[int, Tuple[int, ...]]
+) -> Tuple[str, ...]:
+    """Turn string into tuple, checking that there are exactly as many parts as expected.
+    :param s: String to parse
+    :param separator: Separator character
+    :param n: Expected number of parts, can be a single integer value or several,
+              example `(2, 3)` accepts 2 or 3 parts.
+    """
+    if isinstance(n, int):
+        n = (n,)
+
+    parts = s.split(separator)
+    if len(parts) not in n:
+        raise ValueError('Failed to parse "{}"'.format(s))
+    return tuple(parts)
+
+
+def parse_slice(s: str) -> slice:
+    """
+    Parse slice syntax in the form start:stop[:step]
+    Examples "::4", "2:5", "2::10", "3:100:5"
+    """
+
+    def parse(part: str) -> Optional[int]:
+        if part == "":
+            return None
+        return int(part)
+
+    try:
+        parts = [parse(p) for p in split_and_check(s, ":", (2, 3))]
+    except ValueError:
+        raise ValueError(f'Expect <start>:<stop>[:<step>] syntax, got "{s}"') from None
+
+    return slice(*parts)

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -112,6 +112,25 @@ def split_and_check(
     return tuple(parts)
 
 
+def parse_slice(s: str) -> slice:
+    """
+    Parse slice syntax in the form start:stop[:step]
+    Examples "::4", "2:5", "2::10", "3:100:5"
+    """
+
+    def parse(part: str) -> Optional[int]:
+        if part == "":
+            return None
+        return int(part)
+
+    try:
+        parts = [parse(p) for p in split_and_check(s, ":", (2, 3))]
+    except ValueError:
+        raise ValueError(f'Expect <start>:<stop>[:<step>] syntax, got "{s}"') from None
+
+    return slice(*parts)
+
+
 class S3COGSink:
     def __init__(
         self,

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -2,7 +2,7 @@
 Various I/O adaptors
 """
 
-from typing import Any, Dict, List, Optional, Union, Tuple, cast
+from typing import Any, Dict, List, Optional, Union, cast
 import json
 from urllib.parse import urlparse
 import logging
@@ -35,8 +35,6 @@ WriteResult = namedtuple("WriteResult", ["path", "sha1", "error"])
 
 _log = logging.getLogger(__name__)
 DEFAULT_COG_OPTS = dict(compress="deflate", zlevel=6, blocksize=512,)
-
-PathLike = Union[str, Path]
 
 
 def load_creds(profile: Optional[str] = None) -> ReadOnlyCredentials:
@@ -79,56 +77,6 @@ def _sha1_digest(*write_results):
         file = wr.path.split("/")[-1]
         lines.append(f"{wr.sha1}\t{file}\n")
     return "".join(lines)
-
-
-def read_int(path: PathLike, default=None, base=10) -> Optional[int]:
-    """
-    Read single integer from a text file.
-
-    Useful for things like parsing content of /sys/ or /proc.
-    """
-    try:
-        with open(path, "rt") as f:
-            return int(f.read(), base)
-    except (FileNotFoundError, ValueError):
-        return default
-
-
-def split_and_check(
-        s: str, separator: str, n: Union[int, Tuple[int, ...]]
-) -> Tuple[str, ...]:
-    """Turn string into tuple, checking that there are exactly as many parts as expected.
-    :param s: String to parse
-    :param separator: Separator character
-    :param n: Expected number of parts, can be a single integer value or several,
-              example `(2, 3)` accepts 2 or 3 parts.
-    """
-    if isinstance(n, int):
-        n = (n,)
-
-    parts = s.split(separator)
-    if len(parts) not in n:
-        raise ValueError('Failed to parse "{}"'.format(s))
-    return tuple(parts)
-
-
-def parse_slice(s: str) -> slice:
-    """
-    Parse slice syntax in the form start:stop[:step]
-    Examples "::4", "2:5", "2::10", "3:100:5"
-    """
-
-    def parse(part: str) -> Optional[int]:
-        if part == "":
-            return None
-        return int(part)
-
-    try:
-        parts = [parse(p) for p in split_and_check(s, ":", (2, 3))]
-    except ValueError:
-        raise ValueError(f'Expect <start>:<stop>[:<step>] syntax, got "{s}"') from None
-
-    return slice(*parts)
 
 
 class S3COGSink:

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -41,6 +41,8 @@ WriteResult = namedtuple("WriteResult", ["path", "sha1", "error"])
 _log = logging.getLogger(__name__)
 DEFAULT_COG_OPTS = dict(compress="deflate", zlevel=6, blocksize=512,)
 
+PathLike = Union[str, Path]
+
 
 def load_creds(profile: Optional[str] = None) -> ReadOnlyCredentials:
     session = mk_boto_session(profile=profile)
@@ -82,6 +84,19 @@ def _sha1_digest(*write_results):
         file = wr.path.split("/")[-1]
         lines.append(f"{wr.sha1}\t{file}\n")
     return "".join(lines)
+
+
+def read_int(path: PathLike, default=None, base=10) -> Optional[int]:
+    """
+    Read single integer from a text file.
+
+    Useful for things like parsing content of /sys/ or /proc.
+    """
+    try:
+        with open(path, "rt") as f:
+            return int(f.read(), base)
+    except (FileNotFoundError, ValueError):
+        return default
 
 
 class S3COGSink:

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -14,7 +14,7 @@ from datacube.model import Dataset
 from datacube.utils.dates import normalise_dt
 from datacube.utils.geometry import GeoBox
 from odc.index import odc_uuid
-from .io import split_and_check
+from ._text import split_and_check
 from pystac.extensions.projection import ProjectionExtension
 from toolz import dicttoolz
 from rasterio.crs import CRS

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -7,28 +7,21 @@ from typing import Any, Dict, Optional, Tuple, Union, List, Mapping
 from uuid import UUID
 from pathlib import Path
 
-import json
 import pandas as pd
-import numpy
 import pystac
 import xarray as xr
 from datacube.model import Dataset
 from datacube.utils.dates import normalise_dt
 from datacube.utils.geometry import GeoBox
-from datacube.testutils.io import native_geobox
 from odc.index import odc_uuid
-from odc.io.text import split_and_check
+from .io import split_and_check
 from pystac.extensions.projection import ProjectionExtension
-from toolz import dicttoolz
 from toolz import dicttoolz
 from rasterio.crs import CRS
 import warnings
 
 from eodatasets3.assemble import DatasetAssembler, serialise
 from eodatasets3.images import GridSpec
-from eodatasets3.model import DatasetDoc, ProductDoc, GridDoc
-from eodatasets3.properties import StacPropertyView
-from eodatasets3.verify import PackageChecksum
 
 TileIdx_xy = Tuple[int, int]
 TileIdx_txy = Tuple[str, int, int]

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -15,7 +15,8 @@ import math
 import psutil
 
 from .model import Task, TaskResult, TaskRunnerConfig
-from .io import S3COGSink, read_int
+from .io import S3COGSink
+from ._text import read_int
 from .tasks import TaskReader
 from . import _plugins
 from odc.algo import wait_for_future

--- a/libs/stats/odc/stats/tasks.py
+++ b/libs/stats/odc/stats/tasks.py
@@ -22,7 +22,7 @@ from datacube.utils.dates import normalise_dt
 from odc.index import chopped_dss, bin_dataset_stream, dataset_count, all_datasets
 from odc.dscache.tools.tiling import parse_gridspec_with_name
 from odc.dscache.tools.profiling import ds_stream_test_func
-from .io import split_and_check
+from ._text import split_and_check
 
 from odc.aws import s3_download, s3_url_parse
 from itertools import chain

--- a/libs/stats/odc/stats/tasks.py
+++ b/libs/stats/odc/stats/tasks.py
@@ -4,7 +4,7 @@ import random
 from types import SimpleNamespace
 from collections import namedtuple
 from datetime import datetime
-from itertools import chain, islice
+from itertools import islice
 import pickle
 import json
 import os
@@ -22,7 +22,7 @@ from datacube.utils.dates import normalise_dt
 from odc.index import chopped_dss, bin_dataset_stream, dataset_count, all_datasets
 from odc.dscache.tools.tiling import parse_gridspec_with_name
 from odc.dscache.tools.profiling import ds_stream_test_func
-from odc.io.text import split_and_check
+from .io import split_and_check
 
 from odc.aws import s3_download, s3_url_parse
 from itertools import chain

--- a/libs/stats/setup.cfg
+++ b/libs/stats/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
     odc-cloud[ASYNC]
     odc_algo
     odc_dscache
-    odc_io
     odc_stac
     pandas
     pystac>=1.1.0

--- a/libs/stats/tests/test_proc.py
+++ b/libs/stats/tests/test_proc.py
@@ -1,6 +1,11 @@
 import pytest
-from odc.stats.proc import TaskRunner, TaskRunnerConfig
+from odc.stats.proc import TaskRunner, TaskRunnerConfig, get_cpu_quota, get_mem_quota
 
+def test_quotas():
+    cpuq = get_cpu_quota()
+    memq = get_mem_quota()
+    assert cpuq is None or isinstance(cpuq, float)
+    assert memq is None or isinstance(memq, int)
 
 def test_runner_product_cfg(test_db_path, dummy_plugin_name):
     cfg = TaskRunnerConfig(

--- a/libs/stats/tests/test_text.py
+++ b/libs/stats/tests/test_text.py
@@ -1,0 +1,37 @@
+import pytest
+from odc.stats._text import parse_yaml, split_and_check, parse_slice, parse_range2d_int
+
+
+def test_parse_yaml():
+    o = parse_yaml(
+        """
+a: 3
+b: foo
+"""
+    )
+
+    assert o["a"] == 3 and o["b"] == "foo"
+    assert set(o) == {"a", "b"}
+
+
+def test_split_check():
+    assert split_and_check("one/two/three", "/", 3) == ("one", "two", "three")
+    assert split_and_check("one/two/three", "/", (3, 4)) == ("one", "two", "three")
+
+    with pytest.raises(ValueError):
+        split_and_check("a:b", ":", 3)
+
+
+def test_parse_slice():
+    from numpy import s_
+
+    assert parse_slice("::2") == s_[::2]
+    assert parse_slice("1:") == s_[1:]
+    assert parse_slice("1:4") == s_[1:4]
+    assert parse_slice("1:4:2") == s_[1:4:2]
+    assert parse_slice("1::2") == s_[1::2]
+
+def test_parse_2d_range():
+    assert parse_range2d_int("1:2,3:4") == ((1,2),(3,4))
+    with pytest.raises(ValueError):
+        parse_range2d_int("1,2:3,4")

--- a/libs/stats/tests/test_text.py
+++ b/libs/stats/tests/test_text.py
@@ -1,9 +1,24 @@
 import pytest
-from odc.stats._text import parse_yaml, split_and_check, parse_slice, parse_range2d_int
+from odc.stats._text import read_int, parse_slice, parse_range2d_int, \
+                            parse_yaml, parse_yaml_file_or_inline, \
+                            split_and_check
+
+
+def test_read_int():
+    assert read_int("/not_a_real_file/already", default="bleagh") == "bleagh"
 
 
 def test_parse_yaml():
     o = parse_yaml(
+        """
+a: 3
+b: foo
+"""
+    )
+
+    assert o["a"] == 3 and o["b"] == "foo"
+    assert set(o) == {"a", "b"}
+    o = parse_yaml_file_or_inline(
         """
 a: 3
 b: foo


### PR DESCRIPTION
Remove (direct) dependency of odc-stats on odc-io.

Note stats still depends on odc-io indirectly, via odc-dscache.

Preparatory refactor for #432