### PR TITLE
Attempt to fix pypi/publish action.  Not clear how it came to be broken.

### DIFF
--- a/scripts/mk-pip-tree.sh
+++ b/scripts/mk-pip-tree.sh
@@ -15,7 +15,7 @@ create_pip_tree() {
 
         echo "${src}/${w}"*.whl "-> ${out}/"
         echo "${src}/${w}"*tar.gz "-> ${out}/"
-        cp "${src}/${w}"* "${out}/"
+        cp "${src}/${w}"*.whl "${out}/"
         cp "${src}/${w}"*.tar.gz "${out}/"
     done
 }

--- a/scripts/mk-pip-tree.sh
+++ b/scripts/mk-pip-tree.sh
@@ -13,10 +13,10 @@ create_pip_tree() {
         local out="${dst}/${base}"
         mkdir -p "${out}"
 
-        echo "${src}/${w}"* "-> ${out}/"
-        echo "${src}/${base}"*tar.gz "-> ${out}/"
-        cp "${src}/${w}"*.whl "${out}/"
-        cp "${src}/${base}"*.tar.gz "${out}/"
+        echo "${src}/${w}"*.whl "-> ${out}/"
+        echo "${src}/${w}"*tar.gz "-> ${out}/"
+        cp "${src}/${w}"* "${out}/"
+        cp "${src}/${w}"*.tar.gz "${out}/"
     done
 }
 


### PR DESCRIPTION
The pypi/publish githib action is broken.

Script expected files like `odc-io*.tar.gz` and `odc_io*.whl`  - the tar.gz with a dash and the whl with an underscore, but both are created with an underscore.

None of the relevant scripts have changed for years, it is not clear to me how this came to be broken, but I think this might fix it.