### PR TITLE
Type annotate type aliases

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/_stac.py
+++ b/apps/dc_tools/odc/apps/dc_tools/_stac.py
@@ -4,7 +4,7 @@ Tools for STAC to EO3 translation
 
 import math
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, TypeAlias
 from uuid import UUID
 
 from datacube.metadata import ds2stac
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 
 from ._docs import odc_uuid
 
-Document = Dict[str, Any]
+Document: TypeAlias = dict[str, Any]
 
 # This is an old hack, should be refactored out
 DEA_LANDSAT_PRODUCTS = ["ga_ls8c_ard_3", "ga_ls7e_ard_3", "ga_ls8t_ard_3"]

--- a/libs/io/odc/io/text.py
+++ b/libs/io/odc/io/text.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 from sys import stdin
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, TypeAlias, Union
 
-PathLike = Union[str, Path]
-RawDoc = Union[str, bytes]
+PathLike: TypeAlias = Union[str, Path]
+RawDoc: TypeAlias = Union[str, bytes]
 
 try:
     from ruamel.yaml import YAML


### PR DESCRIPTION
This removes yellow lines in PyCharm
type annotations.