### PR TITLE
Add a URL replace argument for STAC API to DC

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
@@ -66,6 +66,7 @@ def item_to_meta_uri(
     item: Item,
     dc: Datacube,
     rename_product: Optional[str] = None,
+    url_string_replace: tuple[str, str] | None = None,
 ) -> Generator[Tuple[Dataset, str, bool], None, None]:
     for link in item.links:
         if link.rel == "self":
@@ -78,6 +79,15 @@ def item_to_meta_uri(
 
     if rename_product is not None:
         item.properties["odc:product"] = rename_product
+
+    # If we need to modify URLs, do it for the main URL and the asset links
+    if url_string_replace is not None:
+        old_url, new_url = url_string_replace
+
+        uri = uri.replace(old_url, new_url)
+
+        for asset in item.assets.values():
+            asset.href = asset.href.replace(old_url, new_url)
 
     # Try to the Datacube product for the dataset
     product_name = item.properties.get("odc:product", item.collection_id)
@@ -107,10 +117,11 @@ def process_item(
     update_if_exists: bool,
     allow_unsafe: bool,
     rename_product: Optional[str] = None,
+    url_string_replace: tuple[str, str] | None = None,
     archive_less_mature: int | None = None,
     publish_action: bool = False,
 ) -> None:
-    dataset, uri, stac = item_to_meta_uri(item, dc, rename_product)
+    dataset, uri, stac = item_to_meta_uri(item, dc, rename_product, url_string_replace)
     index_update_dataset(
         dataset,
         uri,
@@ -131,6 +142,7 @@ def stac_api_to_odc(
     catalog_href: str,
     allow_unsafe: bool = True,
     rename_product: Optional[str] = None,
+    url_string_replace: tuple[str, str] | None = None,
     archive_less_mature: int | None = None,
     publish_action: Optional[str] = None,
 ) -> Tuple[int, int, int]:
@@ -161,6 +173,7 @@ def stac_api_to_odc(
                 update_if_exists=update_if_exists,
                 allow_unsafe=allow_unsafe,
                 rename_product=rename_product,
+                url_string_replace=url_string_replace,
                 archive_less_mature=archive_less_mature,
                 publish_action=publish_action,
             ): item.id
@@ -215,6 +228,12 @@ def stac_api_to_odc(
     help="Other search terms, as a # separated list, i.e., --options=cloud_cover=0,100#sky=green",
 )
 @rename_product
+@click.option(
+    "--url-string-replace",
+    type=str,
+    default=None,
+    help="Replace a string in the STAC API URLs, e.g., 'https://stac.example.com,s3://stac.example.org'",
+)
 @archive_less_mature
 @publish_action
 @statsd_setting
@@ -229,9 +248,10 @@ def cli(
     datetime,
     options,
     rename_product,
-    statsd_setting,
+    url_string_replace,
     archive_less_mature,
     publish_action,
+    statsd_setting,
 ) -> None:
     """
     Iterate through STAC items from a STAC API and add them to datacube.
@@ -248,6 +268,13 @@ def cli(
     if datetime:
         config["datetime"] = datetime
 
+    if url_string_replace:
+        url_string_replace_tuple = tuple(url_string_replace.split(","))
+        if len(url_string_replace_tuple) != 2:
+            raise ValueError(
+                "url_string_replace must be two strings separated by a comma"
+            )
+
     # Always set the limit, because some APIs will stop at an arbitrary
     # number if max_items is not None.
     config["max_items"] = limit
@@ -261,6 +288,7 @@ def cli(
         catalog_href,
         allow_unsafe=allow_unsafe,
         rename_product=rename_product,
+        url_string_replace=url_string_replace_tuple,
         archive_less_mature=archive_less_mature,
         publish_action=publish_action,
     )

--- a/apps/dc_tools/tests/test_stac_api_to_dc.py
+++ b/apps/dc_tools/tests/test_stac_api_to_dc.py
@@ -1,9 +1,35 @@
-# Tests using the Click framework the stac_api-to-dc CLI tool
+# Tests for the stac_api-to-dc CLI tool
 import pytest
 from click.testing import CliRunner
-
-from odc.apps.dc_tools.stac_api_to_dc import cli
+from odc.apps.dc_tools.stac_api_to_dc import cli, item_to_meta_uri
 from odc.apps.dc_tools.utils import MICROSOFT_PC_STAC_URI
+from pystac import Item
+
+
+def test_rewrite_urls(landsat_stac, odc_db):
+    url_rewrite_tuple = (
+        "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com",
+        "s3://dea-public-data-dev",
+    )
+
+    item = Item.from_dict(landsat_stac)
+
+    print(item.self_href)
+
+    dc = odc_db()
+
+    _, uri, _ = item_to_meta_uri(
+        item,
+        dc,
+        rename_product=None,
+        url_string_replace=url_rewrite_tuple,
+    )
+
+    # https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json
+    assert (
+        uri
+        == "s3://dea-public-data-dev/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
+    )
 
 
 @pytest.mark.xfail(reason="Earth Search API has changed and now this is failing too")

--- a/apps/dc_tools/tests/test_stac_api_to_dc.py
+++ b/apps/dc_tools/tests/test_stac_api_to_dc.py
@@ -6,7 +6,7 @@ from odc.apps.dc_tools.utils import MICROSOFT_PC_STAC_URI
 from pystac import Item
 
 
-def test_rewrite_urls(landsat_stac, odc_db):
+def test_rewrite_urls(landsat_stac, odc_test_db_with_products):
     url_rewrite_tuple = (
         "https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com",
         "s3://dea-public-data-dev",
@@ -16,12 +16,10 @@ def test_rewrite_urls(landsat_stac, odc_db):
 
     print(item.self_href)
 
-    dc = odc_db()
-
     _, uri, _ = item_to_meta_uri(
         item,
-        dc,
-        rename_product=None,
+        odc_test_db_with_products,
+        rename_product="ls8_c2l2_sr",
         url_string_replace=url_rewrite_tuple,
     )
 

--- a/apps/dc_tools/tests/test_stac_api_to_dc.py
+++ b/apps/dc_tools/tests/test_stac_api_to_dc.py
@@ -25,11 +25,13 @@ def test_rewrite_urls(landsat_stac, odc_db):
         url_string_replace=url_rewrite_tuple,
     )
 
-    # https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json
-    assert (
-        uri
-        == "s3://dea-public-data-dev/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
+    # https://dea-public-data-dev.s3-ap-southeast-2.amazonaws.com/
+    # analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json
+    changed_uri = (
+        "s3://dea-public-data-dev/analysis-ready-data/ga_ls8c_ard_3/088/080/2020/05/25/"
+        "ga_ls8c_ard_3-1-0_088080_2020-05-25_final.stac-item.json"
     )
+    assert uri == changed_uri
 
 
 @pytest.mark.xfail(reason="Earth Search API has changed and now this is failing too")


### PR DESCRIPTION
This re-adds some functionality that I swear I added a long time ago, and must have been removed.

In short, there is sometimes a need to rewrite asset URLs at indexing time. An example is for USGS data.

I have tested manually with the below command, which works. And written a test, which I'm hoping will pass in CI, because I didn't get it working.

``` bash
stac-to-dc --catalog-href='https://landsatlook.usgs.gov/stac-server/' \
                    --bbox='114,-9,116,-7' \
                    --collections='landsat-c2l2-st' \
                    --datetime='2025-01-01/2025-05-30' \
                    --rename-product='ls9_c2l2_st' \
                    --url-string-replace='https://landsatlook.usgs.gov/data,s3://usgs-landsat' \
                    --limit=100 \
                    --options="query={\"platform\":{\"in\":[\"LANDSAT_9\"]}}"
```