### PR TITLE
Fix metrics cardinality explosion

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -314,6 +314,4 @@ def statsd_gauge_reporting(value, tags=None, statsd_setting="localhost:8125"):
     options = {"statsd_host": host, "statsd_port": port}
     initialize(**options)
 
-    if os.environ.get("HOSTNAME"):
-        tags.append(f"pod:{os.getenv('HOSTNAME')}")
     statsd.gauge("datacube_index", value, tags=tags)


### PR DESCRIPTION
Metrics are not logs. Pods are short lived. If we ask statsd to keep tracking a separate set of metrics for every unique pod name it has ever encountered, then we will accumulate tens of thousands of separate metrics over the course of a week, all of which being actively exported to prometheus. This impacts the performance and cost of monitoring.