### PR TITLE
Add a test and fix for invalid geometry

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/_stac.py
+++ b/apps/dc_tools/odc/apps/dc_tools/_stac.py
@@ -1,6 +1,7 @@
 """
 Tools for STAC to EO3 translation
 """
+
 import math
 import numpy
 from eodatasets3.serialise import from_doc
@@ -227,7 +228,10 @@ def _get_stac_bands(
         # If transform specified here in the asset it should override
         # the properties-specified transform.
         transform = asset.get("proj:transform") or proj_transform
-        grid = f"g{transform[0]:g}m"
+        if transform is not None:
+            grid = f"g{transform[0]:g}m"
+        else:
+            grid = default_grid
 
         # As per transform, shape here overrides properties
         shape = asset.get("proj:shape") or proj_shape

--- a/apps/dc_tools/odc/apps/dc_tools/_stac.py
+++ b/apps/dc_tools/odc/apps/dc_tools/_stac.py
@@ -270,7 +270,12 @@ def _geographic_to_projected(geometry, crs, precision=10):
     if geom.is_valid:
         return geom.transform(round_coords)
     else:
-        return None
+        # Attempt to fix it if it's not valid
+        print(
+            "Caution, invalid geometry, attempting to fix. This may result in invalid data."
+        )
+        geom = geom.convex_hull
+        return geom.transform(round_coords)
 
 
 def stac_transform_absolute(input_stac):

--- a/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
@@ -311,9 +311,6 @@ def cli(
         publish_action=publish_action,
     )
 
-    print(
-        f"Added {added} Datasets, failed {failed} Datasets, skipped {skipped} Datasets"
-    )
     if statsd_setting:
         statsd_gauge_reporting(
             added, ["app:stac_api_to_dc", "action:added"], statsd_setting

--- a/apps/dc_tools/tests/conftest.py
+++ b/apps/dc_tools/tests/conftest.py
@@ -18,6 +18,7 @@ from datacube.index import index_connect
 from datacube.model import MetadataType
 from datacube.utils import documents
 from odc.apps.dc_tools.add_update_products import add_update_products
+from datacube.utils.geometry import Geometry, CRS
 
 TEST_DATA_FOLDER: Path = Path(__file__).parent.joinpath("data")
 LANDSAT_STAC: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
@@ -338,3 +339,24 @@ def odc_db_for_archive(odc_test_db_with_products: Datacube):
         assert result.exit_code == 0
 
     return odc_test_db_with_products
+
+
+@pytest.fixture
+def geometry_with_a_twist():
+    # From https://planetarycomputer.microsoft.com/api/stac/v1/collections/
+    #       landsat-c2-l2/items/LC08_L2SR_073071_20130427_02_T1
+    return Geometry(
+        {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [-179.9145508, -14.923636],
+                    [-180.0228509, -15.3692234],
+                    [-178.5768881, -16.8780443],
+                    [-179.983072, -16.5695723],
+                    [-179.9145508, -14.923636],
+                ]
+            ],
+        },
+        crs=CRS("epsg:4326"),
+    )

--- a/apps/dc_tools/tests/test_stac_transform.py
+++ b/apps/dc_tools/tests/test_stac_transform.py
@@ -7,7 +7,7 @@ from odc.apps.dc_tools._stac import stac_transform, _geographic_to_projected
 
 
 def test_geographic_to_projected(geometry_with_a_twist):
-    transformed = _geographic_to_projected(geometry_with_a_twist, "EPSG:900913")
+    transformed = _geographic_to_projected(geometry_with_a_twist, "EPSG:3832")
 
     assert transformed is not None
 
@@ -15,11 +15,11 @@ def test_geographic_to_projected(geometry_with_a_twist):
         "type": "Polygon",
         "coordinates": (
             (
-                (-20027996.181356553, -1680401.0306884265),
-                (20034964.592237074, -1731788.8882795917),
-                (-19879088.250739392, -1906633.287019358),
-                (-20035623.926449094, -1870777.708859445),
-                (-20027996.181356553, -1680401.0306884265),
+                (3498004.815848052, -1894234.3033218135),
+                (3341469.1401383593, -1858599.0018098454),
+                (3337040.973246038, -1720470.5990706773),
+                (3349096.8852309, -1669403.410330984),
+                (3498004.815848052, -1894234.3033218135),
             ),
         ),
     }

--- a/apps/dc_tools/tests/test_stac_transform.py
+++ b/apps/dc_tools/tests/test_stac_transform.py
@@ -3,7 +3,28 @@ Test for stac_transform
 """
 
 from datacube.utils.changes import get_doc_changes
-from odc.apps.dc_tools._stac import stac_transform
+from odc.apps.dc_tools._stac import stac_transform, _geographic_to_projected
+
+
+def test_geographic_to_projected(geometry_with_a_twist):
+    transformed = _geographic_to_projected(geometry_with_a_twist, "EPSG:900913")
+
+    assert transformed is not None
+
+    expected = {
+        "type": "Polygon",
+        "coordinates": (
+            (
+                (-20027996.181356553, -1680401.0306884265),
+                (20034964.592237074, -1731788.8882795917),
+                (-19879088.250739392, -1906633.287019358),
+                (-20035623.926449094, -1870777.708859445),
+                (-20027996.181356553, -1680401.0306884265),
+            ),
+        ),
+    }
+
+    assert transformed.json == expected
 
 
 def test_esri_lulc_stac_transform(esri_lulc_stac):


### PR DESCRIPTION
Not sure if this is a good idea.

Is it better to have a scene added where geometry is possibly not right, or to fail and report it for fixing?