### PR TITLE
Add asset name mapping for stac-to-dc

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
@@ -94,11 +94,12 @@ def process_item(
     publish_action: bool = False,
     asset_name_mapping: Optional[str] = None,
 ):
-    for mapping in asset_name_mapping.split(','):
-        name_from, name_to = mapping.split('/')
-        if item.assets[name_from] is not None:
-            item.assets[name_to] = item.assets[name_from]
-            del item.assets[name_from]
+    if asset_name_mapping:
+        for mapping in asset_name_mapping.split(','):
+            name_from, name_to = mapping.split('/')
+            if item.assets[name_from] is not None:
+                item.assets[name_to] = item.assets[name_from]
+                del item.assets[name_from]
     meta, uri, stac = item_to_meta_uri(item, rename_product)
     index_update_dataset(
         meta,


### PR DESCRIPTION
Hi,

this is some code I wrote ages ago as a quick fix for a problem we had where a catalog had changed its asset names, which clashed with the old ones in the ODC database. With the fix, you can do something like this:

`stac-to-dc --catalog-href https://stac.terrabyte.lrz.de/public/api --collections sentinel-2-c1-l2a --rename-product s2_c1_l2a --datetime='2024-03-01/2024-03-31' --bbox=5.9,47.3,15.0,54.9 --asset-name-mapping=B01/coastal,B02/blue,B03/green,B04/red,B05/rededge1,B06/rededge2,B07/rededge3,B08/nir,B8A/nir08,B09/nir09,B11/swir16,B12/swir22,SCL/scl,AOT/aot,WVP/wvp`

I'm just opening this PR as I stumbled across the code while going through stuff I did at that job (which I'm no longer employed at) and didn't want it to go to waste in case you find this interesting.

Would need error checking and documentation of course.