### PR TITLE
Move plugins to a separate plugins package.

### DIFF
--- a/libs/stats/odc/stats/_cli_run.py
+++ b/libs/stats/odc/stats/_cli_run.py
@@ -1,8 +1,6 @@
 import sys
 import click
 from ._cli_common import main, setup_logging, click_resolution, click_yaml_cfg
-from odc.aws.queue import get_messages, get_queue
-from ._sqs import SQSWorkToken
 
 
 @main.command("run")
@@ -102,7 +100,7 @@ def run(
     import logging
     from .model import TaskRunnerConfig
     from .proc import TaskRunner
-    from ._plugins import import_all
+    from .plugins import import_all
 
     _log = logging.getLogger(__name__)
 

--- a/libs/stats/odc/stats/plugins/__init__.py
+++ b/libs/stats/odc/stats/plugins/__init__.py
@@ -1,0 +1,1 @@
+from ._base import resolve, import_all, register

--- a/libs/stats/odc/stats/plugins/_base.py
+++ b/libs/stats/odc/stats/plugins/_base.py
@@ -2,7 +2,7 @@ import pydoc
 from typing import Callable, Dict
 from functools import partial
 
-from .model import StatsPluginInterface
+from odc.stats.model import StatsPluginInterface
 
 PluginFactory = Callable[..., StatsPluginInterface]
 
@@ -36,13 +36,13 @@ def import_all():
 
     # TODO: make that more automatic
     modules = [
-        "odc.stats._fc_percentiles",
-        "odc.stats._tcw_percentiles",
-        "odc.stats._gm",
-        "odc.stats._gm_ls_bitmask",
-        "odc.stats._pq",
-        "odc.stats._pq_bitmask",
-        "odc.stats._wofs",
+        "odc.stats.plugins.fc_percentiles",
+        "odc.stats.plugins.tcw_percentiles",
+        "odc.stats.plugins.gm",
+        "odc.stats.plugins.gm_ls_bitmask",
+        "odc.stats.plugins.pq",
+        "odc.stats.plugins.pq_bitmask",
+        "odc.stats.plugins.wofs",
     ]
 
     for mod in modules:

--- a/libs/stats/odc/stats/plugins/fc_percentiles.py
+++ b/libs/stats/odc/stats/plugins/fc_percentiles.py
@@ -4,17 +4,15 @@ Fractional Cover Percentiles
 from functools import partial
 from typing import Optional, Tuple
 from itertools import product
-import dask.array as da
 import xarray as xr
 import numpy as np
 from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
-from odc.algo._masking import _xr_fuse, _or_fuser, _fuse_mean_np, _fuse_or_np, _fuse_and_np
-from .model import StatsPluginInterface
-from . import _plugins
-
+from odc.algo._masking import _xr_fuse, _or_fuser, _fuse_mean_np, _fuse_or_np
+from odc.stats.model import StatsPluginInterface
+from ._base import register
 
 NODATA = 255
 
@@ -114,4 +112,4 @@ class StatsFCP(StatsPluginInterface):
         return None
 
 
-_plugins.register("fc-percentiles", StatsFCP)
+register("fc-percentiles", StatsFCP)

--- a/libs/stats/odc/stats/plugins/gm.py
+++ b/libs/stats/odc/stats/plugins/gm.py
@@ -1,14 +1,14 @@
 """
 Geomedian
 """
-from typing import Dict, Optional, Tuple, Iterable
+from typing import Optional, Tuple, Iterable
 import xarray as xr
 from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
 from odc.algo import erase_bad, geomedian_with_mads, to_rgba
 from odc.algo.io import load_enum_filtered
-from .model import StatsPluginInterface
-from . import _plugins
+from odc.stats.model import StatsPluginInterface
+from ._base import register
 
 
 class StatsGM(StatsPluginInterface):
@@ -133,7 +133,7 @@ class StatsGM(StatsPluginInterface):
         return to_rgba(xx, clamp=self.rgb_clamp, bands=self.rgb_bands)
 
 
-_plugins.register("gm-generic", StatsGM)
+register("gm-generic", StatsGM)
 
 
 class StatsGMS2(StatsGM):
@@ -194,7 +194,7 @@ class StatsGMS2(StatsGM):
         )
 
 
-_plugins.register("gm-s2", StatsGMS2)
+register("gm-s2", StatsGMS2)
 
 
 class StatsGMLS(StatsGM):
@@ -246,4 +246,4 @@ class StatsGMLS(StatsGM):
         )
 
 
-_plugins.register("gm-ls", StatsGMLS)
+register("gm-ls", StatsGMLS)

--- a/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
@@ -10,9 +10,9 @@ from datacube.utils import masking
 from odc.algo import geomedian_with_mads, keep_good_only, erase_bad
 from odc.algo._masking import _xr_fuse, _first_valid_np, mask_cleanup, _fuse_or_np
 from odc.algo.io import load_with_native_transform
-from odc.stats import _plugins
 from odc.stats.model import StatsPluginInterface
 from odc.stats.model import Task
+from ._base import register
 
 class StatsGMLSBitmask(StatsPluginInterface):
     NAME = "gm_ls_bitmask"
@@ -194,4 +194,4 @@ class StatsGMLSBitmask(StatsPluginInterface):
         return None
 
 
-_plugins.register("gm-ls-bitmask", StatsGMLSBitmask)
+register("gm-ls-bitmask", StatsGMLSBitmask)

--- a/libs/stats/odc/stats/plugins/pq.py
+++ b/libs/stats/odc/stats/plugins/pq.py
@@ -2,7 +2,7 @@
 Sentinel 2 pixel quality stats
 """
 from functools import partial
-from typing import List, Dict, Optional, Tuple, cast, Iterable
+from typing import Dict, Optional, Tuple, cast, Iterable
 
 import xarray as xr
 
@@ -11,8 +11,8 @@ from odc.algo._masking import _or_fuser
 from odc.algo.io import load_with_native_transform
 from odc.stats.model import Task
 
-from .model import StatsPluginInterface
-from . import _plugins
+from odc.stats.model import StatsPluginInterface
+from ._base import register
 
 cloud_classes = (
     "cloud shadows",
@@ -137,7 +137,7 @@ def _pq_fuser(
     return xx
 
 
-_plugins.register("pq", StatsPQ)
+register("pq", StatsPQ)
 
 
 def test_pq_product():
@@ -151,13 +151,13 @@ def test_pq_product():
 
 def test_plugin():
     location = "file:///tmp"
-    pq = _plugins.resolve("pq")()
+    pq = _base.resolve("pq")()
     product = pq.product(location)
 
     assert product.measurements == ("total", "clear", "clear_2_5", "clear_0_5")
     assert pq.filters == default_filters
 
-    pq = _plugins.resolve("pq")(filters={}, resampling="cubic")
+    pq = _base.resolve("pq")(filters={}, resampling="cubic")
     product = pq.product(location)
 
     assert product.measurements == ("total", "clear")

--- a/libs/stats/odc/stats/plugins/pq_bitmask.py
+++ b/libs/stats/odc/stats/plugins/pq_bitmask.py
@@ -33,7 +33,7 @@ resampling = "nearest"
 """
 
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple, Iterable
+from typing import Any, Dict, Optional, Tuple, Iterable
 
 import dask.array as da
 import xarray as xr
@@ -43,8 +43,8 @@ from odc.algo._masking import _xr_fuse, _first_valid_np, _fuse_or_np
 from odc.algo.io import load_with_native_transform
 from odc.stats.model import Task
 
-from .model import StatsPluginInterface
-from . import _plugins
+from odc.stats.model import StatsPluginInterface
+from ._base import register
 
 
 class StatsPQLSBitmask(StatsPluginInterface):
@@ -206,4 +206,4 @@ class StatsPQLSBitmask(StatsPluginInterface):
         return fuser_result
 
 
-_plugins.register("pq-ls-bitmask", StatsPQLSBitmask)
+register("pq-ls-bitmask", StatsPQLSBitmask)

--- a/libs/stats/odc/stats/plugins/tcw_percentiles.py
+++ b/libs/stats/odc/stats/plugins/tcw_percentiles.py
@@ -10,9 +10,8 @@ from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
 from odc.algo._masking import _xr_fuse, _fuse_mean_np, enum_to_bool
-from .model import StatsPluginInterface
-from . import _plugins
-
+from odc.stats.model import StatsPluginInterface
+from ._base import register
 
 NODATA = -9999 # output NODATA
 
@@ -94,4 +93,4 @@ class StatsTCWPC(StatsPluginInterface):
         return None
 
 
-_plugins.register("tcw-percentiles", StatsTCWPC)
+register("tcw-percentiles", StatsTCWPC)

--- a/libs/stats/odc/stats/plugins/wofs.py
+++ b/libs/stats/odc/stats/plugins/wofs.py
@@ -21,8 +21,8 @@ from odc.stats.model import Task
 from odc.algo.io import load_with_native_transform
 from odc.algo import safe_div, apply_numexpr, keep_good_only, binary_dilation
 from odc.algo.io import dc_load
-from .model import StatsPluginInterface
-from . import _plugins
+from odc.stats.model import StatsPluginInterface
+from ._base import register
 
 
 class StatsWofs(StatsPluginInterface):
@@ -168,7 +168,7 @@ class StatsWofs(StatsPluginInterface):
         return None
 
 
-_plugins.register("wofs-summary", StatsWofs)
+register("wofs-summary", StatsWofs)
 
 
 class StatsWofsFullHistory(StatsPluginInterface):
@@ -262,4 +262,4 @@ class StatsWofsFullHistory(StatsPluginInterface):
         return yy
 
 
-_plugins.register("wofs-summary-fh", StatsWofsFullHistory)
+register("wofs-summary-fh", StatsWofsFullHistory)

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -18,7 +18,7 @@ from .model import Task, TaskResult, TaskRunnerConfig
 from .io import S3COGSink
 from ._text import read_int
 from .tasks import TaskReader
-from . import _plugins
+from .plugins import resolve
 from odc.algo import wait_for_future
 from datacube.utils.dask import start_local_dask
 from datacube.utils.rio import configure_s3_access
@@ -42,7 +42,7 @@ class TaskRunner:
         )
 
         _log.info(f"Resolving plugin: {cfg.plugin}")
-        mk_proc = _plugins.resolve(cfg.plugin)
+        mk_proc = resolve(cfg.plugin)
         self.proc = mk_proc(**cfg.plugin_config)
         self.product = self.proc.product(cfg.output_location, **cfg.product)
         _log.info(f"Output product: {self.product}")

--- a/libs/stats/tests/conftest.py
+++ b/libs/stats/tests/conftest.py
@@ -25,7 +25,7 @@ def test_db_path(test_dir):
 
 @pytest.fixture
 def dummy_plugin_name():
-    from odc.stats._plugins import register
+    from odc.stats.plugins import register
 
     name = "dummy-plugin"
     register(name, DummyPlugin)

--- a/libs/stats/tests/test_fc_percentiles.py
+++ b/libs/stats/tests/test_fc_percentiles.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xarray as xr
 import dask.array as da
-from odc.stats._fc_percentiles import StatsFCP
+from odc.stats.plugins.fc_percentiles import StatsFCP
 import pytest 
 import pandas as pd
 

--- a/libs/stats/tests/test_gm_ls_bitmask.py
+++ b/libs/stats/tests/test_gm_ls_bitmask.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xarray as xr
 import dask.array as da
-from odc.stats._gm_ls_bitmask import StatsGMLSBitmask
+from odc.stats.plugins.gm_ls_bitmask import StatsGMLSBitmask
 import pytest
 import pandas as pd
 from .test_utils import usgs_ls8_sr_definition

--- a/libs/stats/tests/test_pq_bitmask.py
+++ b/libs/stats/tests/test_pq_bitmask.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xarray as xr
 import dask.array as da
-from odc.stats._pq_bitmask import StatsPQLSBitmask
+from odc.stats.plugins.pq_bitmask import StatsPQLSBitmask
 import pytest
 import pandas as pd
 from copy import deepcopy

--- a/libs/stats/tests/test_proc.py
+++ b/libs/stats/tests/test_proc.py
@@ -42,11 +42,11 @@ def test_runner_product_cfg(test_db_path, dummy_plugin_name):
 
 
 def test_plugin_resolve():
-    from odc.stats._plugins import resolve
-    from odc.stats._gm import StatsGM
+    from odc.stats.plugins import resolve
+    from odc.stats.plugins.gm import StatsGM
 
     assert resolve("gm-generic") is not None
-    assert resolve("odc.stats._gm.StatsGM") is not None
+    assert resolve("odc.stats.plugins.gm.StatsGM") is not None
 
     # Test no such class
     with pytest.raises(ValueError):

--- a/libs/stats/tests/test_utils.py
+++ b/libs/stats/tests/test_utils.py
@@ -25,7 +25,7 @@ from . import gen_compressed_dss
 
 
 def test_stac(test_db_path):
-    from odc.stats._gm import StatsGMS2
+    from odc.stats.plugins.gm import StatsGMS2
 
     product = StatsGMS2().product(location="/tmp/")
     reader = TaskReader(test_db_path, product)


### PR DESCRIPTION
Next step in refactor.  Just tidying up at this stage.

Yaml files that identify their plugin by name should work transparently.  It looks like you can also identify plugins by their absolute path - if that's the case and any of your yaml files use that feature, they will need to be updated.