### PR TITLE
Improve consistency of cli lineage options

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/azure_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/azure_to_dc.py
@@ -18,14 +18,17 @@ from odc.apps.dc_tools.utils import (
     SkippedException,
     allow_unsafe,
     archive_less_mature,
+    fail_on_missing_lineage,
     index_update_dataset,
     publish_action,
     rename_product,
+    skip_lineage,
     statsd_gauge_reporting,
     statsd_setting,
     transform_stac,
     update_flag,
     update_if_exists_flag,
+    verify_lineage,
 )
 from odc.azure import download_blob, find_blobs
 
@@ -83,8 +86,9 @@ def dump_list_to_odc(
     archive_less_mature: Optional[int] = None,
     publish_action: Optional[str] = None,
     rename_product: Optional[str] = None,
+    **kwargs,
 ):
-    doc2ds = Doc2Dataset(dc.index)
+    doc2ds = Doc2Dataset(dc.index, **kwargs)
 
     # Do the indexing of all the things
     success = 0
@@ -154,6 +158,9 @@ def dump_list_to_odc(
 @click.argument("prefix", type=str, nargs=1)
 @click.argument("suffix", type=str, nargs=1)
 @rename_product
+@skip_lineage
+@fail_on_missing_lineage
+@verify_lineage
 def cli(
     cfg_env: ODCEnvironment,
     update: bool,
@@ -169,6 +176,9 @@ def cli(
     prefix: str,
     suffix: str,
     rename_product: str,
+    skip_lineage: bool,
+    fail_on_missing_lineage: bool,
+    verify_lineage: bool,
 ) -> None:
     # Set up the datacube first, to ensure we have a connection
     dc = Datacube(env=cfg_env)
@@ -192,6 +202,9 @@ def cli(
         archive_less_mature=archive_less_mature,
         publish_action=publish_action,
         rename_product=rename_product,
+        skip_lineage=skip_lineage,
+        fail_on_missing_lineage=fail_on_missing_lineage,
+        verify_lineage=verify_lineage,
     )
 
     print(

--- a/apps/dc_tools/odc/apps/dc_tools/fs_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/fs_to_dc.py
@@ -11,12 +11,15 @@ from odc.apps.dc_tools._stac import stac_transform
 from odc.apps.dc_tools.utils import (
     allow_unsafe,
     archive_less_mature,
+    fail_on_missing_lineage,
     index_update_dataset,
     update_if_exists_flag,
     publish_action,
+    skip_lineage,
     statsd_setting,
     statsd_gauge_reporting,
     transform_stac,
+    verify_lineage,
 )
 
 logging.basicConfig(
@@ -36,6 +39,9 @@ logging.basicConfig(
 @transform_stac
 @statsd_setting
 @publish_action
+@skip_lineage
+@fail_on_missing_lineage
+@verify_lineage
 @click.option(
     "--glob",
     default=None,
@@ -51,9 +57,17 @@ def cli(
     glob,
     archive_less_mature,
     publish_action,
+    skip_lineage,
+    fail_on_missing_lineage,
+    verify_lineage,
 ) -> None:
     dc = datacube.Datacube(env=cfg_env)
-    doc2ds = Doc2Dataset(dc.index)
+    doc2ds = Doc2Dataset(
+        dc.index,
+        skip_lineage=skip_lineage,
+        fail_on_missing_lineage=fail_on_missing_lineage,
+        verify_lineage=verify_lineage,
+    )
 
     if glob is None:
         glob = "**/*.json" if stac else "**/*.yaml"

--- a/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import click
 from datacube import Datacube
+from datacube.index.hl import Doc2Dataset
 from datacube.ui.click import environment_option, pass_config
 from odc.apps.dc_tools.utils import (
     SkippedException,
@@ -24,6 +25,9 @@ from odc.apps.dc_tools.utils import (
     statsd_gauge_reporting,
     statsd_setting,
     update_if_exists_flag,
+    skip_lineage,
+    fail_on_missing_lineage,
+    verify_lineage,
 )
 from pystac.item import Item
 from pystac_client import Client
@@ -71,13 +75,15 @@ def process_item(
     url_string_replace: tuple[str, str] | None = None,
     archive_less_mature: int | None = None,
     publish_action: bool = False,
+    **kwargs,
 ) -> None:
     dataset, uri, stac = item_to_meta_uri(item, dc, rename_product, url_string_replace)
+    doc2ds = Doc2Dataset(dc.index, **kwargs)
     index_update_dataset(
         dataset,
         uri,
         dc,
-        None,
+        doc2ds,
         update_if_exists=update_if_exists,
         allow_unsafe=allow_unsafe,
         archive_less_mature=archive_less_mature,
@@ -96,6 +102,7 @@ def stac_api_to_odc(
     url_string_replace: tuple[str, str] | None = None,
     archive_less_mature: int | None = None,
     publish_action: Optional[str] = None,
+    **kwargs,
 ) -> Tuple[int, int, int]:
     client = Client.open(catalog_href)
 
@@ -127,6 +134,7 @@ def stac_api_to_odc(
                 url_string_replace=url_string_replace,
                 archive_less_mature=archive_less_mature,
                 publish_action=publish_action,
+                **kwargs,
             ): item.id
             for item in search.items()
         }
@@ -183,6 +191,9 @@ def stac_api_to_odc(
 @archive_less_mature
 @publish_action
 @statsd_setting
+@skip_lineage
+@fail_on_missing_lineage
+@verify_lineage
 def cli(
     cfg_env,
     limit,
@@ -198,6 +209,9 @@ def cli(
     archive_less_mature,
     publish_action,
     statsd_setting,
+    skip_lineage,
+    fail_on_missing_lineage,
+    verify_lineage,
 ) -> None:
     """
     Iterate through STAC items from a STAC API and add them to datacube.
@@ -239,6 +253,9 @@ def cli(
         url_string_replace=url_string_replace_tuple,
         archive_less_mature=archive_less_mature,
         publish_action=publish_action,
+        skip_lineage=skip_lineage,
+        fail_on_missing_lineage=fail_on_missing_lineage,
+        verify_lineage=verify_lineage,
     )
 
     print(


### PR DESCRIPTION
The cli tools are inconsistent with providing the lineage options, so add them in where needed.

**Details**

`azure-to-dc`, `fs-to-dc` and `stac-to-dc` were missing the options `--skip-lineage`, `--fail-on-missing-lineage` and `--verify-lineage`.

Now they have them.

