### PR TITLE
pytest: ignore boto deprecation warning

### DIFF
--- a/apps/dc_tools/pyproject.toml
+++ b/apps/dc_tools/pyproject.toml
@@ -6,3 +6,6 @@ build-backend = "setuptools.build_meta"
 addopts = [
     "--import-mode=importlib",
 ]
+filterwarnings = [
+    "ignore:datetime.datetime.utcnow*:DeprecationWarning:botocore.*"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["setuptools>=51.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:datetime.datetime.utcnow*:DeprecationWarning:botocore.*"


### PR DESCRIPTION
Botocore interacts with a large code base
so it cannot fix the utcnow deprecation
warning easily. Since there is nothing
to do about the warning, ignore it.