### PR TITLE
pylintrc: fix variable-rgx

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -63,6 +63,7 @@ attr-rgx=[a-z_][a-z0-9_]{0,50}$
 argument-rgx=[a-z_][a-z0-9_]{0,50}$
 
 # Regular expression which should only match correct variable names
+# Permit any name for variables starting with an underscore.
 variable-rgx=[a-z_][a-z0-9_]{0,50}$|_(.*)$
 
 # Regular expression which should only match correct attribute names in class

--- a/pylintrc
+++ b/pylintrc
@@ -63,7 +63,7 @@ attr-rgx=[a-z_][a-z0-9_]{0,50}$
 argument-rgx=[a-z_][a-z0-9_]{0,50}$
 
 # Regular expression which should only match correct variable names
-variable-rgx=[a-z_][a-z0-9_]{0,50}$
+variable-rgx=[a-z_][a-z0-9_]{0,50}$|_(.*)$
 
 # Regular expression which should only match correct attribute names in class
 # bodies


### PR DESCRIPTION
Permit any name for variables
that start with underscore.