### PR TITLE
Update to click 8.3.1

### DIFF
--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -114,19 +114,14 @@ archive_less_mature = click.option(
     flag_value=500,
     type=int,
     help=(
-        "Archive existing any datasets that match product, "
-        "time and region-code, but have lower dataset-maturity."
-        "Note: An error will be raised and the dataset add will "
-        "fail if a matching dataset with higher or equal dataset-maturity."
-        "Can specify an of leniency for comparing timestamps, provided in milliseconds. "
-        "Default value is 500ms."
-"Archive any existing datasets that match product, "
-"time, and region-code, but have a lower maturity. "
-"If any matching datasets have higher or equal maturity, "
-"the dataset add/update will fail.\n"
-"Can specify a millisecond amount of leniency for comparing timestamps "
-"to account for the possibility of slight differences between matching datasets "
-"(default is 500ms)."
+        "Archive any existing datasets that match product, "
+        "time, and region-code, but have a lower maturity. "
+        "If any matching datasets have higher or equal maturity, "
+        "the dataset add/update will fail.\n"
+        "Can specify a millisecond amount of leniency for comparing timestamps "
+        "to account for the possibility of slight differences between matching datasets "
+        "(default is 500ms)."
+    )
 )
 
 publish_action = click.option(

--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -121,7 +121,7 @@ archive_less_mature = click.option(
         "Can specify a millisecond amount of leniency for comparing timestamps "
         "to account for the possibility of slight differences between matching datasets "
         "(default is 500ms)."
-    )
+    ),
 )
 
 publish_action = click.option(

--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -112,7 +112,6 @@ archive_less_mature = click.option(
     "--archive-less-mature",
     is_flag=False,
     flag_value=500,
-    default=None,
     type=int,
     help=(
         "Archive existing any datasets that match product, "

--- a/apps/dc_tools/odc/apps/dc_tools/utils.py
+++ b/apps/dc_tools/odc/apps/dc_tools/utils.py
@@ -120,7 +120,13 @@ archive_less_mature = click.option(
         "fail if a matching dataset with higher or equal dataset-maturity."
         "Can specify an of leniency for comparing timestamps, provided in milliseconds. "
         "Default value is 500ms."
-    ),
+"Archive any existing datasets that match product, "
+"time, and region-code, but have a lower maturity. "
+"If any matching datasets have higher or equal maturity, "
+"the dataset add/update will fail.\n"
+"Can specify a millisecond amount of leniency for comparing timestamps "
+"to account for the possibility of slight differences between matching datasets "
+"(default is 500ms)."
 )
 
 publish_action = click.option(

--- a/apps/dc_tools/pyproject.toml
+++ b/apps/dc_tools/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "click<8.3", # Test failures/bad --archive-less-mature defn
-    "datacube>=1.9.12,<1.10.0",
+    "datacube>=1.9.14,<1.10.0",
     "datadog",
     "fsspec",
     "odc-cloud[ASYNC]>=0.2.3",

--- a/apps/dc_tools/pyproject.toml
+++ b/apps/dc_tools/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Open Data Cube", email = "earth.observation@ga.gov.au"},
 ]
 dependencies = [
-    "click<8.3", # Test failures/bad --archive-less-mature defn
+    "click>8.3.0",
     "datacube>=1.9.14,<1.10.0",
     "datadog",
     "fsspec",

--- a/apps/dc_tools/tests/conftest.py
+++ b/apps/dc_tools/tests/conftest.py
@@ -11,6 +11,7 @@ import yaml
 from click.testing import CliRunner
 from datacube import Datacube
 from datacube.cfg import ODCConfig, ODCEnvironment
+from datacube.drivers.common_psql import drop_schema
 from datacube.drivers.postgis import _core as pgis_core
 from datacube.drivers.postgres import _core as pgres_core
 from datacube.index import index_connect
@@ -378,7 +379,7 @@ def odc_db(cfg_env):
 
     with index._db._engine.begin() as conn:  # pylint:disable=protected-access
         if index.name == "pg_index":
-            pgres_core.drop_schema(conn)
+            drop_schema(conn, pgres_core.SCHEMA_NAME)
             # We need to run this as well, I think because SQLAlchemy grabs them into it's MetaData,
             # and attempts to recreate them. WTF TODO FIX
             remove_postgres_dynamic_indexes()
@@ -386,7 +387,7 @@ def odc_db(cfg_env):
             #     with conn.cursor() as cur:
             #         cur.execute("DROP SCHEMA IF EXISTS agdc CASCADE;")
         else:
-            pgis_core.drop_schema(conn)
+            drop_schema(conn, pgis_core.SCHEMA_NAME)
 
             remove_postgis_dynamic_indexes()
 

--- a/libs/cloud/pyproject.toml
+++ b/libs/cloud/pyproject.toml
@@ -28,7 +28,8 @@ azure = [
     "azure-storage-blob",
 ]
 async = [
-    "aiobotocore[boto3]>=1.0",
+    "aiobotocore>=1.0",
+    "boto3",
 ]
 
 [build-system]


### PR DESCRIPTION
Click 8.3.1 is broken, but we need
it for datacube 1.9.14, so remove
the default value for
--archive-less-mature. This seems
to get a None when the flag isn't
passed, and the default value
otherwise.