### PR TITLE
add test case for s3-to-dc single absolute s3 path uri

### DIFF
--- a/apps/dc_tools/tests/test_s3_to_dc.py
+++ b/apps/dc_tools/tests/test_s3_to_dc.py
@@ -47,6 +47,7 @@ def test_s3_to_dc_single_stac(aws_env):
         [
             "--no-sign-request",
             "--stac",
+            "--update-if-exists",
             "s3://sentinel-cogs/sentinel-s2-l2a-cogs/42/T/UM/2022/1/S2B_42TUM_20220114_0_L2A/S2B_42TUM_20220114_0_L2A.json",
             "s2_l2a",
         ],

--- a/apps/dc_tools/tests/test_s3_to_dc.py
+++ b/apps/dc_tools/tests/test_s3_to_dc.py
@@ -39,6 +39,23 @@ def test_s3_to_dc_stac(aws_env):
 
 
 @pytest.mark.depends(on=['add_products'])
+def test_s3_to_dc_single_stac(aws_env):
+    runner = CliRunner()
+    # This will fail if requester pays is enabled
+    result = runner.invoke(
+        cli,
+        [
+            "--no-sign-request",
+            "--stac",
+            "s3://sentinel-cogs/sentinel-s2-l2a-cogs/42/T/UM/2022/1/S2B_42TUM_20220114_0_L2A/S2B_42TUM_20220114_0_L2A.json",
+            "s2_l2a",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.output == "Added 1 datasets and failed 0 datasets.\n"
+
+
+@pytest.mark.depends(on=['add_products'])
 def test_s3_to_dc_stac_update_if_exist(aws_env):
     runner = CliRunner()
     # This will fail if requester pays is enabled

--- a/libs/cloud/odc/aws/_find.py
+++ b/libs/cloud/odc/aws/_find.py
@@ -68,5 +68,10 @@ def parse_query(url_query):
 
     base = "/".join(base)
     base = base.rstrip("/") + "/"
+    if not depth and not _file and not glob:
+        if '.' in base.split("/")[-2]:
+            _file = base.split("/")[-2]
+            base = "/".join(base.split("/")[:-2]) + "/"
+
 
     return SimpleNamespace(base=base, depth=depth, file=_file, glob=glob)

--- a/libs/cloud/tests/test_aws.py
+++ b/libs/cloud/tests/test_aws.py
@@ -173,11 +173,14 @@ def test_get_queues_empty(aws_env):
 
 def test_parse_query():
     E = SimpleNamespace
-    base = "s3://bucket/path/a/"
+    base = "s3://bucket.aws/path/a/"
 
     assert parse_query(base) == E(base=base, depth=None, glob=None, file=None)
     assert parse_query(base + "some") == E(
         base=base + "some/", depth=None, glob=None, file=None
+    )
+    assert parse_query(base + "something/file.yaml") == E(
+        base=base+"something/", depth=None, glob=None, file="file.yaml"
     )
     assert parse_query(base + "*") == E(base=base, depth=0, glob="*", file=None)
     assert parse_query(base + "*/*txt") == E(base=base, depth=1, glob="*txt", file=None)


### PR DESCRIPTION
- allow s3-to-dc to index when provided `uri` is a absolute s3 path