### PR TITLE
item_to_meta_uri: pass asset_absolute_paths

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -348,7 +348,7 @@ def item_to_meta_uri(
         )
 
     # Convert the STAC Item to a Dataset
-    dataset = next(stac2ds([item]))
+    dataset = next(stac2ds([item], {"asset_absolute_paths": False}))
     # And assign the product ID
     dataset.product = product
 


### PR DESCRIPTION
This is required for s3-to-dc to accept
STAC files with assets that have relative
URIs.