### PR TITLE
Add wo seasonal option to save-task

### DIFF
--- a/libs/stats/odc/stats/_cli_save_tasks.py
+++ b/libs/stats/odc/stats/_cli_save_tasks.py
@@ -35,7 +35,7 @@ from itertools import groupby
 @click.option(
     "--frequency",
     type=str,
-    help="Specify temporal binning: annual|annual-fy|semiannual|seasonal|all",
+    help="Specify temporal binning: annual|annual-fy|semiannual|seasonal|nov-mar|apr-oct|all",
 )
 @click.option("--env", "-E", type=str, help="Datacube environment name")
 @click.option(
@@ -120,8 +120,8 @@ def save_tasks(
         temporal_range = DateTimeRange.year(year)
 
     if frequency is not None:
-        if frequency not in ("annual", "annual-fy", "semiannual", "seasonal", "all"):
-            print(f"Frequency must be one of annual|annual-fy|semiannual|seasonal|all and not '{frequency}'")
+        if frequency not in ("annual", "annual-fy", "semiannual", "seasonal", "nov-mar", "apr-oct", "all"):
+            print(f"Frequency must be one of annual|annual-fy|semiannual|seasonal|nov-mar|apr-oct|all and not '{frequency}'")
             sys.exit(1)
 
     dc = Datacube(env=env)

--- a/libs/stats/odc/stats/tasks.py
+++ b/libs/stats/odc/stats/tasks.py
@@ -29,7 +29,7 @@ from itertools import chain
 
 from .model import DateTimeRange, Task, OutputProduct, TileIdx, TileIdx_txy, TileIdx_xy
 from ._gjson import gs_bounds, compute_grid_info, gjson_from_tasks
-from .utils import bin_annual, bin_full_history, bin_generic, bin_seasonal
+from .utils import bin_annual, bin_full_history, bin_generic, bin_seasonal, bin_apr_oct, bin_nov_mar
 
 TilesRange2d = Tuple[Tuple[int, int], Tuple[int, int]]
 CompressedDataset = namedtuple("CompressedDataset", ["id", "time"])
@@ -321,6 +321,10 @@ class SaveTasks:
                 tasks = bin_seasonal(cells, months=6, anchor=1)
             elif self._frequency == "seasonal":
                 tasks = bin_seasonal(cells, months=3, anchor=12)
+            elif self._frequency == "nov-mar":
+                tasks = bin_nov_mar(cells)
+            elif self._frequency == "apr-oct":
+                tasks = bin_apr_oct(cells)
             elif self._frequency == "annual-fy":
                 tasks = bin_seasonal(cells, months=12, anchor=7)
             elif self._frequency == "annual":


### PR DESCRIPTION
From WO summary product definition doc, we have two seasonal summary, and their ranges are: Nov to Mar, and Apr to Oct. It is easy to know their lengths are 5 monthes and 7 monthes. These cases cannot be handled by the existing CLI if we try to cache multi-year task.

Therefore, add two WO seasonal ranges as frequency options to `save-task` module.

The new save-tasks output samples can be found:

* http://dea-public-data-dev.s3-website-ap-southeast-2.amazonaws.com/?prefix=ga_ls_wo_fq_nov_mar_3/dbs/. The CSV file is [here](https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/ga_ls_wo_fq_nov_mar_3/dbs/ga_ls_wo_3_2010--P2Y-11--P5M.db.csv)
* http://dea-public-data-dev.s3-website-ap-southeast-2.amazonaws.com/?prefix=ga_ls_wo_fq_apr_oct_3/dbs/. The CSV file is [here](https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/ga_ls_wo_fq_apr_oct_3/dbs/ga_ls_wo_3_2010--P2Y-04--P7M.csv)