### PR TITLE
dc_tools: use datacube functions

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_inventory.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_inventory.py
@@ -2,7 +2,7 @@ import click
 import re
 import sys
 from fnmatch import fnmatch
-from odc.aws import s3_client
+from datacube.utils.aws import s3_client
 from odc.aws.inventory import list_inventory
 
 

--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -13,6 +13,12 @@ import click
 from datacube import Datacube
 from datacube.index.hl import Doc2Dataset
 from datacube.ui.click import environment_option, pass_config
+from datacube.utils.aws import (
+    _aws_unsigned_check_env,
+    auto_find_region,
+    s3_client,
+    s3_fetch,
+)
 from datacube.utils.documents import parse_doc_stream
 from odc.aio import S3Fetcher, s3_find_glob
 from odc.apps.dc_tools.utils import (
@@ -37,7 +43,6 @@ from odc.apps.dc_tools.utils import (
     url_string_replace,
     verify_lineage,
 )
-from odc.aws import _aws_unsigned_check_env, auto_find_region, s3_client, s3_fetch
 from pystac import Item
 
 


### PR DESCRIPTION
These functions were added to datacube
years ago, so use them instead of
the versions in odc.aws.