### PR TITLE
add landsat9 product name

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/_stac.py
+++ b/apps/dc_tools/odc/apps/dc_tools/_stac.py
@@ -63,6 +63,8 @@ def _get_region_code(properties: Dict[str, Any]) -> str:
 def _get_usgs_product_name(properties: Dict[str, Any]) -> str:
     platform = get_in(["platform"], properties)
 
+    if platform == "LANDSAT_9":
+        return "ls9-c2l2-sr"
     if platform == "LANDSAT_8":
         return "ls8-c2l2-sr"
     elif platform == "LANDSAT_7":


### PR DESCRIPTION
This will fix the error raised when trying to index Landsat Collection 2 Level-2 UTM Surface Reflectance (SR) (landsat-c2l2-sr) with `stac-to-odc` tool
the error(odc.apps.dc_tools.utils.IndexingException: Failed to create dataset with error No matching Product found for dataset ...)