### PR TITLE
CI: cancel previous jobs on PR updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,12 @@ on:
       - "!old/**"
       - "!README.md"
 
+# When a PR is updated, cancel the jobs from the previous version. Merges
+# do not define head_ref, so use run_id to never cancel those jobs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-wheels:
     timeout-minutes: 15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   build-wheels:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -67,6 +68,7 @@ jobs:
           find ./wheels/dev -type f
 
   build-test-env-base:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:
@@ -111,6 +113,7 @@ jobs:
           mamba env export -p tests/env
 
   test-with-coverage:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -198,6 +201,7 @@ jobs:
           verbose: false
 
   test-wheels:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     needs:
@@ -284,7 +288,7 @@ jobs:
       github.event_name == 'push'
       && github.repository == 'opendatacube/odc-tools'
       && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/pypi/publish')
-
+    timeout-minutes: 15
     strategy:
       matrix:
         pkg:


### PR DESCRIPTION
This avoids clogging the CI machines when one of the quick checks fail and you update the PR to fix that.

Also add a commit that shortens the job timeout in case someone hangs the CI machines.