### PR TITLE
More precise packaging dependencies for odc.algo

### DIFF
--- a/libs/algo/odc/algo/_version.py
+++ b/libs/algo/odc/algo/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.2"
+__version__ = "0.2.2.post1"

--- a/libs/algo/setup.cfg
+++ b/libs/algo/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     affine
     dask
     dask_image
-    datacube
+    datacube>=1.8.5
     distributed
     numexpr
     numpy


### PR DESCRIPTION
we use hashing of geoboxes that was introduced in datacube 1.8.5

see also: https://github.com/conda-forge/odc-algo-feedstock/pull/1#event-6345314516

