### PR TITLE
odc-ui: update requires-python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,7 +282,7 @@ jobs:
           datacube metadata add apps/dc_tools/tests/data/eo3_sentinel_ard.odc-type.yaml
 
           echo "Running Tests"
-          pytest --timeout=30 libs apps
+          pytest --timeout=90 libs apps
 
         env:
           AWS_DEFAULT_REGION: us-west-2

--- a/libs/ui/pyproject.toml
+++ b/libs/ui/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "rasterio",
     "xarray",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = "Apache-2.0"
 


### PR DESCRIPTION
Datacube 1.9 requires Python 3.10,
so use that as requires-python
in this package as well.

Edit: CI failed intermittently on this, extend the timeout so we get this in the logs:
```
E       assert 1 == 0
E        +  where 1 = <Result APIError('The request exceeded the maximum allowed time, please try again. If the issue persists, please contact planetarycomputer@microsoft.com.\n\n')>.exit_code
```
instead of:
```
 tests/env/lib/python3.12/site-packages/click/testing.py:494: in invoke
    return_value = cli.main(args=args or (), prog_name=prog_name, **extra)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/click/core.py:1363: in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/click/core.py:1226: in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/click/core.py:794: in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/datacube/ui/click.py:267: in new_func
    return f(cfg_env, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/odc/apps/dc_tools/stac_api_to_dc.py:246: in cli
    added, failed, skipped = stac_api_to_odc(
tests/env/lib/python3.12/site-packages/odc/apps/dc_tools/stac_api_to_dc.py:110: in stac_api_to_odc
    n_items = search.matched()
              ^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/pystac_client/item_search.py:764: in matched
    resp = self._stac_io.read_json(self.url, method=self.method, parameters=params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/pystac/stac_io.py:206: in read_json
    txt = self.read_text(source, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/pystac_client/stac_api_io.py:167: in read_text
    return self.request(href, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/pystac_client/stac_api_io.py:214: in request
    resp = self.session.send(prepped, timeout=self.timeout, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/requests/adapters.py:644: in send
    resp = conn.urlopen(
tests/env/lib/python3.12/site-packages/urllib3/connectionpool.py:787: in urlopen
    response = self._make_request(
tests/env/lib/python3.12/site-packages/urllib3/connectionpool.py:534: in _make_request
    response = conn.getresponse()
               ^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/site-packages/urllib3/connection.py:565: in getresponse
    httplib_response = super().getresponse()
                       ^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/http/client.py:1430: in getresponse
    response.begin()
tests/env/lib/python3.12/http/client.py:331: in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/http/client.py:292: in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/socket.py:720: in readinto
    return self._sock.recv_into(b)
           ^^^^^^^^^^^^^^^^^^^^^^^
tests/env/lib/python3.12/ssl.py:1251: in recv_into
    return self.read(nbytes, buffer)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ssl.SSLSocket [closed] fd=-1, family=2, type=1, proto=6>, len = 8192
buffer = <memory at 0x7fc916ff7b80>

    def read(self, len=1024, buffer=None):
        """Read up to LEN bytes and return them.
        Return zero-length string on EOF."""
    
        self._checkClosed()
        if self._sslobj is None:
            raise ValueError("Read on closed or unwrapped SSL socket.")
        try:
            if buffer is not None:
>               return self._sslobj.read(len, buffer)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E               Failed: Timeout (>30.0s) from pytest-timeout.
```