### PR TITLE
tests: update to latest pip

### DIFF
--- a/tests/test-env.yml
+++ b/tests/test-env.yml
@@ -51,7 +51,7 @@ dependencies:
   # TODO: Fix --archive-less-mature flag then remove following line
   - click<8.3 # Fix GHA test failures
 
-  - pip=24
+  - pip=25.3
   - pip:
       # odc.apps.dc-tools
       - thredds-crawler


### PR DESCRIPTION
There are security issues with earlier
versions of pip, so use the latest
version.