### PR TITLE
test-env: remove importlib_resources

### DIFF
--- a/tests/test-env.yml
+++ b/tests/test-env.yml
@@ -28,7 +28,6 @@ dependencies:
   - datadog
   - docker-py
   # - eodatasets3>=1.9.0
-  - importlib_resources>=6.0
   - odc-geo
   - odc-stac
 


### PR DESCRIPTION
Commit 236714099d removed the use
of this package, so remove it from
the test-env as well.