### PR TITLE
Specify datacube>=1.8.15

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -1,6 +1,6 @@
 import click
 import logging
-import pkg_resources
+import importlib_resources
 from datadog import statsd, initialize
 from odc.aws.queue import publish_to_topic
 from typing import Iterable, Optional, Union
@@ -161,7 +161,7 @@ statsd_setting = click.option(
 
 
 def get_esri_list():
-    stream = pkg_resources.resource_stream(__name__, "esri-lc-tiles-list.txt")
+    stream = importlib_resources.files(__name__).joinpath("esri-lc-tiles-list.txt")
     with stream as f:
         for tile in f.readlines():
             tile_id = tile.decode().rstrip("\n")
@@ -222,7 +222,7 @@ def index_update_dataset(
         added = False
         updated = False
         if archive_less_mature and publish_action:
-            dupes = dc.index.datasets.find_less_mature(ds)
+            dupes = dc.index.datasets.find_less_mature(ds, 500)
             for dupe in dupes:
                 archive_stacs.append(ds_to_stac(dupe))
 

--- a/apps/dc_tools/setup.cfg
+++ b/apps/dc_tools/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     urlpath
     datadog
     eodatasets3
+    importlib_resources>=6.0
 
 [options.extras_require]
 tests =

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -48,12 +48,13 @@ coverage==6.3.1
 cryptography==36.0.1
 dask==2022.2.0
 dask-image==2021.12.0
-datacube==1.8.13
+datacube==1.8.15
 datadog==0.44.0
 debugpy==1.5.1
 decorator==5.1.1
 deepdiff==5.7.0
 defusedxml==0.7.1
+deprecat==2.1.1
 distributed==2022.02.0
 docker==5.0.3
 docutils==0.15.2
@@ -81,6 +82,7 @@ idna==3.3
 imageio==2.16.0
 imagesize==1.3.0
 importlib-metadata==5.0.0
+importlib-resources==6.0.0
 iniconfig==1.1.1
 ipykernel==6.9.1
 ipyleaflet==0.15.0

--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -24,7 +24,7 @@ click
 dask[complete]
 dask_image
 
-datacube[dev]>=1.8.13,!=1.8.14
+datacube[dev]>=1.8.15
 datadog
 # things needed for tests that might not be referenced in setup.py
 deepdiff
@@ -54,6 +54,7 @@ toolz
 tqdm
 urlpath
 xarray==2022.3.0
+importlib_resources>=6.0
 
 
 # Moto and Flask

--- a/docker/requirements.in
+++ b/docker/requirements.in
@@ -24,7 +24,7 @@ click
 dask[complete]
 dask_image
 
-datacube[dev]>=1.8.13
+datacube[dev]>=1.8.13,!=1.8.14
 datadog
 # things needed for tests that might not be referenced in setup.py
 deepdiff

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -10,7 +10,7 @@ dependencies:
   - python=3.8
 
   # Datacube
-  - datacube>=1.8.13,!=1.8.14
+  - datacube>=1.8.15
   - sqlalchemy<2.0.0
 
   # odc.algo
@@ -34,6 +34,7 @@ dependencies:
   - urlpath
   - datadog
   - eodatasets3
+  - importlib_resources>=6.0
 
   # odc.{aws,aio}: aiobotocore/boto3
   #  pin aiobotocore for easier resolution of dependencies

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -10,7 +10,7 @@ dependencies:
   - python=3.8
 
   # Datacube
-  - datacube>=1.8.13
+  - datacube>=1.8.13,!=1.8.14
   - sqlalchemy<2.0.0
 
   # odc.algo


### PR DESCRIPTION
Avoid importlib.metadata error in python 3.8; need to use >= 1.8.15 due to `delta` param in `find_less_mature`
Also get rid of pkg_resources while we're at it