### PR TITLE
Abort when doc stream empty

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -90,7 +90,7 @@ def dump_to_odc(
         except SkippedException:
             ds_skipped += 1
     if not found_docs:
-        raise IndexingException("Doc stream was empty")
+        raise click.Abort("Doc stream was empty")
 
     return ds_added, ds_failed, ds_skipped
 


### PR DESCRIPTION
This commit fixes that s3-to-dc waits indefinitely whenever a glob fails to produce any documents.

Instead we raise a click.Abort exception which properly ends execution.