### PR TITLE
Tests: Fix infinite hang if :5000 busy

### DIFF
--- a/apps/dc_tools/tests/conftest.py
+++ b/apps/dc_tools/tests/conftest.py
@@ -55,20 +55,20 @@ def aws_env(monkeypatch) -> None:
 @pytest.fixture
 def mocked_aws_s3_env():
     """
-    Run a Fake Local S3 Service on http://localhost:5000 and redirect odc.aio
-    to use it via an env variable.
+    Run Mock S3 Server and patch environment to use it
     """
 
-    server = ThreadedMotoServer()
+    server = ThreadedMotoServer(ip_address="127.0.0.1", port=0)
     server.start()
+    _host, _port = server.get_host_and_port()
     # run tests
-    os.environ["AWS_S3_ENDPOINT"] = "http://localhost:5000"
+    os.environ["AWS_S3_ENDPOINT"] = f"http://{_host}:{_port}"
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-    yield boto3.resource("s3", endpoint_url="http://localhost:5000")
+    yield boto3.resource("s3", endpoint_url=f"http://{_host}:{_port}")
     del os.environ["AWS_S3_ENDPOINT"]
     server.stop()
 


### PR DESCRIPTION
Start the Mock S3 server on a random port during tests.

The App tests spin up a moto server to mock requests to s3, but it requires port 5000 to be available. If it isn't, the test run freezes until manualy killed.

Port 5000 is a relatively common port, especially on MacOS, which gave me the message:

```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured stdout >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
Starting a new Thread with MotoServer running on 0.0.0.0:5000...
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured stderr >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
Address already in use
Port 5000 is in use by another program. Either identify and stop that program, or start the server with a different port. On macOS, try disabling the 'AirPlay Receiver' service from System Preferences -> General -> AirDrop & Handoff.
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
```