### PR TITLE
utils: handle not having a self-href

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -148,12 +148,13 @@ def dump_to_odc(
                     dataset["properties"][prop] = "false"
         if transform:
             item = Item.from_dict(dataset)
-            dataset, uri, stac = item_to_meta_uri(
+            dataset, new_uri, stac = item_to_meta_uri(
                 item,
                 dc,
                 rename_product=rename_product,
                 url_string_replace=url_string_replace,
             )
+            uri = new_uri or uri
         try:
             index_update_dataset(
                 dataset,

--- a/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/stac_api_to_dc.py
@@ -78,6 +78,10 @@ def process_item(
     **kwargs,
 ) -> None:
     dataset, uri, stac = item_to_meta_uri(item, dc, rename_product, url_string_replace)
+    if uri is None:
+        raise ValueError(
+            f"The links field did not contain a self-reference for item {item}"
+        )
     doc2ds = Doc2Dataset(dc.index, **kwargs)
     index_update_dataset(
         dataset,

--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -301,29 +301,34 @@ def statsd_gauge_reporting(value, tags=None, statsd_setting="localhost:8125") ->
     statsd.gauge("datacube_index", value, tags=tags)
 
 
-def item_to_meta_uri(
-    item: Item,
-    dc: Datacube,
-    rename_product: Optional[str] = None,
-    url_string_replace: tuple[str, str] | None = None,
-) -> Tuple[Dataset, str, Dict[str, Any]]:
+def get_self_link(item: Item) -> str | None:
+    uri = None
     for link in item.links:
         if link.rel == "self":
             uri = link.target
 
         # Override self with canonical
         if link.rel == "canonical":
-            uri = link.target
-            break
+            return link.target
+    return uri
 
+
+def item_to_meta_uri(
+    item: Item,
+    dc: Datacube,
+    rename_product: Optional[str] = None,
+    url_string_replace: tuple[str, str] | None = None,
+) -> Tuple[Dataset, str | None, Dict[str, Any]]:
     if rename_product is not None:
         item.properties["odc:product"] = rename_product
 
     # If we need to modify URLs, do it for the main URL and the asset links
+    uri = get_self_link(item)
     if url_string_replace is not None:
         old_url, new_url = url_string_replace
 
-        uri = uri.replace(old_url, new_url)
+        if uri is not None:
+            uri = uri.replace(old_url, new_url)
 
         for asset in item.assets.values():
             asset.href = asset.href.replace(old_url, new_url)


### PR DESCRIPTION
The current code in odc-stac will happily
return a self-href that is None, so handle
that situation without immediately crashing
with a UnboundLocalError in item_to_meta_uri.