### PR TITLE
Add USGS collection 2 level 2 special case

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/_stac.py
+++ b/apps/dc_tools/odc/apps/dc_tools/_stac.py
@@ -60,6 +60,19 @@ def _get_region_code(properties: Dict[str, Any]) -> str:
     return region_code
 
 
+def _get_usgs_product_name(properties: Dict[str, Any]) -> str:
+    platform = get_in(["platform"], properties)
+
+    if platform == "LANDSAT_8":
+        return "ls8-c2l2-sr"
+    elif platform == "LANDSAT_7":
+        return "ls7-c2l2-sr"
+    elif platform == "LANDSAT_5":
+        return "ls5-c2l2-sr"
+    else:
+        return None
+
+
 def _stac_product_lookup(
     item: Document,
 ) -> Tuple[str, Optional[str], str, Optional[str], str]:
@@ -98,9 +111,15 @@ def _stac_product_lookup(
                 )
             default_grid = "g10m"
 
+    collection = item.get("collection")
+    # Special case for USGS Landsat Collection 2
+    if collection is not None and collection == "landsat-c2l2-sr":
+        product_name = _get_usgs_product_name(properties)
+
+
     # If we still don't have a product name, use collection
     if product_name is None:
-        product_name = item.get("collection")
+        product_name = collection
         if product_name is None:
             raise ValueError("Can't find product name from odc:product or collection.")
 

--- a/apps/dc_tools/tests/data/example_product_list.csv
+++ b/apps/dc_tools/tests/data/example_product_list.csv
@@ -1,7 +1,7 @@
 product,definition
 s2_l2a,https://raw.githubusercontent.com/digitalearthafrica/config/master/products/esa_s2_l2a.odc-product.yaml
 cemp_insar_alos_displacement,https://raw.githubusercontent.com/GeoscienceAustralia/digitalearthau/885e3d3a00bcc9c9fe3ed43e82201d7121898aed/digitalearthau/config/products/cemp_insar_alos_displacement.yaml
-landsat_5;landsat_7;landsat_8,https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/main/products/ls_c2_sr.yaml
+ls5_c2l2_sr;ls7_c2l2_sr;ls8_c2l2_sr,https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/main/products/lsX_c2l2_sr.yaml
 nasadem,https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/main/products/nasadem.odc-product.yaml
 dem_cop_30,https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/main/products/dem_cop_30.odc-product.yaml
 dem_cop_90,https://raw.githubusercontent.com/opendatacube/datacube-dataset-config/main/products/dem_cop_90.odc-product.yaml


### PR DESCRIPTION
This adds a special case for USGS Collection 2 Level 2 data.

When coupled with this: https://github.com/opendatacube/datacube-dataset-config/blob/main/products/lsX_c2l2_sr.yaml it means we can use the simple command:

``` bash
stac-to-dc \
    --catalog-href https://landsatlook.usgs.gov/stac-server/ \
    --collections landsat-c2l2-sr \
    --rewrite-assets=https://landsatlook.usgs.gov/data/,s3://usgs-landsat/ \
     --limit 1000
```

to index USGS Collection 2 data.

As long as you do this:

``` bash
from datacube.utils.aws import configure_s3_access
configure_s3_access(region="us-west-2", requester_pays=True)
```

You can load data too:

![image](https://user-images.githubusercontent.com/3445853/145120477-31c3c323-44a6-4ba1-8ea7-0731bc5284a2.png)
