### PR TITLE
s3-to-dc: set self_href if missing

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
+++ b/apps/dc_tools/odc/apps/dc_tools/s3_to_dc.py
@@ -29,6 +29,7 @@ from odc.apps.dc_tools.utils import (
     fail_on_missing_lineage,
     index_update_dataset,
     item_to_meta_uri,
+    get_self_link,
     no_sign_request,
     publish_action,
     rename_product,
@@ -275,6 +276,8 @@ def cli(
             stac_doc = None
             if stac:
                 item = Item.from_dict(dataset)
+                if get_self_link(item) is None:
+                    item.set_self_href(uri)
                 dataset, new_uri, stac_doc = item_to_meta_uri(
                     item,
                     dc,


### PR DESCRIPTION
This will populate the uri_* columns in `odc.dataset` with `s3` and the bucket/path to the STAC file when passing in STAC files without a self-href/canonical in its links.
