### PR TITLE
When a geometry is invalid, fall back to the native transform

### DIFF
--- a/apps/dc_tools/tests/conftest.py
+++ b/apps/dc_tools/tests/conftest.py
@@ -1,23 +1,24 @@
-import boto3
 import configparser
-import docker
 import json
 import os
-import psycopg2
-import pytest
 import time
-import yaml
-from click.testing import CliRunner
-from moto import mock_s3
-from moto.server import ThreadedMotoServer
 from pathlib import Path
 
+import boto3
+import psycopg2
+import pytest
+import yaml
+from click.testing import CliRunner
 from datacube import Datacube
 from datacube.drivers.postgres import _core as pgres_core
 from datacube.index import index_connect
 from datacube.model import MetadataType
 from datacube.utils import documents
+from moto import mock_s3
+from moto.server import ThreadedMotoServer
 from odc.apps.dc_tools.add_update_products import add_update_products
+
+import docker
 
 TEST_DATA_FOLDER: Path = Path(__file__).parent.joinpath("data")
 LANDSAT_STAC: str = "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
@@ -29,6 +30,7 @@ USGS_LANDSAT_STAC: str = "LC08_L2SR_081119_20200101_20200823_02_T2.json"
 LIDAR_STAC: str = "lidar_dem.json"
 MATURITY_PRODUCT: str = "ga_ls5t_gm_product.yaml"
 ESRI_LULC_STAC: str = "29V-2021.stac-item.json"
+WORLD_WRAPPING_STAC: str = "world-wrapping.stac-item.json"
 
 
 @pytest.fixture
@@ -106,6 +108,12 @@ def mocked_s3_datasets(mocked_aws_s3_env):
                 Key=str(fname.relative_to(TEST_DATA_FOLDER)),
             )
         yield bucket
+
+
+@pytest.fixture
+def world_wrapping_stac():
+    with TEST_DATA_FOLDER.joinpath(WORLD_WRAPPING_STAC).open("r", encoding="utf8") as f:
+        return json.load(f)
 
 
 @pytest.fixture

--- a/apps/dc_tools/tests/data/world-wrapping.stac-item.json
+++ b/apps/dc_tools/tests/data/world-wrapping.stac-item.json
@@ -1,0 +1,318 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "dep_ls_geomad_66_20_2023",
+    "properties": {
+        "start_datetime": "2023-01-01T00:00:00.000Z",
+        "datetime": "2023-01-01T00:00:00Z",
+        "end_datetime": "2023-12-31T23:59:59Z",
+        "created": "2023-12-01T03:19:24.875082Z",
+        "proj:epsg": 3832,
+        "proj:geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [
+                        3336000.0,
+                        -2080020.0
+                    ],
+                    [
+                        3432000.0,
+                        -2080020.0
+                    ],
+                    [
+                        3432000.0,
+                        -1983990.0
+                    ],
+                    [
+                        3336000.0,
+                        -1983990.0
+                    ],
+                    [
+                        3336000.0,
+                        -2080020.0
+                    ]
+                ]
+            ]
+        },
+        "proj:bbox": [
+            3336000.0,
+            -2080020.0,
+            3432000.0,
+            -1983990.0
+        ],
+        "proj:shape": [
+            3201,
+            3200
+        ],
+        "proj:transform": [
+            30.0,
+            0.0,
+            3336000.0,
+            0.0,
+            -30.0,
+            -1983990.0,
+            0.0,
+            0.0,
+            1.0
+        ],
+        "proj:projjson": {
+            "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
+            "type": "ProjectedCRS",
+            "name": "WGS 84 / PDC Mercator",
+            "base_crs": {
+                "name": "WGS 84",
+                "datum": {
+                    "type": "GeodeticReferenceFrame",
+                    "name": "World Geodetic System 1984",
+                    "ellipsoid": {
+                        "name": "WGS 84",
+                        "semi_major_axis": 6378137,
+                        "inverse_flattening": 298.257223563
+                    }
+                },
+                "coordinate_system": {
+                    "subtype": "ellipsoidal",
+                    "axis": [
+                        {
+                            "name": "Geodetic latitude",
+                            "abbreviation": "Lat",
+                            "direction": "north",
+                            "unit": "degree"
+                        },
+                        {
+                            "name": "Geodetic longitude",
+                            "abbreviation": "Lon",
+                            "direction": "east",
+                            "unit": "degree"
+                        }
+                    ]
+                },
+                "id": {
+                    "authority": "EPSG",
+                    "code": 4326
+                }
+            },
+            "conversion": {
+                "name": "unnamed",
+                "method": {
+                    "name": "Mercator (variant A)",
+                    "id": {
+                        "authority": "EPSG",
+                        "code": 9804
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "Latitude of natural origin",
+                        "value": 0,
+                        "unit": "degree",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8801
+                        }
+                    },
+                    {
+                        "name": "Longitude of natural origin",
+                        "value": 150,
+                        "unit": "degree",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8802
+                        }
+                    },
+                    {
+                        "name": "Scale factor at natural origin",
+                        "value": 1,
+                        "unit": "unity",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8805
+                        }
+                    },
+                    {
+                        "name": "False easting",
+                        "value": 0,
+                        "unit": "metre",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8806
+                        }
+                    },
+                    {
+                        "name": "False northing",
+                        "value": 0,
+                        "unit": "metre",
+                        "id": {
+                            "authority": "EPSG",
+                            "code": 8807
+                        }
+                    }
+                ]
+            },
+            "coordinate_system": {
+                "subtype": "Cartesian",
+                "axis": [
+                    {
+                        "name": "Easting",
+                        "abbreviation": "",
+                        "direction": "east",
+                        "unit": "metre"
+                    },
+                    {
+                        "name": "Northing",
+                        "abbreviation": "",
+                        "direction": "north",
+                        "unit": "metre"
+                    }
+                ]
+            },
+            "id": {
+                "authority": "EPSG",
+                "code": 3832
+            }
+        }
+    },
+    "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [
+                [
+                    [
+                        179.96779787822723,
+                        -18.477840859860567
+                    ],
+                    [
+                        179.96779787822723,
+                        -17.65272718152993
+                    ],
+                    [
+                        180.0,
+                        -17.65272718152993
+                    ],
+                    [
+                        180.0,
+                        -18.477840859860567
+                    ],
+                    [
+                        179.96779787822723,
+                        -18.477840859860567
+                    ]
+                ]
+            ],
+            [
+                [
+                    [
+                        -179.169819449018,
+                        -17.65272718152993
+                    ],
+                    [
+                        -179.169819449018,
+                        -18.477840859860567
+                    ],
+                    [
+                        -180.0,
+                        -18.477840859860567
+                    ],
+                    [
+                        -180.0,
+                        -17.65272718152993
+                    ],
+                    [
+                        -179.169819449018,
+                        -17.65272718152993
+                    ]
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "collection",
+            "href": "https://stac.staging.digitalearthpacific.org/collections/dep_ls_geomad",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "red": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_red.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "green": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_green.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "blue": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_blue.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "nir08": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_nir08.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "swir16": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_swir16.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "swir22": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_swir22.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "emad": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_emad.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "smad": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_smad.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "bcmad": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_bcmad.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        },
+        "count": {
+            "href": "https://deppcpublicstorage.blob.core.windows.net/output/dep_ls_geomad/0-0-2/66/20/2023/dep_ls_geomad_66_20_2023_count.tif",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -180.0,
+        -18.477840859860567,
+        180.0,
+        -17.65272718152993
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "dep_ls_geomad"
+}

--- a/apps/dc_tools/tests/test_stac_transform.py
+++ b/apps/dc_tools/tests/test_stac_transform.py
@@ -96,3 +96,18 @@ def test_lidar_stac_transform(lidar_stac):
     assert (
         transformed_stac_doc["geometry"]["coordinates"] == expected_geometry_coordinates
     )
+
+
+def test_world_wrapping_stac(world_wrapping_stac):
+    transformed_stac_doc = stac_transform(world_wrapping_stac)
+    expected_geometry_coordinates = (
+        (3336000.0, -2079990.0),
+        (3336000.0, -1983990.0),
+        (3432030.0, -1983990.0),
+        (3432030.0, -2079990.0),
+        (3336000.0, -2079990.0),
+    )
+    assert (
+        transformed_stac_doc["geometry"]["coordinates"][0]
+        == expected_geometry_coordinates
+    )


### PR DESCRIPTION
Basically, we have a native geometry that crosses the anti-meridian when converted to lat/lon. So we split the feature there, maintaining coordinates that are between `-180` and `180`. But that then makes it really hard to put back into projected coordinates.

Rather than do that, if there's an invalid geometry, this proposed change falls back to native transform information to create a native geometry.