### PR TITLE
urgent fix to except skipped

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
@@ -17,7 +17,7 @@ import requests
 from datacube import Datacube
 from datacube.index.hl import Doc2Dataset
 from datacube.utils import documents
-from odc.apps.dc_tools.utils import (IndexingException, allow_unsafe, archive,
+from odc.apps.dc_tools.utils import (IndexingException, SkippedException, allow_unsafe, archive,
                                      fail_on_missing_lineage,
                                      index_update_dataset, limit, no_sign_request,
                                      skip_lineage,
@@ -242,16 +242,19 @@ def queue_to_odc(
 
                 # Index the dataset
                 if metadata is not None and uri is not None:
-                    index_update_dataset(
-                        metadata,
-                        uri,
-                        dc,
-                        doc2ds,
-                        update=update,
-                        update_if_exists=update_if_exists,
-                        allow_unsafe=allow_unsafe,
-                    )
-                    ds_success += 1
+                    try:
+                        index_update_dataset(
+                            metadata,
+                            uri,
+                            dc,
+                            doc2ds,
+                            update=update,
+                            update_if_exists=update_if_exists,
+                            allow_unsafe=allow_unsafe,
+                        )
+                        ds_success += 1
+                    except (SkippedException) as e:
+                        ds_skipped += 1
                 else:
                     logging.warning("Found None for metadata and uri, skipping")
                     ds_skipped += 1


### PR DESCRIPTION
properly handle skippedexcception

```
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO - WARNING:root:Dataset already exists, not indexing
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO - Traceback (most recent call last):
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -   File "/usr/local/bin/sqs-to-dc", line 8, in <module>
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -     sys.exit(cli())
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1130, in __call__
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -     return self.main(*args, **kwargs)
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1055, in main
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -     rv = self.invoke(ctx)
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1404, in invoke
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -     return ctx.invoke(self.callback, **ctx.params)
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 760, in invoke
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -     return __callback(*args, **kwargs)
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -   File "/usr/local/lib/python3.8/dist-packages/odc/apps/dc_tools/sqs_to_dc.py", line 336, in cli
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -     success, failed = queue_to_odc(
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -   File "/usr/local/lib/python3.8/dist-packages/odc/apps/dc_tools/sqs_to_dc.py", line 244, in queue_to_odc
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -     index_update_dataset(
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -   File "/usr/local/lib/python3.8/dist-packages/odc/apps/dc_tools/utils.py", line 187, in index_update_dataset
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO -     raise SkippedException(
[2022-08-25, 11:05:26 AEST] {pod_launcher.py:159} INFO - odc.apps.dc_tools.utils.SkippedException: Dataset already exists, not indexing
[2022-08-25, 11:05:28 AEST] {pod_launcher.py:216} INFO - Event: datacube-index-s2-nrt-streamline.9afc0af515fc4e6b81b7cedce5ba0879 had an event of type Failed
[2022-08-25, 11:05:28 AEST] {pod_launcher.py:328} ERROR - Event with job id datacube-index-s2-nrt-streamline.9afc0af515fc4e6b81b7cedce5ba0879 Failed
```