### PR TITLE
Stop publishing to s3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -256,55 +256,6 @@ jobs:
         DASK_TEMPORARY_DIRECTORY: /tmp/dask
         DATACUBE_DB_URL: postgresql:///datacube
 
-  publish-s3:
-    if: |
-        github.event_name == 'push'
-        && github.repository == 'opendatacube/odc-tools'
-        && github.ref == 'refs/heads/develop'
-
-    needs:
-      - build-wheels
-      - test-wheels
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Config
-      id: cfg
-      if: |
-        github.ref == 'refs/heads/develop'
-        && github.event_name == 'push'
-        && github.repository == 'opendatacube/odc-tools'
-      run: |
-        echo "publish=yes" >> $GITHUB_OUTPUT
-    - uses: actions/cache@v3
-      id: wheels_cache
-      if: steps.cfg.outputs.publish == 'yes'
-      with:
-        path: ./wheels
-        key: wheels-${{ github.sha }}
-
-    - name: Prepare for upload to S3
-      if: steps.cfg.outputs.publish == 'yes'
-      run: |
-        mkdir -p ./pips
-        ./scripts/mk-pip-tree.sh ./wheels/dev/ ./pips
-        find ./pips -type f
-    - name: Upload to S3
-      if: steps.cfg.outputs.publish == 'yes'
-      run: |
-        echo "Using Keys: ...${AWS_ACCESS_KEY_ID:(-4)}/...${AWS_SECRET_ACCESS_KEY:(-4)}"
-        aws s3 ls "${S3_DST}"
-        aws s3 sync ./pips/ "${S3_DST}"
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: 'ap-southeast-2'
-        AWS_REGION: 'ap-southeast-2'
-        S3_DST: 's3://datacube-core-deployment/'
-
-
   publish-pypi:
     if: |
         github.event_name == 'push'


### PR DESCRIPTION
Publishing packages to S3 was important a long time ago, when we didn't have them published to PyPI, to be installed from https://packages.dea.ga.gov.au/

But:
- That domain belongs to Digital Earth Australia, not ODC
- They're available on PyPI! Where they can be easily installed.
- It's maintenance burden to keep doing it.
- We don't even want to publish development versions there after every PR, they should go to PyPI or test PyPI as well.