### PR TITLE
Restore missing dependency

### DIFF
--- a/apps/dc_tools/setup.cfg
+++ b/apps/dc_tools/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     urlpath
     datadog
     eodatasets3>=1.9
+    importlib_resources>=6.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
The s3-to-dc command does
not start without having
importlib_resources available,
so restore this dependency
that was removed in #625.