### PR TITLE
pyproject: use datacube < 1.10.0

### DIFF
--- a/apps/dc_tools/pyproject.toml
+++ b/apps/dc_tools/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "click<8.3", # Test failures/bad --archive-less-mature defn
-    "datacube>=1.9.10",
+    "datacube>=1.9.10,<1.10.0",
     "datadog",
     "fsspec",
     "odc-cloud[ASYNC]>=0.2.3",

--- a/libs/ui/pyproject.toml
+++ b/libs/ui/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Open Data Cube", email = "earth.observation@ga.gov.au"},
 ]
 dependencies = [
-    "datacube>=1.9.2",
+    "datacube>=1.9.2,<1.10.0",
     "ipyleaflet",
     "ipython",
     "ipywidgets>=8.0",


### PR DESCRIPTION
This will keep the package working
even after the next API breaking
datacube version is released.