### PR TITLE
Isolate plugin layer

### DIFF
--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -20,7 +20,7 @@ from datacube.utils.cog import to_cog
 from datacube.model import Dataset
 from botocore.credentials import ReadOnlyCredentials
 from .model import Task, EXT_TIFF
-from .plugins._base import StatsPluginInterface
+from .plugins import StatsPluginInterface
 from hashlib import sha1
 from collections import namedtuple
 from odc.stats import __version__

--- a/libs/stats/odc/stats/io.py
+++ b/libs/stats/odc/stats/io.py
@@ -19,7 +19,8 @@ from datacube.utils.dask import save_blob_to_s3, save_blob_to_file
 from datacube.utils.cog import to_cog
 from datacube.model import Dataset
 from botocore.credentials import ReadOnlyCredentials
-from .model import Task, EXT_TIFF, StatsPluginInterface
+from .model import Task, EXT_TIFF
+from .plugins._base import StatsPluginInterface
 from hashlib import sha1
 from collections import namedtuple
 from odc.stats import __version__

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, Tuple, Union, List, Mapping
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from uuid import UUID
 from pathlib import Path
 
@@ -509,7 +509,7 @@ class StatsPluginInterface(ABC):
         pass
 
     @abstractmethod
-    def input_data(self, task: Task) -> xr.Dataset:
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         pass
 
     @abstractmethod

--- a/libs/stats/odc/stats/model.py
+++ b/libs/stats/odc/stats/model.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 from pathlib import Path
 
@@ -22,6 +22,8 @@ import warnings
 
 from eodatasets3.assemble import DatasetAssembler, serialise
 from eodatasets3.images import GridSpec
+
+from .plugins import StatsPluginInterface
 
 TileIdx_xy = Tuple[int, int]
 TileIdx_txy = Tuple[str, int, int]
@@ -496,31 +498,6 @@ class Task:
 
         return item.to_dict()
 
-
-class StatsPluginInterface(ABC):
-    NAME = "*unset*"
-    SHORT_NAME = ""
-    VERSION = "0.0.0"
-    PRODUCT_FAMILY = "statistics"
-
-    @property
-    @abstractmethod
-    def measurements(self) -> Tuple[str, ...]:
-        pass
-
-    @abstractmethod
-    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
-        pass
-
-    @abstractmethod
-    def reduce(self, xx: xr.Dataset) -> xr.Dataset:
-        pass
-
-    def rgba(self, xx: xr.Dataset) -> Optional[xr.DataArray]:
-        """
-        Given result of ``.reduce(..)`` optionally produce RGBA preview image
-        """
-        return None
 
 def product_for_plugin(
     plugin: StatsPluginInterface,

--- a/libs/stats/odc/stats/plugins/__init__.py
+++ b/libs/stats/odc/stats/plugins/__init__.py
@@ -1,1 +1,6 @@
-from ._base import resolve, import_all, register
+from ._base import (
+    resolve,
+    import_all,
+    register,
+    StatsPluginInterface
+)

--- a/libs/stats/odc/stats/plugins/__init__.py
+++ b/libs/stats/odc/stats/plugins/__init__.py
@@ -1,6 +1,6 @@
-from ._base import (
+from ._base import StatsPluginInterface
+from ._registry import (
     resolve,
     import_all,
-    register,
-    StatsPluginInterface
+    register
 )

--- a/libs/stats/odc/stats/plugins/_base.py
+++ b/libs/stats/odc/stats/plugins/_base.py
@@ -1,11 +1,10 @@
-import pydoc
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, Tuple, Sequence, Optional
-from functools import partial
+from typing import Tuple, Sequence, Optional
 
 import xarray as xr
 from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
+
 
 class StatsPluginInterface(ABC):
     NAME = "*unset*"
@@ -31,52 +30,3 @@ class StatsPluginInterface(ABC):
         Given result of ``.reduce(..)`` optionally produce RGBA preview image
         """
         return None
-
-
-PluginFactory = Callable[..., StatsPluginInterface]
-
-_plugins: Dict[str, PluginFactory] = {}
-
-
-def _new(plugin_class, *args, **kwargs) -> StatsPluginInterface:
-    return plugin_class(*args, **kwargs)
-
-
-def resolve(name: str) -> PluginFactory:
-    maker = _plugins.get(name)
-    if maker is None:
-        maker = pydoc.locate(name)
-        if maker is not None:
-            if not issubclass(maker, (StatsPluginInterface,)):
-                raise ValueError(f"Custom StatsPlugin '{name}' is not derived from StatsPluginInterface")
-            return partial(_new, maker)
-
-    if maker is None:
-        raise ValueError(f"Failed to resolved named plugin: '{name}'")
-    return maker
-
-
-def register(name: str, plugin_class):
-    _plugins[name] = partial(_new, plugin_class)
-
-
-def import_all():
-    import importlib
-
-    # TODO: make that more automatic
-    modules = [
-        "odc.stats.plugins.fc_percentiles",
-        "odc.stats.plugins.tcw_percentiles",
-        "odc.stats.plugins.gm",
-        "odc.stats.plugins.gm_ls_bitmask",
-        "odc.stats.plugins.pq",
-        "odc.stats.plugins.pq_bitmask",
-        "odc.stats.plugins.wofs",
-    ]
-
-    for mod in modules:
-        try:
-            importlib.import_module(mod)
-        except ModuleNotFoundError:
-            pass
-

--- a/libs/stats/odc/stats/plugins/_base.py
+++ b/libs/stats/odc/stats/plugins/_base.py
@@ -1,8 +1,37 @@
 import pydoc
-from typing import Callable, Dict
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, Tuple, Sequence, Optional
 from functools import partial
 
-from odc.stats.model import StatsPluginInterface
+import xarray as xr
+from datacube.model import Dataset
+from datacube.utils.geometry import GeoBox
+
+class StatsPluginInterface(ABC):
+    NAME = "*unset*"
+    SHORT_NAME = ""
+    VERSION = "0.0.0"
+    PRODUCT_FAMILY = "statistics"
+
+    @property
+    @abstractmethod
+    def measurements(self) -> Tuple[str, ...]:
+        pass
+
+    @abstractmethod
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
+        pass
+
+    @abstractmethod
+    def reduce(self, xx: xr.Dataset) -> xr.Dataset:
+        pass
+
+    def rgba(self, xx: xr.Dataset) -> Optional[xr.DataArray]:
+        """
+        Given result of ``.reduce(..)`` optionally produce RGBA preview image
+        """
+        return None
+
 
 PluginFactory = Callable[..., StatsPluginInterface]
 
@@ -50,3 +79,4 @@ def import_all():
             importlib.import_module(mod)
         except ModuleNotFoundError:
             pass
+

--- a/libs/stats/odc/stats/plugins/_registry.py
+++ b/libs/stats/odc/stats/plugins/_registry.py
@@ -1,0 +1,54 @@
+import pydoc
+from typing import Callable, Dict, Type
+from functools import partial
+
+from ._base import StatsPluginInterface
+
+
+PluginFactory = Callable[..., StatsPluginInterface]
+
+_plugins: Dict[str, PluginFactory] = {}
+
+
+def _new(plugin_class, *args, **kwargs) -> StatsPluginInterface:
+    return plugin_class(*args, **kwargs)
+
+
+def resolve(name: str) -> PluginFactory:
+    maker = _plugins.get(name)
+    if maker is None:
+        maker = pydoc.locate(name)
+        if maker is not None:
+            if not issubclass(maker, (StatsPluginInterface,)):
+                raise ValueError(f"Custom StatsPlugin '{name}' is not derived from StatsPluginInterface")
+            return partial(_new, maker)
+
+    if maker is None:
+        raise ValueError(f"Failed to resolved named plugin: '{name}'")
+    return maker
+
+
+def register(name: str, plugin_class: Type[StatsPluginInterface]):
+    _plugins[name] = partial(_new, plugin_class)
+
+
+def import_all():
+    import importlib
+
+    # TODO: make that more automatic
+    modules = [
+        "odc.stats.plugins.fc_percentiles",
+        "odc.stats.plugins.tcw_percentiles",
+        "odc.stats.plugins.gm",
+        "odc.stats.plugins.gm_ls_bitmask",
+        "odc.stats.plugins.pq",
+        "odc.stats.plugins.pq_bitmask",
+        "odc.stats.plugins.wofs",
+    ]
+
+    for mod in modules:
+        try:
+            importlib.import_module(mod)
+        except ModuleNotFoundError:
+            pass
+

--- a/libs/stats/odc/stats/plugins/fc_percentiles.py
+++ b/libs/stats/odc/stats/plugins/fc_percentiles.py
@@ -2,11 +2,12 @@
 Fractional Cover Percentiles
 """
 from functools import partial
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 from itertools import product
 import xarray as xr
 import numpy as np
-from odc.stats.model import Task
+from datacube.model import Dataset
+from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
@@ -69,14 +70,13 @@ class StatsFCP(StatsPluginInterface):
         xx["wet"] = _xr_fuse(wet, _fuse_or_np, wet.name) & all_bands_invalid
         return xx
     
-    def input_data(self, task: Task) -> xr.Dataset:
-
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         chunks = {"y": -1, "x": -1}
 
         xx = load_with_native_transform(
-            task.datasets,
+            datasets,
             bands=["water", "pv", "bs", "npv"],
-            geobox=task.geobox,
+            geobox=geobox,
             native_transform=self._native_tr,
             fuser=self._fuser,
             groupby="solar_day",

--- a/libs/stats/odc/stats/plugins/fc_percentiles.py
+++ b/libs/stats/odc/stats/plugins/fc_percentiles.py
@@ -12,7 +12,7 @@ from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
 from odc.algo._masking import _xr_fuse, _or_fuser, _fuse_mean_np, _fuse_or_np
-from ._base import StatsPluginInterface, register
+from ._registry import StatsPluginInterface, register
 
 NODATA = 255
 

--- a/libs/stats/odc/stats/plugins/fc_percentiles.py
+++ b/libs/stats/odc/stats/plugins/fc_percentiles.py
@@ -12,8 +12,7 @@ from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
 from odc.algo._masking import _xr_fuse, _or_fuser, _fuse_mean_np, _fuse_or_np
-from odc.stats.model import StatsPluginInterface
-from ._base import register
+from ._base import StatsPluginInterface, register
 
 NODATA = 255
 

--- a/libs/stats/odc/stats/plugins/gm.py
+++ b/libs/stats/odc/stats/plugins/gm.py
@@ -8,8 +8,7 @@ from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
 from odc.algo import erase_bad, geomedian_with_mads, to_rgba
 from odc.algo.io import load_enum_filtered
-from odc.stats.model import StatsPluginInterface
-from ._base import register
+from ._base import StatsPluginInterface, register
 
 
 class StatsGM(StatsPluginInterface):

--- a/libs/stats/odc/stats/plugins/gm.py
+++ b/libs/stats/odc/stats/plugins/gm.py
@@ -1,9 +1,10 @@
 """
 Geomedian
 """
-from typing import Optional, Tuple, Iterable
+from typing import Optional, Sequence, Tuple, Iterable
 import xarray as xr
-from odc.stats.model import Task
+from datacube.model import Dataset
+from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
 from odc.algo import erase_bad, geomedian_with_mads, to_rgba
 from odc.algo.io import load_enum_filtered
@@ -72,15 +73,15 @@ class StatsGM(StatsPluginInterface):
 
         return xx
 
-    def input_data(self, task: Task) -> xr.Dataset:
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         basis = self._basis_band
         chunks = {"y": -1, "x": -1}
         groupby = "solar_day"
 
         erased = load_enum_filtered(
-            task.datasets,
+            datasets,
             self._mask_band,
-            task.geobox,
+            geobox,
             categories=self.cloud_classes,
             filters=self.filters,
             groupby=groupby,
@@ -95,9 +96,9 @@ class StatsGM(StatsPluginInterface):
             bands_to_load = (*bands_to_load, self._mask_band)
 
         xx = load_with_native_transform(
-            task.datasets,
+            datasets,
             bands_to_load,
-            task.geobox,
+            geobox,
             self._native_op_data_band,
             groupby=groupby,
             basis=basis,

--- a/libs/stats/odc/stats/plugins/gm.py
+++ b/libs/stats/odc/stats/plugins/gm.py
@@ -8,7 +8,7 @@ from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
 from odc.algo import erase_bad, geomedian_with_mads, to_rgba
 from odc.algo.io import load_enum_filtered
-from ._base import StatsPluginInterface, register
+from ._registry import StatsPluginInterface, register
 
 
 class StatsGM(StatsPluginInterface):

--- a/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
@@ -12,8 +12,7 @@ from datacube.utils import masking
 from odc.algo import geomedian_with_mads, keep_good_only, erase_bad
 from odc.algo._masking import _xr_fuse, _first_valid_np, mask_cleanup, _fuse_or_np
 from odc.algo.io import load_with_native_transform
-from odc.stats.model import StatsPluginInterface
-from ._base import register
+from ._base import StatsPluginInterface, register
 
 class StatsGMLSBitmask(StatsPluginInterface):
     NAME = "gm_ls_bitmask"

--- a/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
@@ -2,16 +2,17 @@
 Landsat QA Pixel Geomedian
 """
 from functools import partial
-from typing import Dict, Optional, Tuple, Any, Iterable
+from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
 
 import xarray as xr
 import numpy as np
+from datacube.model import Dataset
+from datacube.utils.geometry import GeoBox
 from datacube.utils import masking
 from odc.algo import geomedian_with_mads, keep_good_only, erase_bad
 from odc.algo._masking import _xr_fuse, _first_valid_np, mask_cleanup, _fuse_or_np
 from odc.algo.io import load_with_native_transform
 from odc.stats.model import StatsPluginInterface
-from odc.stats.model import Task
 from ._base import register
 
 class StatsGMLSBitmask(StatsPluginInterface):
@@ -121,14 +122,13 @@ class StatsGMLSBitmask(StatsPluginInterface):
 
         return xx
 
-    def input_data(self, task: Task) -> xr.Dataset:
-
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         chunks = {"y": -1, "x": -1}
 
         xx = load_with_native_transform(
-            task.datasets,
+            datasets,
             bands=self.bands + [self.mask_band],
-            geobox=task.geobox,
+            geobox=geobox,
             native_transform=self._native_tr,
             fuser=self._fuser,
             groupby="solar_day",

--- a/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
@@ -12,7 +12,7 @@ from datacube.utils import masking
 from odc.algo import geomedian_with_mads, keep_good_only, erase_bad
 from odc.algo._masking import _xr_fuse, _first_valid_np, mask_cleanup, _fuse_or_np
 from odc.algo.io import load_with_native_transform
-from ._base import StatsPluginInterface, register
+from ._registry import StatsPluginInterface, register
 
 class StatsGMLSBitmask(StatsPluginInterface):
     NAME = "gm_ls_bitmask"

--- a/libs/stats/odc/stats/plugins/pq.py
+++ b/libs/stats/odc/stats/plugins/pq.py
@@ -2,17 +2,17 @@
 Sentinel 2 pixel quality stats
 """
 from functools import partial
-from typing import Dict, Optional, Tuple, cast, Iterable
+from typing import Dict, Iterable, Optional, Sequence, Tuple, cast
 
 import xarray as xr
-
+from datacube.model import Dataset
+from datacube.utils.geometry import GeoBox
 from odc.algo import enum_to_bool, mask_cleanup
 from odc.algo._masking import _or_fuser
 from odc.algo.io import load_with_native_transform
-from odc.stats.model import Task
 
 from odc.stats.model import StatsPluginInterface
-from ._base import register, resolve
+from ._base import register
 
 cloud_classes = (
     "cloud shadows",
@@ -55,7 +55,7 @@ class StatsPQ(StatsPluginInterface):
 
         return tuple(measurements)
 
-    def input_data(self, task: Task) -> xr.Dataset:
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         """
         .valid           Bool
         .erased          Bool
@@ -65,9 +65,9 @@ class StatsPQ(StatsPluginInterface):
         resampling = self.resampling
 
         return load_with_native_transform(
-            task.datasets,
+            datasets,
             ["SCL"],
-            task.geobox,
+            geobox,
             _pq_native_transform,
             groupby="solar_day",
             resampling=resampling,

--- a/libs/stats/odc/stats/plugins/pq.py
+++ b/libs/stats/odc/stats/plugins/pq.py
@@ -11,8 +11,7 @@ from odc.algo import enum_to_bool, mask_cleanup
 from odc.algo._masking import _or_fuser
 from odc.algo.io import load_with_native_transform
 
-from odc.stats.model import StatsPluginInterface
-from ._base import register
+from ._base import StatsPluginInterface, register
 
 cloud_classes = (
     "cloud shadows",

--- a/libs/stats/odc/stats/plugins/pq.py
+++ b/libs/stats/odc/stats/plugins/pq.py
@@ -11,7 +11,7 @@ from odc.algo import enum_to_bool, mask_cleanup
 from odc.algo._masking import _or_fuser
 from odc.algo.io import load_with_native_transform
 
-from ._base import StatsPluginInterface, register
+from ._registry import StatsPluginInterface, register
 
 cloud_classes = (
     "cloud shadows",

--- a/libs/stats/odc/stats/plugins/pq_bitmask.py
+++ b/libs/stats/odc/stats/plugins/pq_bitmask.py
@@ -44,7 +44,7 @@ from odc.algo.io import load_with_native_transform
 from odc.stats.model import Task
 
 from odc.stats.model import StatsPluginInterface
-from ._base import register
+from ._registry import register
 
 
 class StatsPQLSBitmask(StatsPluginInterface):

--- a/libs/stats/odc/stats/plugins/tcw_percentiles.py
+++ b/libs/stats/odc/stats/plugins/tcw_percentiles.py
@@ -11,7 +11,7 @@ from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
 from odc.algo._masking import _xr_fuse, _fuse_mean_np, enum_to_bool
-from ._base import StatsPluginInterface, register
+from ._registry import StatsPluginInterface, register
 
 NODATA = -9999 # output NODATA
 

--- a/libs/stats/odc/stats/plugins/tcw_percentiles.py
+++ b/libs/stats/odc/stats/plugins/tcw_percentiles.py
@@ -11,8 +11,7 @@ from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
 from odc.algo._masking import _xr_fuse, _fuse_mean_np, enum_to_bool
-from odc.stats.model import StatsPluginInterface
-from ._base import register
+from ._base import StatsPluginInterface, register
 
 NODATA = -9999 # output NODATA
 

--- a/libs/stats/odc/stats/plugins/tcw_percentiles.py
+++ b/libs/stats/odc/stats/plugins/tcw_percentiles.py
@@ -2,10 +2,11 @@
 Fractional Cover Percentiles
 """
 from functools import partial
-from typing import Optional, Tuple, Dict
+from typing import Optional, Sequence, Tuple, Dict
 import xarray as xr
 import numpy as np
-from odc.stats.model import Task
+from datacube.model import Dataset
+from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
@@ -66,14 +67,13 @@ class StatsTCWPC(StatsPluginInterface):
 
         return xx
     
-    def input_data(self, task: Task) -> xr.Dataset:
-
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         chunks = {"y": -1, "x": -1}
 
         xx = load_with_native_transform(
-            task.datasets,
+            datasets,
             bands=["blue", "green", "red", "nir", "swir1", "swir2", "fmask", "nbart_contiguity"],
-            geobox=task.geobox,
+            geobox=geobox,
             native_transform=self._native_tr,
             fuser=self._fuser,
             groupby="solar_day",

--- a/libs/stats/odc/stats/plugins/wofs.py
+++ b/libs/stats/odc/stats/plugins/wofs.py
@@ -22,8 +22,7 @@ from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
 from odc.algo import safe_div, apply_numexpr, keep_good_only, binary_dilation
 from odc.algo.io import dc_load
-from odc.stats.model import StatsPluginInterface
-from ._base import register
+from ._base import StatsPluginInterface, register
 
 
 class StatsWofs(StatsPluginInterface):

--- a/libs/stats/odc/stats/plugins/wofs.py
+++ b/libs/stats/odc/stats/plugins/wofs.py
@@ -22,7 +22,7 @@ from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
 from odc.algo import safe_div, apply_numexpr, keep_good_only, binary_dilation
 from odc.algo.io import dc_load
-from ._base import StatsPluginInterface, register
+from ._registry import StatsPluginInterface, register
 
 
 class StatsWofs(StatsPluginInterface):

--- a/libs/stats/odc/stats/plugins/wofs.py
+++ b/libs/stats/odc/stats/plugins/wofs.py
@@ -14,10 +14,11 @@ individual water observations, and the second generates a summary of summaries, 
 of time summary from existing annual summaries.
 
 """
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 import numpy as np
 import xarray as xr
-from odc.stats.model import Task
+from datacube.model import Dataset
+from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
 from odc.algo import safe_div, apply_numexpr, keep_good_only, binary_dilation
 from odc.algo.io import dc_load
@@ -124,14 +125,14 @@ class StatsWofs(StatsPluginInterface):
 
         return xr.Dataset(dict(wet=wet, dry=dry, bad=xx.bad, some=xx.some))
 
-    def input_data(self, task: Task) -> xr.Dataset:
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         chunks = {"y": -1, "x": -1}
         groupby = "solar_day"
 
         xx = load_with_native_transform(
-            task.datasets,
+            datasets,
             bands=["water"],
-            geobox=task.geobox,
+            geobox=geobox,
             native_transform=self._native_tr,
             fuser=self._fuser,
             groupby=groupby,
@@ -195,11 +196,11 @@ class StatsWofsFullHistory(StatsPluginInterface):
     def measurements(self) -> Tuple[str, ...]:
         return "count_wet", "count_clear", "frequency"
 
-    def input_data(self, task: Task) -> xr.Dataset:
+    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         return dc_load(
-            task.datasets,
+            datasets,
             measurements=["count_wet", "count_clear"],
-            geobox=task.geobox,
+            geobox=geobox,
             chunks={},
         )
 

--- a/libs/stats/odc/stats/proc.py
+++ b/libs/stats/odc/stats/proc.py
@@ -203,7 +203,7 @@ class TaskRunner:
                     continue
 
             _log.debug("Building Dask Graph")
-            ds = proc.reduce(proc.input_data(task))
+            ds = proc.reduce(proc.input_data(task.datasets, task.geobox))
 
             _log.debug(f"Submitting to Dask ({task.location})")
             ds = client.persist(ds, fifo_timeout="1ms")

--- a/libs/stats/tests/__init__.py
+++ b/libs/stats/tests/__init__.py
@@ -8,7 +8,7 @@ import xarray as xr
 import dask.array as da
 import numpy as np
 from odc.stats.utils import CompressedDataset
-from odc.stats.model import StatsPluginInterface
+from odc.stats.plugins import StatsPluginInterface
 
 
 class DummyPlugin(StatsPluginInterface):

--- a/libs/stats/tests/__init__.py
+++ b/libs/stats/tests/__init__.py
@@ -27,10 +27,10 @@ class DummyPlugin(StatsPluginInterface):
     def measurements(self):
         return self._bands
 
-    def input_data(self, task):
-        ts = sorted([ds.center_time for ds in task.datasets])
+    def input_data(self, datasets, geobox):
+        ts = sorted([ds.center_time for ds in datasets])
         xx = mk_dask_xx(
-            task.geobox,
+            geobox,
             timestamps=ts,
             mode="random",
             attrs=dict(nodata=self._nodata),


### PR DESCRIPTION
Changed `StatsPluginInterface` API so it is independent of the (rest of the) `stats.model` layer.

Moved `StatsPluginInterface` to `plugins._base`, and moved the plugin registry code to a new module `plugins._registry`.

All plugin-related code is now cleanly isolated in the `stats.plugins` package, which has no internal dependencies on the rest of `odc.stats`.