### PR TITLE
Archive if action is provided in message attributes

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/sqs_to_dc.py
@@ -64,7 +64,7 @@ def extract_metadata_from_message(message):
 def extract_action_from_message(message):
     attributes = message.message_attributes
     if attributes:
-        return dicttoolz.get_in(['action', 'StringValue'], attributes)
+        return dicttoolz.get_in(["action", "StringValue"], attributes)
     return None
 
 

--- a/apps/dc_tools/tests/test_sns_publishing.py
+++ b/apps/dc_tools/tests/test_sns_publishing.py
@@ -250,12 +250,7 @@ def test_sqs_publishing_archive_attribute(
     sqs.send_message(
         QueueUrl=input_queue.get("QueueUrl"),
         MessageBody=json.dumps(sqs_message),
-        MessageAttributes={
-            'action': {
-                'DataType': 'String',
-                'StringValue': 'ARCHIVED'
-            }
-        }
+        MessageAttributes={"action": {"DataType": "String", "StringValue": "ARCHIVED"}},
     )
 
     dc = odc_db_for_archive
@@ -355,9 +350,13 @@ def test_with_archive_less_mature(
     assert len(messages) == 2
 
     nrt_message = messages[0]
-    assert nrt_message.get("MessageAttributes")["action"].get("StringValue") == "ARCHIVED"
+    assert (
+        nrt_message.get("MessageAttributes")["action"].get("StringValue") == "ARCHIVED"
+    )
     assert json.loads(nrt_message["Body"]).get("id") == nrt_dsid
 
     final_message = messages[1]
-    assert final_message.get("MessageAttributes")["action"].get("StringValue") == "ADDED"
+    assert (
+        final_message.get("MessageAttributes")["action"].get("StringValue") == "ADDED"
+    )
     assert json.loads(final_message["Body"]).get("id") == final_dsid


### PR DESCRIPTION
Currently, the only way to archive a dataset using sqs_to_dc is by providing the `--archive` flag. In order to simplify pipelines that need to both archive and add datasets, check for `action: ARCHIVED` in the message attributes as well.