### PR TITLE
tests: include error message for cli

### DIFF
--- a/apps/dc_tools/tests/conftest.py
+++ b/apps/dc_tools/tests/conftest.py
@@ -446,6 +446,6 @@ def odc_db_for_archive(odc_test_db_with_products: Datacube, env_name):
             ["--stac", "--glob", filename, str(TEST_DATA_FOLDER), "--env", env_name],
         )
         print(result.output)
-        assert result.exit_code == 0
+        assert result.exit_code == 0, f"Output: {result.output}"
 
     return odc_test_db_with_products

--- a/apps/dc_tools/tests/test_add_update_products.py
+++ b/apps/dc_tools/tests/test_add_update_products.py
@@ -45,7 +45,7 @@ def test_add_products(local_csv, odc_db, env_name) -> None:
         ],
     )
     print(f"CLI Output: {result.output}")
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 @pytest.fixture

--- a/apps/dc_tools/tests/test_cop_dem_to_dc.py
+++ b/apps/dc_tools/tests/test_cop_dem_to_dc.py
@@ -56,7 +56,7 @@ def test_indexing_cli(bbox, product, odc_db, env_name) -> None:
             env_name,
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert f"Product definition added for {product}" in result.output
     assert "Added 4 Datasets, failed 0 Datasets, skipped 0 Datasets" in result.output
 
@@ -73,6 +73,6 @@ def test_indexing_cli(bbox, product, odc_db, env_name) -> None:
             env_name,
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert f"Product definition added for {product}" in result.output
     assert "Added 0 Datasets, failed 0 Datasets, skipped 4 Datasets" in result.output

--- a/apps/dc_tools/tests/test_esa_worldcover_to_dc.py
+++ b/apps/dc_tools/tests/test_esa_worldcover_to_dc.py
@@ -87,4 +87,4 @@ def test_indexing_cli(
             env_name,
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"

--- a/apps/dc_tools/tests/test_fs_to_dc.py
+++ b/apps/dc_tools/tests/test_fs_to_dc.py
@@ -19,7 +19,7 @@ def test_fs_to_fc_yaml(test_data_dir, env_name, odc_test_db_with_products) -> No
         ],
         catch_exceptions=False,
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 def test_archive_less_mature(

--- a/apps/dc_tools/tests/test_s3_to_dc.py
+++ b/apps/dc_tools/tests/test_s3_to_dc.py
@@ -39,21 +39,21 @@ def test_redrive_to_queue_cli(aws_env) -> None:
         redrive_cli,
         [str(DEAD_QUEUE_NAME), str(ALIVE_QUEUE_NAME), "--limit", "string_test"],
     )
-    assert returned.exit_code == 1
+    assert returned.exit_code == 1, f"Output: {returned.output}"
 
     # Invalid value 0
     returned = runner.invoke(
         redrive_cli,
         [str(DEAD_QUEUE_NAME), str(ALIVE_QUEUE_NAME), "--limit", 0],
     )
-    assert returned.exit_code == 1
+    assert returned.exit_code == 1, f"Output: {returned.output}"
 
     # Valid value 1
     returned = runner.invoke(
         redrive_cli,
         [str(DEAD_QUEUE_NAME), str(ALIVE_QUEUE_NAME), "--limit", 1],
     )
-    assert returned.exit_code == 0
+    assert returned.exit_code == 0, f"Output: {returned.output}"
     assert (
         int(get_queue(ALIVE_QUEUE_NAME).attributes.get("ApproximateNumberOfMessages"))
         == 1
@@ -64,7 +64,7 @@ def test_redrive_to_queue_cli(aws_env) -> None:
         redrive_cli,
         [str(DEAD_QUEUE_NAME), str(ALIVE_QUEUE_NAME), "--limit", None],
     )
-    assert returned.exit_code == 0
+    assert returned.exit_code == 0, f"Output: {returned.output}"
     assert (
         int(get_queue(DEAD_QUEUE_NAME).attributes.get("ApproximateNumberOfMessages"))
         == 0
@@ -91,14 +91,14 @@ def test_s3_to_dc_skips_already_indexed_datasets(
     ]
 
     # The first run should succeed and index all 25 datasets
-    assert results[0].exit_code == 0
+    assert results[0].exit_code == 0, f"Output: {results[0].output}"
     assert (
         results[0].output
         == "Added 25 datasets, skipped 0 datasets and failed 0 datasets.\n"
     )
 
     # The second run should succeed by SKIPPING all 25 datasets
-    assert results[1].exit_code == 0
+    assert results[1].exit_code == 0, f"Output: {results[1].output}"
     assert (
         results[1].output
         == "Added 0 datasets, skipped 25 datasets and failed 0 datasets.\n"
@@ -121,7 +121,7 @@ def test_s3_to_dc_stac(
         ],
         catch_exceptions=False,
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
     )
@@ -143,7 +143,7 @@ def test_s3_to_dc_stac_update_if_exist(
             env_name,
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
     )
@@ -168,7 +168,7 @@ def test_s3_to_dc_stac_update_if_exist_allow_unsafe(
         ],
     )
     print(f"s3-to-dc exit_code: {result.exit_code}, output:{result.output}")
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
     )
@@ -189,7 +189,7 @@ def test_s3_to_dc_fails_to_index_non_dataset_yaml(
         ],
         catch_exceptions=False,
     )
-    assert result.exit_code == 1
+    assert result.exit_code == 1, f"Output: {result.output}"
     assert (
         result.output == "Added 0 datasets, skipped 0 datasets and failed 1 datasets.\n"
     )
@@ -211,7 +211,7 @@ def test_s3_to_dc_partially_succeeds_when_given_invalid_and_valid_dataset_yamls(
             env_name,
         ],
     )
-    assert result.exit_code == 1
+    assert result.exit_code == 1, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 1 datasets.\n"
     )
@@ -234,7 +234,7 @@ def test_s3_to_dc_list_absolute_urls(
             env_name,
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 3 datasets, skipped 0 datasets and failed 0 datasets.\n"
     )
@@ -255,7 +255,7 @@ def test_s3_to_dc_no_product(
         ],
         catch_exceptions=False,
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
     )
@@ -274,7 +274,7 @@ def test_s3_to_dc_no_product(
         ],
         catch_exceptions=False,
     )
-    assert result2.exit_code == 0
+    assert result2.exit_code == 0, f"Output: {result2.output}"
     assert (
         result2.output
         == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
@@ -297,7 +297,7 @@ def test_convert_bools(mocked_s3_datasets, odc_test_db_with_products, env_name) 
         ],
         catch_exceptions=False,
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     ds = dc.index.datasets.get("5f94dd81-241f-559a-9362-05b223d45ae1")
     # boolean values converted to strings
     assert ds.metadata.noise_removal_applied == "true"

--- a/apps/dc_tools/tests/test_sns_publishing.py
+++ b/apps/dc_tools/tests/test_sns_publishing.py
@@ -97,7 +97,7 @@ def test_s3_publishing_action_from_stac(
     )
 
     print(f"s3-to-dc exit_code: {result.exit_code}, output:{result.output}")
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
     )
@@ -136,7 +136,7 @@ def test_s3_publishing_action_from_eo3(
     )
 
     print(f"s3-to-dc exit_code: {result.exit_code}, output:{result.output}")
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
     )
@@ -206,7 +206,7 @@ def test_sqs_publishing(
     )
     print(f"sqs-to-dc exit_code: {result.exit_code}, output:{result.output}")
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     messages = sqs.receive_message(
         QueueUrl=output_queue_url,
@@ -265,7 +265,7 @@ def test_sqs_publishing_archive_flag(
     )
     print(f"sqs-to-dc exit_code: {result.exit_code}, output:{result.output}")
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
     messages = sqs.receive_message(
         QueueUrl=output_queue_url,
@@ -323,7 +323,7 @@ def test_sqs_publishing_archive_attribute(
         catch_exceptions=False,
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     messages = sqs.receive_message(
         QueueUrl=output_queue_url,
         MessageAttributeNames=["All"],
@@ -363,7 +363,7 @@ def test_with_archive_less_mature(
     )
     print(f"fs-to-dc exit_code: {nrt_result.exit_code}, " "output:{nrt_result.output}")
 
-    assert nrt_result.exit_code == 0
+    assert nrt_result.exit_code == 0, f"Output: {nrt_result.output}"
     assert dc.index.datasets.get(nrt_dsid) is not None
 
     messages = sqs.receive_message(
@@ -394,7 +394,7 @@ def test_with_archive_less_mature(
         f"fs-to-dc exit_code: {final_result.exit_code}, " "output:{final_result.output}"
     )
 
-    assert final_result.exit_code == 0
+    assert final_result.exit_code == 0, f"Output: {final_result.output}"
     assert dc.index.datasets.get(final_dsid) is not None
 
     messages = sqs.receive_message(

--- a/apps/dc_tools/tests/test_stac_api_to_dc.py
+++ b/apps/dc_tools/tests/test_stac_api_to_dc.py
@@ -47,7 +47,7 @@ def test_stac_to_dc_earthsearch(odc_test_db_with_products, env_name) -> None:
         ],
         catch_exceptions=False,
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
     assert "Added 10 Datasets, failed 0 Datasets, skipped 0 Datasets" in result.output
 
 
@@ -66,7 +66,7 @@ def test_stac_to_dc_usgs(odc_test_db_with_products, env_name) -> None:
         ],
         catch_exceptions=False,
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"
 
 
 def test_stac_to_dc_planetarycomputer(odc_test_db_with_products, env_name) -> None:
@@ -81,4 +81,4 @@ def test_stac_to_dc_planetarycomputer(odc_test_db_with_products, env_name) -> No
             env_name,
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Output: {result.output}"


### PR DESCRIPTION
Asserting on the exit code is robust,
but it's difficult to understand why
tests fail when they fail, so add
the CLI output to the assert message.