### PR TITLE
Stop printing in tests

### DIFF
--- a/apps/dc_tools/tests/conftest.py
+++ b/apps/dc_tools/tests/conftest.py
@@ -446,7 +446,6 @@ def odc_db_for_archive(odc_test_db_with_products: Datacube, env_name):
             fs_to_dc_cli,
             ["--stac", "--glob", filename, str(TEST_DATA_FOLDER), "--env", env_name],
         )
-        print(result.output)
         assert result.exit_code == 0, f"Output: {result.output}"
 
     return odc_test_db_with_products

--- a/apps/dc_tools/tests/test_add_update_products.py
+++ b/apps/dc_tools/tests/test_add_update_products.py
@@ -44,7 +44,6 @@ def test_add_products(local_csv, odc_db, env_name) -> None:
             env_name,
         ],
     )
-    print(f"CLI Output: {result.output}")
     assert result.exit_code == 0, f"Output: {result.output}"
 
 

--- a/apps/dc_tools/tests/test_esa_worldcover_to_dc.py
+++ b/apps/dc_tools/tests/test_esa_worldcover_to_dc.py
@@ -50,7 +50,6 @@ def test_get_dem_tile_uris(bbox) -> None:
         "v100/2020/map/ESA_WorldCover_10m_2020_v100_N03E003_Map.tif"
     )
 
-    print(uris)
     assert len(uris) == 4
 
 

--- a/apps/dc_tools/tests/test_s3_to_dc.py
+++ b/apps/dc_tools/tests/test_s3_to_dc.py
@@ -166,7 +166,6 @@ def test_s3_to_dc_stac_update_if_exist_allow_unsafe(
             env_name,
         ],
     )
-    print(f"s3-to-dc exit_code: {result.exit_code}, output:{result.output}")
     assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"

--- a/apps/dc_tools/tests/test_sns_publishing.py
+++ b/apps/dc_tools/tests/test_sns_publishing.py
@@ -96,7 +96,6 @@ def test_s3_publishing_action_from_stac(
         catch_exceptions=False,
     )
 
-    print(f"s3-to-dc exit_code: {result.exit_code}, output:{result.output}")
     assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
@@ -135,7 +134,6 @@ def test_s3_publishing_action_from_eo3(
         catch_exceptions=False,
     )
 
-    print(f"s3-to-dc exit_code: {result.exit_code}, output:{result.output}")
     assert result.exit_code == 0, f"Output: {result.output}"
     assert (
         result.output == "Added 1 datasets, skipped 0 datasets and failed 0 datasets.\n"
@@ -204,7 +202,6 @@ def test_sqs_publishing(
         ],
         catch_exceptions=False,
     )
-    print(f"sqs-to-dc exit_code: {result.exit_code}, output:{result.output}")
 
     assert result.exit_code == 0, f"Output: {result.output}"
 
@@ -263,7 +260,6 @@ def test_sqs_publishing_archive_flag(
         ],
         catch_exceptions=False,
     )
-    print(f"sqs-to-dc exit_code: {result.exit_code}, output:{result.output}")
 
     assert result.exit_code == 0, f"Output: {result.output}"
 
@@ -361,7 +357,6 @@ def test_with_archive_less_mature(
         ],
         catch_exceptions=False,
     )
-    print(f"fs-to-dc exit_code: {nrt_result.exit_code}, " "output:{nrt_result.output}")
 
     assert nrt_result.exit_code == 0, f"Output: {nrt_result.output}"
     assert dc.index.datasets.get(nrt_dsid) is not None
@@ -389,9 +384,6 @@ def test_with_archive_less_mature(
             env_name,
         ],
         catch_exceptions=False,
-    )
-    print(
-        f"fs-to-dc exit_code: {final_result.exit_code}, " "output:{final_result.output}"
     )
 
     assert final_result.exit_code == 0, f"Output: {final_result.output}"

--- a/apps/dc_tools/tests/test_stac_api_to_dc.py
+++ b/apps/dc_tools/tests/test_stac_api_to_dc.py
@@ -13,8 +13,6 @@ def test_rewrite_urls(landsat_stac, odc_test_db_with_products):
 
     item = Item.from_dict(landsat_stac)
 
-    print(item.self_href)
-
     _, uri, _ = item_to_meta_uri(
         item,
         odc_test_db_with_products,

--- a/libs/cloud/tests/test_azure.py
+++ b/libs/cloud/tests/test_azure.py
@@ -41,5 +41,4 @@ def test_download_yamls():
     results = download_yamls(account_url, container_name, credential, test_blob_names)
     assert results
     assert len(results) == 1
-    print(results)
     assert results[0][0] is not None

--- a/libs/cloud/tests/test_thredds.py
+++ b/libs/cloud/tests/test_thredds.py
@@ -37,7 +37,6 @@ def test_download_yaml():
     results = download_yamls(test_urls)
     assert results
     assert len(results) == 3
-    print(results)
     assert results[0][0] is not None
     assert results[1][0] is None
     assert results[1][2] == "Yaml not found"


### PR DESCRIPTION
The assert shows the output
if it fails, so stop flooding
the logs with noise.