### PR TITLE
fix xarray groupby

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,8 +84,9 @@ jobs:
         channels: conda-forge,defaults
         channel-priority: true
         activate-environment: ""
-        mamba-version: "*"
+          # mamba-version: "*"
         use-mamba: true
+        miniforge-variant: Mambaforge
 
     - name: Dump Conda Environment Info
       shell: bash -l {0}

--- a/libs/algo/odc/algo/io.py
+++ b/libs/algo/odc/algo/io.py
@@ -2,6 +2,7 @@
 
 import json
 import xarray as xr
+import pandas as pd
 from pyproj import aoi, transformer
 from typing import (
     Callable,
@@ -133,6 +134,13 @@ def _load_with_native_transform_1(
     if groupby is not None:
         if fuser is None:
             fuser = _nodata_fuser  # type: ignore
+
+        for dim in xx.dims:
+            if isinstance(xx.get_index(dim), pd.MultiIndex):
+                xx = xx.reset_index(dim)
+
+        if groupby not in xx.indexes.keys():
+            xx = xx.set_xindex(groupby)
         xx = xx.groupby(groupby).map(fuser)
 
     _chunks = None
@@ -239,6 +247,11 @@ def load_with_native_transform(
     else:
         xx = xr.concat(_xx, sources.dims[0])  # type: ignore
         if groupby != "idx":
+            for dim in xx.dims:
+                if isinstance(xx.get_index(dim), pd.MultiIndex):
+                    xx = xx.reset_index(dim)
+            if groupby not in xx.indexes.keys():
+                xx = xx.set_xindex(groupby)
             xx = xx.groupby(groupby).map(fuser)
 
     # TODO: probably want to replace spec MultiIndex with just `time` component

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -11,6 +11,7 @@ dependencies:
 
   # Datacube
   - datacube>=1.8.8
+  - sqlalchemy<2.0.0
 
   # odc.algo
   - dask-image


### PR DESCRIPTION
`groupby` has trouble on `MultiIndex` since `xarray > 2022.3.0`. 

The fix/workaround:

- remove `MultiIndex`
- set index on the coords on which to `groupby`, e.g., `solar_day`
- apply `groupby` and `map`
- reinstate `MultiIndex`