### PR TITLE
Stats plugins refactor

### DIFF
--- a/libs/stats/odc/stats/plugins/_base.py
+++ b/libs/stats/odc/stats/plugins/_base.py
@@ -4,6 +4,7 @@ from typing import Tuple, Sequence, Optional
 import xarray as xr
 from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
+from odc.algo import to_rgba
 
 
 class StatsPluginInterface(ABC):
@@ -11,6 +12,10 @@ class StatsPluginInterface(ABC):
     SHORT_NAME = ""
     VERSION = "0.0.0"
     PRODUCT_FAMILY = "statistics"
+
+    def __init__(self, rgb_bands=None, rgb_clamp=[1, 3_000]):
+        self.rgb_bands = rgb_bands
+        self.rgb_clamp = rgb_clamp
 
     @property
     @abstractmethod
@@ -29,4 +34,6 @@ class StatsPluginInterface(ABC):
         """
         Given result of ``.reduce(..)`` optionally produce RGBA preview image
         """
-        return None
+        if self.rgb_bands is None:
+            return None
+        return to_rgba(xx, clamp=self.rgb_clamp, bands=self.reg_bands)

--- a/libs/stats/odc/stats/plugins/_base.py
+++ b/libs/stats/odc/stats/plugins/_base.py
@@ -7,9 +7,6 @@ from datacube.utils.geometry import GeoBox
 from odc.algo import to_rgba
 from odc.algo.io import load_with_native_transform
 
-NODATA = -9999 # output NODATA
-
-
 
 class StatsPluginInterface(ABC):
     NAME = "*unset*"

--- a/libs/stats/odc/stats/plugins/fc_percentiles.py
+++ b/libs/stats/odc/stats/plugins/fc_percentiles.py
@@ -27,7 +27,9 @@ class StatsFCP(StatsPluginInterface):
     def __init__(
         self,
         resampling: str = "bilinear",
+        **kwargs
     ):
+        super().__init__(**kwargs)
         self.resampling = resampling
 
     @property

--- a/libs/stats/odc/stats/plugins/fc_percentiles.py
+++ b/libs/stats/odc/stats/plugins/fc_percentiles.py
@@ -107,8 +107,5 @@ class StatsFCP(StatsPluginInterface):
         yy["qa"] = 1 + all_bands_valid - is_ever_wet * (1 - all_bands_valid)
         return yy
 
-    def rgba(self, xx: xr.Dataset) -> Optional[xr.DataArray]:
-        return None
-
 
 register("fc-percentiles", StatsFCP)

--- a/libs/stats/odc/stats/plugins/gm.py
+++ b/libs/stats/odc/stats/plugins/gm.py
@@ -6,7 +6,7 @@ import xarray as xr
 from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
 from odc.algo.io import load_with_native_transform
-from odc.algo import erase_bad, geomedian_with_mads, to_rgba
+from odc.algo import erase_bad, geomedian_with_mads
 from odc.algo.io import load_enum_filtered
 from ._registry import StatsPluginInterface, register
 
@@ -126,11 +126,6 @@ class StatsGM(StatsPluginInterface):
         gm = gm.rename(self._renames)
 
         return gm
-
-    def rgba(self, xx: xr.Dataset) -> Optional[xr.DataArray]:
-        if self.rgb_bands is None:
-            return None
-        return to_rgba(xx, clamp=self.rgb_clamp, bands=self.rgb_bands)
 
 
 register("gm-generic", StatsGM)

--- a/libs/stats/odc/stats/plugins/gm.py
+++ b/libs/stats/odc/stats/plugins/gm.py
@@ -26,11 +26,11 @@ class StatsGM(StatsPluginInterface):
         filters: Optional[Iterable[Tuple[str, int]]] = None,
         basis_band=None,
         aux_names=dict(smad="smad", emad="emad", bcmad="bcmad", count="count"),
-        rgb_bands=None,
-        rgb_clamp=(1, 3_000),
         resampling: str = "bilinear",
         work_chunks: Tuple[int, int] = (400, 400),
+        **kwargs,
     ):
+        super().__init__(**kwargs)
         self.bands = tuple(bands)
         self._basis_band = basis_band or self.bands[0]
 
@@ -46,8 +46,6 @@ class StatsGM(StatsPluginInterface):
         self.aux_bands = tuple(
             self._renames.get(k, k) for k in ("smad", "emad", "bcmad", "count")
         )
-        self.rgb_bands = rgb_bands
-        self.rgb_clamp = rgb_clamp
 
         self.resampling = resampling
         self._work_chunks = work_chunks
@@ -151,11 +149,10 @@ class StatsGMS2(StatsGM):
         filters: Optional[Iterable[Tuple[str, int]]] = [("opening", 2), ("dilation",5)],
         basis_band: Optional[str] = None,
         aux_names=dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT"),
-        rgb_bands=None,
-        rgb_clamp=(1, 3_000),
         resampling: str = "bilinear",
         work_chunks: Tuple[int, int] = (400, 400),
-        **other,
+        rgb_bands=None,
+        **kwargs
     ):
         if bands is None:
             bands = (
@@ -181,11 +178,10 @@ class StatsGMS2(StatsGM):
             filters=filters,
             basis_band=basis_band,
             aux_names=aux_names,
-            rgb_bands=rgb_bands,
-            rgb_clamp=rgb_clamp,
             resampling=resampling,
             work_chunks=work_chunks,
-            **other,
+            rgb_bands=rgb_bands,
+            **kwargs
         )
 
 
@@ -211,7 +207,7 @@ class StatsGMLS(StatsGM):
         rgb_clamp=(1, 3_000),
         resampling: str = "bilinear",
         work_chunks: Tuple[int, int] = (400, 400),
-        **other,
+        **kwargs
     ):
         if bands is None:
             bands = (
@@ -234,10 +230,9 @@ class StatsGMLS(StatsGM):
             basis_band=basis_band,
             aux_names=aux_names,
             rgb_bands=rgb_bands,
-            rgb_clamp=rgb_clamp,
             resampling=resampling,
             work_chunks=work_chunks,
-            **other,
+            **kwargs,
         )
 
 

--- a/libs/stats/odc/stats/plugins/gm.py
+++ b/libs/stats/odc/stats/plugins/gm.py
@@ -5,7 +5,6 @@ from typing import Optional, Sequence, Tuple, Iterable
 import xarray as xr
 from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
-from odc.algo.io import load_with_native_transform
 from odc.algo import erase_bad, geomedian_with_mads
 from odc.algo.io import load_enum_filtered
 from ._registry import StatsPluginInterface, register
@@ -26,20 +25,26 @@ class StatsGM(StatsPluginInterface):
         filters: Optional[Iterable[Tuple[str, int]]] = None,
         basis_band=None,
         aux_names=dict(smad="smad", emad="emad", bcmad="bcmad", count="count"),
-        resampling: str = "bilinear",
         work_chunks: Tuple[int, int] = (400, 400),
         **kwargs,
     ):
-        super().__init__(**kwargs)
         self.bands = tuple(bands)
-        self._basis_band = basis_band or self.bands[0]
+        self._mask_band = mask_band
+        self._nodata_classes = nodata_classes
+        input_bands = self.bands
+        if self._nodata_classes is not None:
+            # NOTE: this ends up loading Mask band twice, once to compute
+            # ``.erase`` band and once to compute ``nodata`` mask.
+            input_bands = (*input_bands, self._mask_band)
+        super().__init__(
+            input_bands=input_bands,
+            basis=basis_band or self.bands[0],
+            **kwargs)
 
         if nodata_classes is not None:
             nodata_classes = tuple(nodata_classes)
 
-        self._mask_band = mask_band
         self.cloud_classes = tuple(cloud_classes)
-        self._nodata_classes = nodata_classes
         self.filters = filters
 
         self._renames = aux_names
@@ -47,14 +52,13 @@ class StatsGM(StatsPluginInterface):
             self._renames.get(k, k) for k in ("smad", "emad", "bcmad", "count")
         )
 
-        self.resampling = resampling
         self._work_chunks = work_chunks
 
     @property
     def measurements(self) -> Tuple[str, ...]:
         return self.bands + self.aux_bands
 
-    def _native_op_data_band(self, xx):
+    def native_transform(self, xx: xr.Dataset) -> xr.Dataset:
         from odc.algo import enum_to_bool, keep_good_only
 
         if not self._mask_band in xx.data_vars:
@@ -71,38 +75,17 @@ class StatsGM(StatsPluginInterface):
         return xx
 
     def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
-        basis = self._basis_band
-        chunks = {"y": -1, "x": -1}
-        groupby = "solar_day"
-
         erased = load_enum_filtered(
             datasets,
             self._mask_band,
             geobox,
             categories=self.cloud_classes,
             filters=self.filters,
-            groupby=groupby,
+            groupby=self.groupby,
             resampling=self.resampling,
             chunks={},
         )
-
-        bands_to_load = self.bands
-        if self._nodata_classes is not None:
-            # NOTE: this ends up loading Mask band twice, once to compute
-            # ``.erase`` band and once to compute ``nodata`` mask.
-            bands_to_load = (*bands_to_load, self._mask_band)
-
-        xx = load_with_native_transform(
-            datasets,
-            bands_to_load,
-            geobox,
-            self._native_op_data_band,
-            groupby=groupby,
-            basis=basis,
-            resampling=self.resampling,
-            chunks=chunks,
-        )
-
+        xx = super.input_data(datasets, geobox)
         xx = erase_bad(xx, erased)
         return xx
 
@@ -145,12 +128,8 @@ class StatsGMS2(StatsGM):
             "cloud high probability",
             "thin cirrus",
         ),
-        nodata_classes: Optional[Tuple[str, ...]] = None,
         filters: Optional[Iterable[Tuple[str, int]]] = [("opening", 2), ("dilation",5)],
-        basis_band: Optional[str] = None,
         aux_names=dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT"),
-        resampling: str = "bilinear",
-        work_chunks: Tuple[int, int] = (400, 400),
         rgb_bands=None,
         **kwargs
     ):
@@ -174,12 +153,8 @@ class StatsGMS2(StatsGM):
             bands=bands,
             mask_band=mask_band,
             cloud_classes=cloud_classes,
-            nodata_classes=nodata_classes,
             filters=filters,
-            basis_band=basis_band,
             aux_names=aux_names,
-            resampling=resampling,
-            work_chunks=work_chunks,
             rgb_bands=rgb_bands,
             **kwargs
         )
@@ -200,13 +175,8 @@ class StatsGMLS(StatsGM):
         mask_band: str = "fmask",
         cloud_classes: Tuple[str, ...] = ("cloud", "shadow"),
         nodata_classes: Optional[Tuple[str, ...]] = ("nodata",),
-        filters: Optional[Iterable[Tuple[str, int]]] = None,
-        basis_band: Optional[str] = None,
         aux_names=dict(smad="sdev", emad="edev", bcmad="bcdev", count="count"),
         rgb_bands=None,
-        rgb_clamp=(1, 3_000),
-        resampling: str = "bilinear",
-        work_chunks: Tuple[int, int] = (400, 400),
         **kwargs
     ):
         if bands is None:
@@ -226,12 +196,8 @@ class StatsGMLS(StatsGM):
             mask_band=mask_band,
             cloud_classes=cloud_classes,
             nodata_classes=nodata_classes,
-            filters=filters,
-            basis_band=basis_band,
             aux_names=aux_names,
             rgb_bands=rgb_bands,
-            resampling=resampling,
-            work_chunks=work_chunks,
             **kwargs,
         )
 

--- a/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
@@ -35,7 +35,17 @@ class StatsGMLSBitmask(StatsPluginInterface):
             output_dtype: str = "uint16", # dtype of gm rescaling
             **kwargs,
     ):
-        self.bands = tuple(bands)
+        if bands is None:
+            self.bands = (
+                "red",
+                "green",
+                "blue",
+                "nir",
+                "swir_1",
+                "swir_2",
+            )
+        else:
+            self.bands = bands
         self.mask_band = mask_band
         super().__init__(input_bands=tuple(bands) + (mask_band,), **kwargs)
         self.flags = flags
@@ -49,16 +59,6 @@ class StatsGMLSBitmask(StatsPluginInterface):
         self.output_scale = output_scale
         self.output_dtype = np.dtype(output_dtype)
         self.output_nodata = 0
-
-        if self.bands is None:
-            self.bands = (
-                "red",
-                "green",
-                "blue",
-                "nir",
-                "swir_1",
-                "swir_2",
-            )
 
     @property
     def measurements(self) -> Tuple[str, ...]:

--- a/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
@@ -189,8 +189,5 @@ class StatsGMLSBitmask(StatsPluginInterface):
 
         return xx
 
-    def rgba(self, xx: xr.Dataset) -> Optional[xr.DataArray]:
-        return None
-
 
 register("gm-ls-bitmask", StatsGMLSBitmask)

--- a/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
+++ b/libs/stats/odc/stats/plugins/gm_ls_bitmask.py
@@ -37,8 +37,9 @@ class StatsGMLSBitmask(StatsPluginInterface):
             offset: float = -0.2,
             output_scale: int = 10000, # gm rescaling - making SR range match sentinel-2 gm
             output_dtype: str = "uint16", # dtype of gm rescaling
-            **other,
+            **kwargs,
     ):
+        super().__init__(**kwargs)
         self.mask_band = mask_band
         self.resampling = resampling
         self.bands = bands

--- a/libs/stats/odc/stats/plugins/pq.py
+++ b/libs/stats/odc/stats/plugins/pq.py
@@ -1,15 +1,11 @@
 """
 Sentinel 2 pixel quality stats
 """
-from functools import partial
-from typing import Dict, Iterable, Optional, Sequence, Tuple, cast
+from typing import Dict, Iterable, Optional, Tuple, cast
 
 import xarray as xr
-from datacube.model import Dataset
-from datacube.utils.geometry import GeoBox
 from odc.algo import enum_to_bool, mask_cleanup
 from odc.algo._masking import _or_fuser
-from odc.algo.io import load_with_native_transform
 
 from ._registry import StatsPluginInterface, register
 
@@ -40,11 +36,10 @@ class StatsPQ(StatsPluginInterface):
         resampling: str = "nearest",
         **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(input_bands=["SCL"], resampling=resampling, **kwargs)
         if filters is None:
             filters = default_filters
         self.filters = filters
-        self.resampling = resampling
 
     @property
     def measurements(self) -> Tuple[str, ...]:
@@ -56,24 +51,41 @@ class StatsPQ(StatsPluginInterface):
 
         return tuple(measurements)
 
-    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
+    def fuser(self, xx: xr.Dataset) -> xr.Dataset:
         """
-        .valid           Bool
-        .erased          Bool
-        .erased{postfix} Bool
-        """
-        filters = self.filters
-        resampling = self.resampling
+        Native:
+          .valid    -> .valid  (fuse with OR)
+          .erased   -> .erased (fuse with OR)
+                    -> .erased{postfix} for All Filters (mask_cleanup applied post-fusing)
+        Projected:
+         fuse all bands with OR
 
-        return load_with_native_transform(
-            datasets,
-            ["SCL"],
-            geobox,
-            _pq_native_transform,
-            groupby="solar_day",
-            resampling=resampling,
-            fuser=partial(_pq_fuser, filters=filters),
-            chunks={"x": -1, "y": -1},
+        """
+        is_native = xx.attrs.get("native", False)
+        xx = xx.map(_or_fuser)
+        xx.attrs.pop("native", None)
+
+        if is_native:
+            for band, mask_filters in self.filters.items():
+                erased_filter_band_name = band.replace("clear", "erased")
+                xx[erased_filter_band_name] = mask_cleanup(xx["erased"], mask_filters=mask_filters)
+
+        return xx
+
+    def native_transform(self, xx: xr.Dataset) -> xr.Dataset:
+        """
+        config:
+        cloud_classes
+
+        .SCL -> .valid   (anything but nodata)
+                .erased  (cloud pixels only)
+        """
+        scl = xx.SCL
+        valid = scl != scl.nodata
+        erased = enum_to_bool(scl, cloud_classes)
+        return xr.Dataset(
+            dict(valid=valid, erased=erased),
+            attrs={"native": True},  # <- native flag needed for fuser
         )
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
@@ -94,48 +106,6 @@ class StatsPQ(StatsPluginInterface):
             pq[clear_name] = clear.sum(axis=0, dtype="uint16")
 
         return pq
-
-
-def _pq_native_transform(xx: xr.Dataset) -> xr.Dataset:
-    """
-    config:
-    cloud_classes
-
-    .SCL -> .valid   (anything but nodata)
-            .erased  (cloud pixels only)
-    """
-    scl = xx.SCL
-    valid = scl != scl.nodata
-    erased = enum_to_bool(scl, cloud_classes)
-    return xr.Dataset(
-        dict(valid=valid, erased=erased),
-        attrs={"native": True},  # <- native flag needed for fuser
-    )
-
-
-def _pq_fuser(
-    xx: xr.Dataset,
-    filters: Optional[Dict[str, Iterable[Tuple[str, int]]]] = None
-) -> xr.Dataset:
-    """
-    Native:
-      .valid    -> .valid  (fuse with OR)
-      .erased   -> .erased (fuse with OR)
-                -> .erased{postfix} for All Filters (mask_cleanup applied post-fusing)
-    Projected:
-     fuse all bands with OR
-
-    """
-    is_native = xx.attrs.get("native", False)
-    xx = xx.map(_or_fuser)
-    xx.attrs.pop("native", None)
-
-    if is_native:
-        for band, mask_filters in filters.items():
-            erased_filter_band_name = band.replace("clear", "erased")
-            xx[erased_filter_band_name] = mask_cleanup(xx["erased"], mask_filters=mask_filters)
-
-    return xx
 
 
 register("pq", StatsPQ)

--- a/libs/stats/odc/stats/plugins/pq.py
+++ b/libs/stats/odc/stats/plugins/pq.py
@@ -38,7 +38,9 @@ class StatsPQ(StatsPluginInterface):
         self,
         filters: Optional[Dict[str, Iterable[Tuple[str, int]]]] = None,
         resampling: str = "nearest",
+        **kwargs
     ):
+        super().__init__(**kwargs)
         if filters is None:
             filters = default_filters
         self.filters = filters

--- a/libs/stats/odc/stats/plugins/pq_bitmask.py
+++ b/libs/stats/odc/stats/plugins/pq_bitmask.py
@@ -66,7 +66,9 @@ class StatsPQLSBitmask(StatsPluginInterface):
             filters: Optional[Dict[str, Iterable[Tuple[str, int]]]] = None,
             aerosol_filters: Optional[Dict[str, Iterable[Tuple[str, int]]]] = None,
             resampling: str = "nearest",
+            **kwargs
     ):
+        super().__init__(**kwargs)
         self.pq_band = pq_band
         self.aerosol_band = aerosol_band
         self.flags = flags

--- a/libs/stats/odc/stats/plugins/pq_bitmask.py
+++ b/libs/stats/odc/stats/plugins/pq_bitmask.py
@@ -40,8 +40,6 @@ import xarray as xr
 from datacube.utils import masking
 from odc.algo import mask_cleanup, keep_good_only
 from odc.algo._masking import _xr_fuse, _first_valid_np, _fuse_or_np
-from odc.algo.io import load_with_native_transform
-from odc.stats.model import Task
 
 from odc.stats.model import StatsPluginInterface
 from ._registry import register
@@ -68,14 +66,18 @@ class StatsPQLSBitmask(StatsPluginInterface):
             resampling: str = "nearest",
             **kwargs
     ):
-        super().__init__(**kwargs)
         self.pq_band = pq_band
         self.aerosol_band = aerosol_band
+        input_bands = [self.pq_band]
+        if self.aerosol_band:
+            input_bands.append(self.aerosol_band)
+        super().__init__(
+                         input_bands=input_bands, resampling=resampling,
+                         **kwargs)
         self.flags = flags
         self.nodata_flags = nodata_flags
         self.filters = filters or {}
         self.aerosol_filters = aerosol_filters or {}
-        self.resampling = resampling
 
     @property
     def measurements(self) -> Tuple[str, ...]:
@@ -94,22 +96,6 @@ class StatsPQLSBitmask(StatsPluginInterface):
                 measurements.extend(list(self.aerosol_filters))
 
         return tuple(measurements)
-
-    def input_data(self, task: Task) -> xr.Dataset:
-        bands = [self.pq_band]
-        if self.aerosol_band:
-            bands.append(self.aerosol_band)
-
-        return load_with_native_transform(
-            task.datasets,
-            bands=bands,  # measurements to load
-            geobox=task.geobox,
-            native_transform=self._native_tr,
-            fuser=self._fuser,
-            groupby="solar_day",
-            resampling=self.resampling,
-            chunks={"x": -1, "y": -1},
-        )
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         """
@@ -147,7 +133,7 @@ class StatsPQLSBitmask(StatsPluginInterface):
 
         return pq
 
-    def _native_tr(self, xx: xr.Dataset) -> xr.Dataset:
+    def native_transform(self, xx: xr.Dataset) -> xr.Dataset:
         """
         Loads the data in the native projection and perform transform
         bands:
@@ -190,7 +176,7 @@ class StatsPQLSBitmask(StatsPluginInterface):
 
         return xx
 
-    def _fuser(self, xx: xr.Dataset) -> xr.Dataset:
+    def fuser(self, xx: xr.Dataset) -> xr.Dataset:
         """
         Fuser cloud and aerosol masking bands with OR
         """

--- a/libs/stats/odc/stats/plugins/tcw_percentiles.py
+++ b/libs/stats/odc/stats/plugins/tcw_percentiles.py
@@ -29,7 +29,9 @@ class StatsTCWPC(StatsPluginInterface):
         coefficients: Dict[str, float] = {
             'blue': 0.0315, 'green': 0.2021, 'red': 0.3102, 'nir': 0.1594, 'swir1': -0.6806, 'swir2': -0.6109
             },
+        **kwargs
     ):
+        super().__init__(**kwargs)
         self.resampling = resampling
         self.coefficients = coefficients
 

--- a/libs/stats/odc/stats/plugins/tcw_percentiles.py
+++ b/libs/stats/odc/stats/plugins/tcw_percentiles.py
@@ -88,8 +88,5 @@ class StatsTCWPC(StatsPluginInterface):
         yy = xr_quantile_bands(xx, [0.1, 0.5, 0.9], nodata=NODATA)
         return yy
 
-    def rgba(self, xx: xr.Dataset) -> Optional[xr.DataArray]:
-        return None
-
 
 register("tcw-percentiles", StatsTCWPC)

--- a/libs/stats/odc/stats/plugins/tcw_percentiles.py
+++ b/libs/stats/odc/stats/plugins/tcw_percentiles.py
@@ -5,9 +5,6 @@ from functools import partial
 from typing import Optional, Sequence, Tuple, Dict
 import xarray as xr
 import numpy as np
-from datacube.model import Dataset
-from datacube.utils.geometry import GeoBox
-from odc.algo.io import load_with_native_transform
 from odc.algo import keep_good_only
 from odc.algo._percentile import xr_quantile_bands
 from odc.algo._masking import _xr_fuse, _fuse_mean_np, enum_to_bool
@@ -25,23 +22,21 @@ class StatsTCWPC(StatsPluginInterface):
 
     def __init__(
         self,
-        resampling: str = "bilinear",
         coefficients: Dict[str, float] = {
             'blue': 0.0315, 'green': 0.2021, 'red': 0.3102, 'nir': 0.1594, 'swir1': -0.6806, 'swir2': -0.6109
             },
+        input_bands: Sequence[str] = ["blue", "green", "red", "nir", "swir1", "swir2", "fmask", "nbart_contiguity"],
         **kwargs
     ):
-        super().__init__(**kwargs)
-        self.resampling = resampling
+        super().__init__(input_bands=input_bands, **kwargs)
         self.coefficients = coefficients
 
     @property
     def measurements(self) -> Tuple[str, ...]:
         _measurments = ["wet_pc_10", "wet_pc_50", "wet_pc_90"]
-        _measurments
         return _measurments
 
-    def _native_tr(self, xx):
+    def native_transform(self, xx):
         """
         Loads data in its native projection.
         """
@@ -62,31 +57,13 @@ class StatsTCWPC(StatsPluginInterface):
         return xx
 
     @staticmethod
-    def _fuser(xx):
-
+    def fuser(xx):
         xx = _xr_fuse(xx, partial(_fuse_mean_np, nodata=NODATA), '')
 
         return xx
     
-    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
-        chunks = {"y": -1, "x": -1}
-
-        xx = load_with_native_transform(
-            datasets,
-            bands=["blue", "green", "red", "nir", "swir1", "swir2", "fmask", "nbart_contiguity"],
-            geobox=geobox,
-            native_transform=self._native_tr,
-            fuser=self._fuser,
-            groupby="solar_day",
-            resampling=self.resampling,
-            chunks=chunks,
-        )
-
-        return xx
-
     @staticmethod
     def reduce(xx: xr.Dataset) -> xr.Dataset:
-
         yy = xr_quantile_bands(xx, [0.1, 0.5, 0.9], nodata=NODATA)
         return yy
 

--- a/libs/stats/odc/stats/plugins/wofs.py
+++ b/libs/stats/odc/stats/plugins/wofs.py
@@ -14,7 +14,7 @@ individual water observations, and the second generates a summary of summaries, 
 of time summary from existing annual summaries.
 
 """
-from typing import Optional, Sequence, Tuple
+from typing import Sequence, Tuple
 import numpy as np
 import xarray as xr
 from datacube.model import Dataset
@@ -49,19 +49,17 @@ class StatsWofs(StatsPluginInterface):
 
     def __init__(
         self,
-        resampling: str = "bilinear",
         dilation: int = 0,
         **kwargs
     ):
-        super().__init__(**kwargs)
-        self.resampling = resampling
+        super().__init__(input_bands=["water"], **kwargs)
         self._dilation = dilation  # number of pixels to pad around BAD pixels
 
     @property
     def measurements(self) -> Tuple[str, ...]:
         return "count_wet", "count_clear", "frequency"
 
-    def _native_tr(self, xx):
+    def native_transform(self, xx):
         """
         xx.water -- uint8 classifier bitmask
 
@@ -105,7 +103,7 @@ class StatsWofs(StatsPluginInterface):
         return xx
 
     @staticmethod
-    def _fuser(xx):
+    def fuser(xx):
         """
         xx.bad  -- don't count
         xx.wet  -- is wet
@@ -125,23 +123,6 @@ class StatsWofs(StatsPluginInterface):
         dry = apply_numexpr("dry & (~wet) & (~bad)", xx, dtype="bool")
 
         return xr.Dataset(dict(wet=wet, dry=dry, bad=xx.bad, some=xx.some))
-
-    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
-        chunks = {"y": -1, "x": -1}
-        groupby = "solar_day"
-
-        xx = load_with_native_transform(
-            datasets,
-            bands=["water"],
-            geobox=geobox,
-            native_transform=self._native_tr,
-            fuser=self._fuser,
-            groupby=groupby,
-            resampling=self.resampling,
-            chunks=chunks,
-        )
-
-        return xx
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         nodata = -999
@@ -190,6 +171,9 @@ class StatsWofsFullHistory(StatsPluginInterface):
     VERSION = "1.6.0"
     PRODUCT_FAMILY = "wo_summary"
 
+    def __init__(self, **kwargs):
+        super().__init__(input_bands=['count_wet', 'count_clear'])
+
     @property
     def measurements(self) -> Tuple[str, ...]:
         return "count_wet", "count_clear", "frequency"
@@ -197,7 +181,7 @@ class StatsWofsFullHistory(StatsPluginInterface):
     def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
         return dc_load(
             datasets,
-            measurements=["count_wet", "count_clear"],
+            measurements=self.input_bands,
             geobox=geobox,
             chunks={},
         )

--- a/libs/stats/odc/stats/plugins/wofs.py
+++ b/libs/stats/odc/stats/plugins/wofs.py
@@ -164,9 +164,6 @@ class StatsWofs(StatsPluginInterface):
             )
         )
 
-    def rgba(self, xx: xr.Dataset) -> Optional[xr.DataArray]:
-        return None
-
 
 register("wofs-summary", StatsWofs)
 

--- a/libs/stats/odc/stats/plugins/wofs.py
+++ b/libs/stats/odc/stats/plugins/wofs.py
@@ -51,7 +51,9 @@ class StatsWofs(StatsPluginInterface):
         self,
         resampling: str = "bilinear",
         dilation: int = 0,
+        **kwargs
     ):
+        super().__init__(**kwargs)
         self.resampling = resampling
         self._dilation = dilation  # number of pixels to pad around BAD pixels
 

--- a/libs/stats/tests/test_fc_percentiles.py
+++ b/libs/stats/tests/test_fc_percentiles.py
@@ -1,3 +1,4 @@
+from functools import partial
 import numpy as np
 import xarray as xr
 import dask.array as da
@@ -45,7 +46,7 @@ def test_native_transform(dataset, bits):
     
     xx = dataset.copy()
     xx['water'] = da.bitwise_or(xx['water'], bits)
-    xx = StatsFCP._native_tr(xx)
+    xx = StatsFCP.native_transform(None, xx)
     assert xx["band_1"].attrs["test_attr"] == 57
     
     expected_result = np.array([
@@ -66,8 +67,8 @@ def test_native_transform(dataset, bits):
 
 
 def test_fusing(dataset):
-    xx = StatsFCP._native_tr(dataset)
-    xx = xx.groupby("solar_day").map(StatsFCP._fuser)
+    xx = StatsFCP.native_transform(None, dataset)
+    xx = xx.groupby("solar_day").map(partial(StatsFCP.fuser, None))
     assert xx["band_1"].attrs["test_attr"] == 57
     
     expected_result = np.array(
@@ -87,7 +88,7 @@ def test_fusing(dataset):
 
 def test_reduce(dataset):
     fcp = StatsFCP()
-    xx = fcp._native_tr(dataset)
+    xx = fcp.native_transform(dataset)
     xx = fcp.reduce(xx)
 
     result = xx.compute()["band_1_pc_10"].data

--- a/libs/stats/tests/test_gm_ls_bitmask.py
+++ b/libs/stats/tests/test_gm_ls_bitmask.py
@@ -47,7 +47,7 @@ def dataset(usgs_ls8_sr_definition):
 def test_native_transform(dataset):
     gm = StatsGMLSBitmask(bands=["band_red"], offset=-0.2, scale=0.00975)
 
-    xx = gm._native_tr(dataset)
+    xx = gm.native_transform(dataset)
     expected_result = np.array([
         [[255, 57], [0, 0]],
         [[0, 0], [70, 80]],
@@ -68,8 +68,8 @@ def test_native_transform(dataset):
 def test_fuser(dataset):
     gm = StatsGMLSBitmask(bands=["band_red"], offset=-0.2, scale=0.00975)
 
-    xx = gm._native_tr(dataset)
-    xx = xx.groupby("solar_day").map(gm._fuser)
+    xx = gm.native_transform(dataset)
+    xx = xx.groupby("solar_day").map(gm.fuser)
 
     expected_result = np.array(
         [[255, 57], [70, 80]],
@@ -87,7 +87,7 @@ def test_reduce(dataset):
     _ = pytest.importorskip("hdstats")
     gm = StatsGMLSBitmask(bands=["band_red"], offset=-0.2, scale=0.00975, output_scale=100)
 
-    xx = gm._native_tr(dataset)
+    xx = gm.native_transform(dataset)
     xx = gm.reduce(xx)
 
     result = xx.compute()
@@ -122,7 +122,7 @@ def test_reduce_with_filters(dataset):
     mask_filters = [("closing", 2), ("dilation",1)]
     gm = StatsGMLSBitmask(bands=["band_red"], filters=mask_filters, offset=-0.2, scale=0.00975, output_scale=100)
 
-    xx = gm._native_tr(dataset)
+    xx = gm.native_transform(dataset)
     xx = gm.reduce(xx)
 
     result = xx.compute()
@@ -154,7 +154,7 @@ def test_aux_result_bands_to_match_inputs(dataset):
     aux_names=dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT")
     gm = StatsGMLSBitmask(bands=["band_red"], aux_names=aux_names, offset=-0.2, scale=0.00975, output_scale=100)
 
-    xx = gm._native_tr(dataset)
+    xx = gm.native_transform(dataset)
     xx = gm.reduce(xx)
 
     assert set(xx.data_vars.keys()) == set(

--- a/libs/stats/tests/test_pq_bitmask.py
+++ b/libs/stats/tests/test_pq_bitmask.py
@@ -92,7 +92,7 @@ def test_meaurements(dataset):
 def test_native_transform(dataset):
     pq = StatsPQLSBitmask()
 
-    xx = pq._native_tr(dataset)
+    xx = pq.native_transform(dataset)
     tr_result = xx.compute()
 
     expected_result = np.array([
@@ -114,8 +114,8 @@ def test_native_transform(dataset):
 def test_fuser(dataset):
     pq = StatsPQLSBitmask()
 
-    xx = pq._native_tr(dataset)
-    xx = xx.groupby("solar_day").map(pq._fuser)
+    xx = pq.native_transform(dataset)
+    xx = xx.groupby("solar_day").map(pq.fuser)
     fuser_result = xx.compute()
 
     expected_result = np.array(
@@ -127,7 +127,7 @@ def test_fuser(dataset):
 def test_reduce(dataset):
     pq = StatsPQLSBitmask()
 
-    xx = pq._native_tr(dataset)
+    xx = pq.native_transform(dataset)
     xx = pq.reduce(xx)
     reduce_result = xx.compute()
 
@@ -154,7 +154,7 @@ def test_reduce_with_filter(dataset):
     }
     pq = StatsPQLSBitmask(filters=filters)
 
-    xx = pq._native_tr(dataset)
+    xx = pq.native_transform(dataset)
     xx = pq.reduce(xx)
     reduce_result = xx.compute()
 
@@ -189,7 +189,7 @@ def test_reduce_with_filter(dataset):
 def test_native_transform_for_aerosol(dataset_with_aerosol_band):
     pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL")
 
-    xx = pq._native_tr(dataset_with_aerosol_band)
+    xx = pq.native_transform(dataset_with_aerosol_band)
     tr_result = xx.compute()
 
     expected_result = np.array([
@@ -203,8 +203,8 @@ def test_native_transform_for_aerosol(dataset_with_aerosol_band):
 def test_fuse_for_aerosol(dataset_with_aerosol_band):
     pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL")
 
-    xx = pq._native_tr(dataset_with_aerosol_band)
-    xx = xx.groupby("solar_day").map(pq._fuser)
+    xx = pq.native_transform(dataset_with_aerosol_band)
+    xx = xx.groupby("solar_day").map(pq.fuser)
     fuser_result = xx.compute()
 
     expected_result = np.array(
@@ -216,7 +216,7 @@ def test_fuse_for_aerosol(dataset_with_aerosol_band):
 def test_reduce_for_aerosol(dataset_with_aerosol_band):
     pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL")
 
-    xx = pq._native_tr(dataset_with_aerosol_band)
+    xx = pq.native_transform(dataset_with_aerosol_band)
     xx = pq.reduce(xx)
     reduce_result = xx.compute()
 
@@ -245,7 +245,7 @@ def test_reduce_for_aerosol_with_filter(dataset_with_aerosol_band):
     }
     pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL", filters=filters, aerosol_filters=aerosol_filters)
 
-    xx = pq._native_tr(dataset_with_aerosol_band)
+    xx = pq.native_transform(dataset_with_aerosol_band)
     xx = pq.reduce(xx)
     reduce_result = xx.compute()
 
@@ -268,7 +268,7 @@ def test_reduce_for_aerosol_with_filter(dataset_with_aerosol_band):
 def test_native_transform_for_atmos_opacity(dataset_with_atmos_opacity_band):
     pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_ATMOS_OPACITY")
 
-    xx = pq._native_tr(dataset_with_atmos_opacity_band)
+    xx = pq.native_transform(dataset_with_atmos_opacity_band)
     tr_result = xx.compute()
 
     expected_result = np.array([
@@ -282,8 +282,8 @@ def test_native_transform_for_atmos_opacity(dataset_with_atmos_opacity_band):
 def test_fuse_for_atmos_opacity(dataset_with_atmos_opacity_band):
     pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_ATMOS_OPACITY")
 
-    xx = pq._native_tr(dataset_with_atmos_opacity_band)
-    xx = xx.groupby("solar_day").map(pq._fuser)
+    xx = pq.native_transform(dataset_with_atmos_opacity_band)
+    xx = xx.groupby("solar_day").map(pq.fuser)
     fuser_result = xx.compute()
 
     expected_result = np.array(
@@ -295,7 +295,7 @@ def test_fuse_for_atmos_opacity(dataset_with_atmos_opacity_band):
 def test_reduce_for_atmos_opacity(dataset_with_atmos_opacity_band):
     pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_ATMOS_OPACITY")
 
-    xx = pq._native_tr(dataset_with_atmos_opacity_band)
+    xx = pq.native_transform(dataset_with_atmos_opacity_band)
     xx = pq.reduce(xx)
     reduce_result = xx.compute()
 


### PR DESCRIPTION
* Consolidate rgba method into base class.
* Consolidate input_data method calling load_with_native_transform into base class. (See notes below)
* Make handling of fuser and native_transform callbacks more consistent.
* Update tests to use new API.

input_data notes:

* Most plugins can completely drop their input_data method and use the base class implementation.
* WOFSFullHistory plugin uses straight dc.load instead of load_with_native_transform - overrides base implementation
* Geomedian base plugin has some additional code, but now extends the base implementation

I think the code is cleaner and easier to follow like this, but I'm open to feedback.