### PR TITLE
s3-to-dc: stop printing long backtraces

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -292,17 +292,23 @@ def cli(
                 )
     # Get a generator from supplied S3 Uri for candidate documents
     # Grab the URL from the resulting S3 item
-    if is_glob:
-        fetcher = S3Fetcher(aws_unsigned=no_sign_request)
-        document_stream = fetcher(
-            url.url
-            for url in s3_find_glob(uris[0], skip_check=skip_check, s3=fetcher, **opts)
-        )
-    else:
-        # if working with absolute URLs, no need for all the globbing logic
-        document_stream = SimpleFetcher(
-            aws_unsigned=no_sign_request, request_opts=opts
-        )(uris)
+    try:
+        if is_glob:
+            fetcher = S3Fetcher(aws_unsigned=no_sign_request)
+            document_stream = fetcher(
+                url.url
+                for url in s3_find_glob(
+                    uris[0], skip_check=skip_check, s3=fetcher, **opts
+                )
+            )
+        else:
+            # if working with absolute URLs, no need for all the globbing logic
+            document_stream = SimpleFetcher(
+                aws_unsigned=no_sign_request, request_opts=opts
+            )(uris)
+    except OSError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
 
     if url_string_replace:
         url_string_replace_tuple = tuple(url_string_replace.split(","))

--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -313,9 +313,11 @@ def cli(
     if url_string_replace:
         url_string_replace_tuple = tuple(url_string_replace.split(","))
         if len(url_string_replace_tuple) != 2:
-            raise ValueError(
-                "url_string_replace must be two strings separated by a comma"
+            print(
+                "url_string_replace must be two strings separated by a comma",
+                file=sys.stderr,
             )
+            sys.exit(1)
     else:
         url_string_replace_tuple = None
 

--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -294,17 +294,15 @@ def cli(
     # Grab the URL from the resulting S3 item
     if is_glob:
         fetcher = S3Fetcher(aws_unsigned=no_sign_request)
-        document_stream = (
+        document_stream = fetcher(
             url.url
             for url in s3_find_glob(uris[0], skip_check=skip_check, s3=fetcher, **opts)
         )
     else:
         # if working with absolute URLs, no need for all the globbing logic
-        fetcher = SimpleFetcher(
-            aws_unsigned=no_sign_request,
-            request_opts=opts,
-        )
-        document_stream = uris
+        document_stream = SimpleFetcher(
+            aws_unsigned=no_sign_request, request_opts=opts
+        )(uris)
 
     if url_string_replace:
         url_string_replace_tuple = tuple(url_string_replace.split(","))
@@ -316,7 +314,7 @@ def cli(
         url_string_replace_tuple = None
 
     added, failed, skipped = dump_to_odc(
-        fetcher(document_stream),
+        document_stream,
         dc,
         candidate_products,
         skip_lineage=skip_lineage,


### PR DESCRIPTION
Print the error and exit instead of giving the user a long backtrace for errors that can be expected.