### PR TITLE
Replace deprecated `urlpath` package with standard library URL manipulation APIs.

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/_stac.py
+++ b/apps/dc_tools/odc/apps/dc_tools/_stac.py
@@ -204,7 +204,10 @@ def _get_stac_bands(
                     raise ValueError
 
                 self_parts = urlparse(self_link)
-                if self_parts.scheme != parts.scheme or self_parts.netloc != self_parts.netloc:
+                if (
+                    self_parts.scheme != parts.scheme
+                    or self_parts.netloc != self_parts.netloc
+                ):
                     raise ValueError("href cannot be made relative to self link")
                 path = parts.path
                 self_path = self_parts.path


### PR DESCRIPTION
The stac implementation uses the external `urlpath` package which is orphaned and only supported to Python 3.10.

This PR replaces it with `urlparse` and `posixpath` from the standard library.