### PR TITLE
CI: fix code coverage step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,8 @@ jobs:
 
   test-with-coverage:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     needs:
       - build-test-env-base
     services:
@@ -192,6 +193,7 @@ jobs:
 
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
+          use_oidc: true
           fail_ci_if_error: false
           verbose: false
 


### PR DESCRIPTION
The code coverage currently
fails because this repository
does not pass any token, so
generate an OIDC token and use
that.