### PR TITLE
Do not hang on empty stac file

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -62,6 +62,9 @@ def dump_to_odc(
 
     found_docs = False
     for uri, metadata in uris_docs:
+        if metadata is None:
+            ds_skipped += 1
+            continue
         found_docs = True
         stac_doc = None
         if transform:


### PR DESCRIPTION
Check that there is a document
returned from parse_doc_stream,
so a zero byte file does not
crash s3_to_dc.